### PR TITLE
Change KeywordToken's value to be read-only

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/InstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/InstructionTests.cs
@@ -56,10 +56,6 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Equal("run", result.InstructionName);
                         Assert.Equal(@"echo ""hello world""", result.ArgLines.Single());
-
-                        result.InstructionName = "ARG";
-                        result.ArgLines[0] = "MY_ARG";
-                        Assert.Equal($"{result.InstructionName} MY_ARG", result.ToString());
                     }
                 },
                 new InstructionParseTestScenario
@@ -76,10 +72,6 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Equal("run", result.InstructionName);
                         Assert.Equal(@"echo ""hello world""", result.ArgLines.Single());
-
-                        result.InstructionName = "ARG";
-                        result.ArgLines[0] = "MY_ARG";
-                        Assert.Equal($"{result.InstructionName} MY_ARG\n", result.ToString());
                     }
                 },
                 new InstructionParseTestScenario
@@ -105,13 +97,6 @@ namespace DockerfileModel.Tests
                         Assert.Equal(2, argLines.Count);
                         Assert.Equal(@"echo ""hello world""", argLines[0]);
                         Assert.Equal(@"&& ls -a", argLines[1]);
-
-                        result.InstructionName = "ARG";
-                        argLines[0] = @"echo ""hello WORLD""";
-                        argLines[1] = "&& ls";
-                        Assert.Equal(
-                            $"{result.InstructionName} {argLines[0]}  \\\r\n  {argLines[1]}",
-                            result.ToString());
                     }
                 },
                 new InstructionParseTestScenario
@@ -141,13 +126,6 @@ namespace DockerfileModel.Tests
                         Assert.Equal(2, argLines.Count);
                         Assert.Equal(@"echo ""hello world""", argLines[0]);
                         Assert.Equal(@"&& ls -a", argLines[1]);
-
-                        result.InstructionName = "ARG";
-                        argLines[0] = @"echo ""hello WORLD""";
-                        argLines[1] = "&& ls";
-                        Assert.Equal(
-                            $"{result.InstructionName} {argLines[0]}  \\\r\n \\\n  {argLines[1]}",
-                            result.ToString());
                     }
                 },
                 new InstructionParseTestScenario

--- a/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
@@ -48,14 +48,6 @@ namespace DockerfileModel.Tests
             Assert.Equal("foo", token.Key);
             Assert.Equal("foo", token.KeyToken.Value);
 
-            token.Key = "foo2";
-            Assert.Equal("foo2", token.Key);
-            Assert.Equal("foo2", token.KeyToken.Value);
-
-            token.KeyToken.Value = "foo3";
-            Assert.Equal("foo3", token.Key);
-            Assert.Equal("foo3", token.KeyToken.Value);
-
             token.KeyToken = new KeywordToken("foo4");
             Assert.Equal("foo4", token.Key);
             Assert.Equal("foo4", token.KeyToken.Value);

--- a/src/DockerfileModel/DockerfileModel.Tests/ParserDirectiveTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ParserDirectiveTests.cs
@@ -58,10 +58,9 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Equal("directive", result.DirectiveName);
                         Assert.Equal("value", result.DirectiveValue);
-
-                        result.DirectiveName = "directive2";
+                        
                         result.DirectiveValue = "newvalue";
-                        Assert.Equal($"#{result.DirectiveName}={result.DirectiveValue}", result.ToString());
+                        Assert.Equal($"#{result.DirectiveName}=newvalue", result.ToString());
                     }
                 },
                 new ParseTestScenario
@@ -84,9 +83,8 @@ namespace DockerfileModel.Tests
                         Assert.Equal("directive", result.DirectiveName);
                         Assert.Equal("value", result.DirectiveValue);
 
-                        result.DirectiveName = "directive2";
                         result.DirectiveValue = "newvalue";
-                        Assert.Equal($" # {result.DirectiveName}   = {result.DirectiveValue}  ", result.ToString());
+                        Assert.Equal($" # {result.DirectiveName}   = newvalue  ", result.ToString());
                     }
                 },
                 new ParseTestScenario
@@ -119,9 +117,8 @@ namespace DockerfileModel.Tests
                         Assert.Equal("directive", result.DirectiveName);
                         Assert.Equal("value", result.DirectiveValue);
 
-                        result.DirectiveName = "directive2";
                         result.DirectiveValue = "newvalue";
-                        Assert.Equal($"#{result.DirectiveName}={result.DirectiveValue}", result.ToString());
+                        Assert.Equal($"#{result.DirectiveName}=newvalue", result.ToString());
                     }
                 },
                 new CreateTestScenario
@@ -144,9 +141,8 @@ namespace DockerfileModel.Tests
                         Assert.Equal("directive", result.DirectiveName);
                         Assert.Equal("value", result.DirectiveValue);
 
-                        result.DirectiveName = "directive2";
                         result.DirectiveValue = "newvalue";
-                        Assert.Equal($"# {result.DirectiveName}   = {result.DirectiveValue}  ", result.ToString());
+                        Assert.Equal($"# {result.DirectiveName}   = newvalue  ", result.ToString());
                     }
                 }
             };

--- a/src/DockerfileModel/DockerfileModel/InstructionBase.cs
+++ b/src/DockerfileModel/DockerfileModel/InstructionBase.cs
@@ -18,17 +18,11 @@ namespace DockerfileModel
         public string InstructionName
         {
             get => this.InstructionNameToken.Value;
-            set => this.InstructionNameToken.Value = value;
         }
 
         public KeywordToken InstructionNameToken
         {
             get => Tokens.OfType<KeywordToken>().First();
-            set
-            {
-                Requires.NotNull(value, nameof(value));
-                SetToken(InstructionNameToken, value);
-            }
         }
 
         public IList<string?> Comments => GetComments();

--- a/src/DockerfileModel/DockerfileModel/ParserDirective.cs
+++ b/src/DockerfileModel/DockerfileModel/ParserDirective.cs
@@ -19,7 +19,6 @@ namespace DockerfileModel
         public string DirectiveName
         {
             get => Tokens.OfType<KeywordToken>().First().Value;
-            set => Tokens.OfType<KeywordToken>().First().Value = value;
         }
 
         public string DirectiveValue

--- a/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
@@ -22,11 +22,6 @@ namespace DockerfileModel.Tokens
         public string Key
         {
             get => KeyToken.Value;
-            set
-            {
-                Requires.NotNull(value, nameof(value));
-                KeyToken.Value = value;
-            }
         }
 
         public KeywordToken KeyToken

--- a/src/DockerfileModel/DockerfileModel/Tokens/KeywordToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/KeywordToken.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace DockerfileModel.Tokens
 {
@@ -13,10 +14,12 @@ namespace DockerfileModel.Tokens
         {
         }
 
-        public string Value
+        public string Value => this.ToString(TokenStringOptions.CreateOptionsForValueString());
+
+        string IValueToken.Value
         {
-            get => this.ToString(TokenStringOptions.CreateOptionsForValueString());
-            set => ReplaceWithToken(new StringToken(value));
+            get => Value;
+            set => throw new NotSupportedException("The value of a keyword is read-only.");
         }
     }
 }


### PR DESCRIPTION
It doesn't make sense for `KeywordToken` to have a value that can be changed because it would change the semantic meaning of its usage which could then imply a completely different consuming type.