### PR TITLE
Adds optional escapeChar param to Create methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ bld/
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 
+# VS Code configuration
+.vscode/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/src/DockerfileModel/DockerfileModel.Tests/VariableRefTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/VariableRefTokenTests.cs
@@ -230,15 +230,15 @@ namespace DockerfileModel.Tests
 
                         };
 
-                        string result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test", result);
 
                         variables["foo"] = null;
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("", result);
 
                         variables["foo"] = "test2";
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test2", result);
                     }
                 },
@@ -263,15 +263,15 @@ namespace DockerfileModel.Tests
                         {
                         };
 
-                        string result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test", result);
 
                         variables["foo"] = null;
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test", result);
 
                         variables["foo"] = "test2";
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test2", result);
                     }
                 },
@@ -295,15 +295,15 @@ namespace DockerfileModel.Tests
                         {
                         };
 
-                        string result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("", result);
 
                         variables["foo"] = null;
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test", result);
 
                         variables["foo"] = "test2";
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test", result);
                     }
                 },
@@ -328,15 +328,15 @@ namespace DockerfileModel.Tests
                         {
                         };
 
-                        string result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("", result);
 
                         variables["foo"] = null;
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("", result);
 
                         variables["foo"] = "test2";
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test", result);
                     }
                 },
@@ -360,14 +360,14 @@ namespace DockerfileModel.Tests
                         {
                         };
 
-                        Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Instruction.DefaultEscapeChar, variables));
+                        Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables));
 
                         variables["foo"] = null;
-                        string result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("", result);
 
                         variables["foo"] = "test2";
-                        result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test2", result);
                     }
                 },
@@ -392,13 +392,13 @@ namespace DockerfileModel.Tests
                         {
                         };
 
-                        Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Instruction.DefaultEscapeChar, variables));
+                        Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables));
 
                         variables["foo"] = null;
-                        Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Instruction.DefaultEscapeChar, variables));
+                        Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables));
 
                         variables["foo"] = "test2";
-                        string result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("test2", result);
                     }
                 },
@@ -429,7 +429,7 @@ namespace DockerfileModel.Tests
                             { "bar", "test2" }
                         };
 
-                        string result = token.ResolveVariables(Instruction.DefaultEscapeChar, variables);
+                        string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                         Assert.Equal("atest2x", result);
 
                     }

--- a/src/DockerfileModel/DockerfileModel/ArgInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/ArgInstruction.cs
@@ -94,7 +94,8 @@ namespace DockerfileModel
         public static ArgInstruction Parse(string text, char escapeChar) =>
             new ArgInstruction(text, escapeChar);
 
-        public static ArgInstruction Create(string argName, string? argValue = null)
+        public static ArgInstruction Create(string argName, string? argValue = null,
+            char escapeChar = Dockerfile.DefaultEscapeChar)
         {
             StringBuilder builder = new StringBuilder($"ARG {argName}");
             if (argValue != null)
@@ -102,7 +103,7 @@ namespace DockerfileModel
                 builder.Append($"{AssignmentOperator}{argValue}");
             }
 
