### PR TITLE
Define PrimitiveToken

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/TokenValidator.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/TokenValidator.cs
@@ -10,45 +10,47 @@ namespace DockerfileModel.Tests
         public static void ValidateWhitespace(Token token, string whitespace)
         {
             Assert.IsType<WhitespaceToken>(token);
-            Assert.Equal(whitespace, token.Value);
+            Assert.Equal(whitespace, ((WhitespaceToken)token).Value);
         }
 
         public static void ValidateSymbol(Token token, string symbol)
         {
             Assert.IsType<SymbolToken>(token);
-            Assert.Equal(symbol, token.Value);
+            Assert.Equal(symbol, ((SymbolToken)token).Value);
         }
 
         public static void ValidateKeyword(Token token, string keyword)
         {
             Assert.IsType<KeywordToken>(token);
-            Assert.Equal(keyword, token.Value);
+            Assert.Equal(keyword, ((KeywordToken)token).Value);
         }
 
         public static void ValidateLiteral(Token token, string literal, char? quoteChar = null)
         {
             Assert.IsType<LiteralToken>(token);
-            Assert.Equal(literal, token.Value);
-            Assert.Equal(quoteChar, ((LiteralToken)token).QuoteChar);
+            LiteralToken literalToken = (LiteralToken)token;
+            Assert.Equal(literal, literalToken.Value);
+            Assert.Equal(quoteChar, literalToken.QuoteChar);
         }
 
         public static void ValidateIdentifier(Token token, string identifier, char? quoteChar = null)
         {
             Assert.IsType<IdentifierToken>(token);
-            Assert.Equal(identifier, token.Value);
-            Assert.Equal(quoteChar, ((IdentifierToken)token).QuoteChar);
+            IdentifierToken identifierToken = (IdentifierToken)token;
+            Assert.Equal(identifier, identifierToken.Value);
+            Assert.Equal(quoteChar, identifierToken.QuoteChar);
         }
 
         public static void ValidateLineContinuation(Token token, string text)
         {
             Assert.IsType<LineContinuationToken>(token);
-            Assert.Equal(text, token.Value);
+            Assert.Equal(text, ((LineContinuationToken)token).Value);
         }
 
         public static void ValidateNewLine(Token token, string text)
         {
             Assert.IsType<NewLineToken>(token);
-            Assert.Equal(text, token.Value);
+            Assert.Equal(text, ((NewLineToken)token).Value);
         }
 
         public static void ValidateAggregate<T>(Token token, string text, params Action<Token>[] tokenValidators)

--- a/src/DockerfileModel/DockerfileModel/Tokens/AggregateToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/AggregateToken.cs
@@ -10,14 +10,12 @@ namespace DockerfileModel.Tokens
     public abstract class AggregateToken : Token
     {
         protected AggregateToken(string text, Parser<IEnumerable<Token?>> parser)
-            : base(text)
         {
             this.TokenList = FilterNulls(parser.Parse(text))
                 .ToList();
         }
 
         protected AggregateToken(string text, Parser<Token> parser)
-            : base(text)
         {
             this.TokenList = new List<Token>
             {
@@ -26,7 +24,6 @@ namespace DockerfileModel.Tokens
         }
 
         protected AggregateToken(IEnumerable<Token> tokens)
-            : base(TokensToString(tokens))
         {
             this.TokenList = tokens.ToList();
         }
@@ -36,12 +33,7 @@ namespace DockerfileModel.Tokens
         public IEnumerable<Token> Tokens => this.TokenList;
 
         public override string ToString() =>
-            TokensToString(Tokens);
-
-        private static string TokensToString(IEnumerable<Token> tokens) =>
-            String.Join("", tokens
-                .Select(token => token.ToString())
-                .ToArray());
+            String.Concat(Tokens.Select(token => token.ToString()));
 
         protected IList<string> GetComments()
         {

--- a/src/DockerfileModel/DockerfileModel/Tokens/Token.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/Token.cs
@@ -2,7 +2,11 @@
 {
     public abstract class Token
     {
-        public Token(string value)
+    }
+
+    public abstract class PrimitiveToken : Token
+    {
+        public PrimitiveToken(string value)
         {
             this.Value = value;
         }
@@ -12,21 +16,21 @@
         public override string ToString() => this.Value;
     }
 
-    public class KeywordToken : Token
+    public class KeywordToken : PrimitiveToken
     {
         public KeywordToken(string value) : base(value)
         {
         }
     }
 
-    public class SymbolToken : Token
+    public class SymbolToken : PrimitiveToken
     {
         public SymbolToken(string value) : base(value)
         {
         }
     }
 
-    public abstract class QuotableToken : Token
+    public abstract class QuotableToken : PrimitiveToken
     {
         public QuotableToken(string value) : base(value)
         {
@@ -59,7 +63,7 @@
         }
     }
 
-    public class WhitespaceToken : Token
+    public class WhitespaceToken : PrimitiveToken
     {
         public WhitespaceToken(string value) : base(value)
         {
@@ -73,7 +77,7 @@
         }
     }
 
-    public class LineContinuationToken : Token
+    public class LineContinuationToken : SymbolToken
     {
         public LineContinuationToken(string value) : base(value)
         {


### PR DESCRIPTION
Having the `Token` class define a `Value` property was problematic.  Because `AggregateToken` derived classes inherited that property, it mean that when their sub-token values had been changed, the `Value` property became out-of-sync.  It really represented the parsed value, a snapshot of the original value, and didn't provide any value to `AggregateToken` derived classes.

A new class, `PrimitiveToken`, is defined and the `Value` property has been moved to it from the `Token` class to handle this issue.