### PR TITLE
Resolve args of any instruction without modifying it

### DIFF
--- a/src/DockerfileModel/DockerfileModel/InstructionBase.cs
+++ b/src/DockerfileModel/DockerfileModel/InstructionBase.cs
@@ -24,7 +24,7 @@ namespace DockerfileModel
 
         public override ConstructType Type => ConstructType.Instruction;
 
-        public void ResolveArgValues(char escapeChar, IDictionary<string, string?>? argValues = null)
+        internal void ResolveArgValues(char escapeChar, IDictionary<string, string?>? argValues = null)
         {
             if (argValues is null)
             {


### PR DESCRIPTION
Previously the only way to resolve args without modifying an instruction required using the `ArgResolver` class but that required the caller to explicitly provide the arg values.  This required the caller to know the arg flow rules of a Dockerfile.  Instead, a new `ResolveArgValues` method is added to `Dockerfile` that can be called to get a resolved value from any instruction within that Dockerfile.