-            return Parse(builder.ToString(), Instruction.DefaultEscapeChar);
+            return Parse(builder.ToString(), escapeChar);
         }
 
         public static Parser<IEnumerable<Token>> GetParser(char escapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/Dockerfile.cs
+++ b/src/DockerfileModel/DockerfileModel/Dockerfile.cs
@@ -7,6 +7,8 @@ namespace DockerfileModel
 {
     public class Dockerfile : IConstructContainer
     {
+        public const char DefaultEscapeChar = '\\';
+
         public Dockerfile(IEnumerable<DockerfileConstruct> items)
         {
             this.Items = items;
@@ -18,7 +20,7 @@ namespace DockerfileModel
             Items
                 .OfType<ParserDirective>()
                 .FirstOrDefault(directive => directive.DirectiveName == ParserDirective.EscapeDirective)
-                ?.DirectiveValue[0] ?? Instruction.DefaultEscapeChar;
+                ?.DirectiveValue[0] ?? DefaultEscapeChar; 
 
         public static Dockerfile Parse(string text) =>
             DockerfileParser.ParseContent(text);

--- a/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
@@ -37,7 +37,7 @@ namespace DockerfileModel
         public static Dockerfile ParseContent(string text)
         {
             bool parserDirectivesComplete = false;
-            char escapeChar = Instruction.DefaultEscapeChar;
+            char escapeChar = Dockerfile.DefaultEscapeChar;
 
             List<DockerfileConstruct> dockerfileConstructs = new List<DockerfileConstruct>();
 

--- a/src/DockerfileModel/DockerfileModel/ExecFormRunCommand.cs
+++ b/src/DockerfileModel/DockerfileModel/ExecFormRunCommand.cs
@@ -18,8 +18,8 @@ namespace DockerfileModel
         {
         }
 
-        public static ExecFormRunCommand Create(IEnumerable<string> commands) =>
-            Parse(FormatCommands(commands), Instruction.DefaultEscapeChar);
+        public static ExecFormRunCommand Create(IEnumerable<string> commands, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse(FormatCommands(commands), escapeChar);
 
         public static ExecFormRunCommand Parse(string text, char escapeChar) =>
             new ExecFormRunCommand(text, escapeChar);

--- a/src/DockerfileModel/DockerfileModel/FromInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/FromInstruction.cs
@@ -125,7 +125,8 @@ namespace DockerfileModel
         public static FromInstruction Parse(string text, char escapeChar) =>
             new FromInstruction(text, escapeChar);
 
-        public static FromInstruction Create(string imageName, string? stageName = null, string? platform = null)
+        public static FromInstruction Create(string imageName, string? stageName = null, string? platform = null,
+            char escapeChar = Dockerfile.DefaultEscapeChar)
         {
             StringBuilder builder = new StringBuilder("FROM ");
             if (platform != null)
@@ -140,7 +141,7 @@ namespace DockerfileModel
                 builder.Append($" AS {stageName}");
             }
 
-            return Parse(builder.ToString(), Instruction.DefaultEscapeChar);
+            return Parse(builder.ToString(), escapeChar);
         }
 
         public static Parser<IEnumerable<Token>> GetParser(char escapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/Instruction.cs
+++ b/src/DockerfileModel/DockerfileModel/Instruction.cs
@@ -9,8 +9,6 @@ namespace DockerfileModel
 {
     public class Instruction : InstructionBase
     {
-        public const char DefaultEscapeChar = '\\';
-
         private Instruction(string text, char escapeChar)
             : base(text, InstructionParser(escapeChar))
         {
@@ -25,8 +23,8 @@ namespace DockerfileModel
         public static bool IsInstruction(string text, char escapeChar) =>
             InstructionParser(escapeChar).TryParse(text).WasSuccessful;
 
-        public static Instruction Create(string instruction, string args) =>
-            Parse($"{instruction} {args}", DefaultEscapeChar);
+        public static Instruction Create(string instruction, string args, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse($"{instruction} {args}", escapeChar);
 
         public static Instruction Parse(string text, char escapeChar) =>
             new Instruction(text, escapeChar);

--- a/src/DockerfileModel/DockerfileModel/MountFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/MountFlag.cs
@@ -31,8 +31,8 @@ namespace DockerfileModel
 
         private KeyValueToken<Mount> MountKeyValueToken => Tokens.OfType<KeyValueToken<Mount>>().First();
 
-        public static MountFlag Create(Mount mount) =>
-            Parse($"--mount={mount}", Instruction.DefaultEscapeChar);
+        public static MountFlag Create(Mount mount, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse($"--mount={mount}", escapeChar);
 
         public static MountFlag Parse(string text, char escapeChar) =>
             new MountFlag(text, escapeChar);

--- a/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
@@ -39,8 +39,8 @@ namespace DockerfileModel
             }
         }
 
-        public static PlatformFlag Create(string platform) =>
-            Parse($"--platform={platform}", Instruction.DefaultEscapeChar);
+        public static PlatformFlag Create(string platform, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse($"--platform={platform}", escapeChar);
 
         public static PlatformFlag Parse(string text, char escapeChar) =>
             new PlatformFlag(text, escapeChar);

--- a/src/DockerfileModel/DockerfileModel/RunInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/RunInstruction.cs
@@ -34,11 +34,11 @@ namespace DockerfileModel
             Instruction("RUN", escapeChar,
                 GetArgsParser(escapeChar));
 
-        public static RunInstruction Create(string command) =>
-            Parse($"RUN {command}", Instruction.DefaultEscapeChar);
+        public static RunInstruction Create(string command, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse($"RUN {command}", escapeChar);
 
-        public static RunInstruction Create(IEnumerable<string> commands) =>
-            Parse($"RUN {ExecFormRunCommand.FormatCommands(commands)}", Instruction.DefaultEscapeChar);
+        public static RunInstruction Create(IEnumerable<string> commands, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse($"RUN {ExecFormRunCommand.FormatCommands(commands)}", escapeChar);
 
         public override string? ResolveVariables(char escapeChar, IDictionary<string, string?>? variables = null, ResolutionOptions? options = null)
         {

--- a/src/DockerfileModel/DockerfileModel/SecretMount.cs
+++ b/src/DockerfileModel/DockerfileModel/SecretMount.cs
@@ -75,7 +75,8 @@ namespace DockerfileModel
             }
         }
 
-        public static SecretMount Create(string id, string? destinationPath = null)
+        public static SecretMount Create(string id, string? destinationPath = null,
+            char escapeChar = Dockerfile.DefaultEscapeChar)
         {
             string? destinationSegment = null;
             if (!String.IsNullOrEmpty(destinationPath))
@@ -83,7 +84,7 @@ namespace DockerfileModel
                 destinationSegment = $",dst={destinationPath}";
             }
 
-            return Parse($"type=secret,id={id}{destinationSegment}", Instruction.DefaultEscapeChar);
+            return Parse($"type=secret,id={id}{destinationSegment}", escapeChar);
         }
 
         public static SecretMount Parse(string text, char escapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/ShellFormRunCommand.cs
+++ b/src/DockerfileModel/DockerfileModel/ShellFormRunCommand.cs
@@ -19,8 +19,8 @@ namespace DockerfileModel
         {
         }
 
-        public static ShellFormRunCommand Create(string command) =>
-            Parse(command, Instruction.DefaultEscapeChar);
+        public static ShellFormRunCommand Create(string command, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse(command, escapeChar);
 
         public static ShellFormRunCommand Parse(string text, char escapeChar) =>
             new ShellFormRunCommand(text, escapeChar);

--- a/src/DockerfileModel/DockerfileModel/StageName.cs
+++ b/src/DockerfileModel/DockerfileModel/StageName.cs
@@ -52,8 +52,8 @@ namespace DockerfileModel
 
         public IEnumerable<CommentToken> CommentTokens => GetCommentTokens();
 
-        public static StageName Create(string stageName) =>
-            Parse($"AS {stageName}", Instruction.DefaultEscapeChar);
+        public static StageName Create(string stageName, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse($"AS {stageName}", escapeChar);
 
         public static StageName Parse(string text, char escapeChar) =>
             new StageName(text, escapeChar);

--- a/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
@@ -55,7 +55,7 @@ namespace DockerfileModel.Tokens
         }
 
         public static KeyValueToken<LiteralToken> Create(string key, string value) =>
-            Parse($"{key}={value}", Instruction.DefaultEscapeChar, key);
+            Parse($"{key}={value}", Dockerfile.DefaultEscapeChar, key);
 
         public static KeyValueToken<LiteralToken> Parse(string text, char escapeChar, string key) =>
             new KeyValueToken<LiteralToken>(text, escapeChar, key);

--- a/src/DockerfileModel/DockerfileModel/Tokens/VariableRefToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/VariableRefToken.cs
@@ -208,11 +208,11 @@ namespace DockerfileModel.Tokens
                 builder.Append("}");
             }
 
-            return Parse(builder.ToString(), Instruction.DefaultEscapeChar);
+            return Parse(builder.ToString(), Dockerfile.DefaultEscapeChar);
         }
 
         public static VariableRefToken Create(string variableName, string modifier, string modifierValue) =>
-            Parse($"${{{variableName}{modifier}{modifierValue}}}", Instruction.DefaultEscapeChar);
+            Parse($"${{{variableName}{modifier}{modifierValue}}}", Dockerfile.DefaultEscapeChar);
 
         public static VariableRefToken Parse(string text, char escapeChar) =>
             new VariableRefToken(text, escapeChar, (char escapeChar, IEnumerable<char> excludedChars) =>


### PR DESCRIPTION
Previously, the Create methods would default the escape character to be used for the parsing.  This prevented the caller from using a non-default escape character within their input.  Updated the Create methods to allow an optional escape character to be passed.