### PR TITLE
Implement TokenBuilder

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/DockerfileBuilderTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/DockerfileBuilderTests.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace DockerfileModel.Tests

--- a/src/DockerfileModel/DockerfileModel.Tests/LineContinuationTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/LineContinuationTokenTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DockerfileModel.Tokens;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
+
+namespace DockerfileModel.Tests
+{
+    public class LineContinuationTokenTests
+    {
+        [Fact]
+        public void Create()
+        {
+            LineContinuationToken token = LineContinuationToken.Create();
+            Assert.Collection(token.Tokens, new Action<Token>[]
+            {
+                token => ValidateSymbol(token, '\\'),
+                token => ValidateNewLine(token, Environment.NewLine)
+            });
+
+            token = LineContinuationToken.Create('`');
+            Assert.Collection(token.Tokens, new Action<Token>[]
+            {
+                token => ValidateSymbol(token, '`'),
+                token => ValidateNewLine(token, Environment.NewLine)
+            });
+
+            token = LineContinuationToken.Create("\n", '`');
+            Assert.Collection(token.Tokens, new Action<Token>[]
+            {
+                token => ValidateSymbol(token, '`'),
+                token => ValidateNewLine(token, "\n")
+            });
+        }
+
+        [Fact]
+        public void Parse()
+        {
+            LineContinuationToken token = LineContinuationToken.Parse("\\\n");
+            Assert.Equal("\\\n", token.ToString());
+            Assert.Collection(token.Tokens, new Action<Token>[]
+            {
+                token => ValidateSymbol(token, '\\'),
+                token => ValidateNewLine(token, "\n")
+            });
+
+            token = LineContinuationToken.Parse("`  \n", '`');
+            Assert.Equal("`  \n", token.ToString());
+            Assert.Collection(token.Tokens, new Action<Token>[]
+            {
+                token => ValidateSymbol(token, '`'),
+                token => ValidateWhitespace(token, "  "),
+                token => ValidateNewLine(token, "\n")
+            });
+        }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
@@ -265,5 +265,45 @@ namespace DockerfileModel.Tests
 
             Assert.Equal(expectedOutput, builder.Dockerfile.ToString());
         }
+
+        /// <summary>
+        /// Create a fully-customized Dockerfile from scratch using the fluent API of TokenBuilder.
+        /// </summary>
+        [Fact]
+        public void CreateNewDockerfileWithTokenBuilder()
+        {
+            DockerfileBuilder builder = new DockerfileBuilder();
+            builder
+                .Comment("Made from scratch Dockerfile")
+                .NewLine()
+                .ArgInstruction("TAG", "latest")
+                .FromInstruction("alpine:$TAG")
+                .ArgInstruction("MESSAGE")
+                .RunInstruction(tokenBuilder =>
+                {
+                    // Configure the RUN instruction to have a line continuation with an inline comment
+                    tokenBuilder
+                        .Keyword("RUN")
+                        .Whitespace(" ")
+                        .LineContinuation()
+                        .Whitespace("  ")
+                        .Comment(" Output message")
+                        .NewLine()
+                        .Whitespace("  ")
+                        .ShellFormRunCommand("echo $MESSAGE");
+                });
+
+            string expectedOutput =
+                "# Made from scratch Dockerfile" + Environment.NewLine +
+                Environment.NewLine +
+                "ARG TAG=latest" + Environment.NewLine +
+                "FROM alpine:$TAG" + Environment.NewLine +
+                "ARG MESSAGE" + Environment.NewLine +
+                "RUN \\" + Environment.NewLine +
+                "  # Output message" + Environment.NewLine +
+                "  echo $MESSAGE" + Environment.NewLine;
+
+            Assert.Equal(expectedOutput, builder.Dockerfile.ToString());
+        }
     }
 }

--- a/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using DockerfileModel.Tokens;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
+
+namespace DockerfileModel.Tests
+{
+    public class TokenBuilderTests
+    {
+        [Fact]
+        public void BuildAllTokens()
+        {
+            TokenBuilder builder = new TokenBuilder();
+            builder
+                .Comment("comment")
+                .Digest("digest")
+                .ExecFormRunCommand("cmd1", "cmd2")
+                .Identifier("id")
+                .ImageName("repo")
+                .KeyValue<KeywordToken>("key", "value")
+                .Keyword("key")
+                .LineContinuation()
+                .Literal("literal")
+                .MountFlag(SecretMount.Create("id"))
+                .NewLine()
+                .PlatformFlag("platform")
+                .Registry("registry")
+                .Repository("repo")
+                .SecretMount("id")
+                .ShellFormRunCommand("cmd")
+                .StageName("stage")
+                .Symbol('-')
+                .Tag("tag")
+                .VariableRef("var")
+                .Whitespace(" ");
+
+            Assert.Collection(builder.Tokens, new Action<Token>[]
+            {
+                token => ValidateAggregate<CommentToken>(token, "#comment",
+                    token => ValidateSymbol(token, '#'),
+                    token => ValidateString(token, "comment")),
+                token => ValidateAggregate<DigestToken>(token, "digest",
+                    token => ValidateString(token, "digest")),
+                token => ValidateAggregate<ExecFormRunCommand>(token, "[\"cmd1\", \"cmd2\"]",
+                    token => ValidateLiteral(token, "cmd1", ParseHelper.DoubleQuote),
+                    token => ValidateSymbol(token, ','),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateLiteral(token, "cmd2", ParseHelper.DoubleQuote)),
+                token => ValidateIdentifier(token, "id"),
+                token => ValidateAggregate<ImageName>(token, "repo",
+                    token => ValidateAggregate<RepositoryToken>(token, "repo",
+                        token => ValidateString(token, "repo"))),
+                token => ValidateAggregate<KeyValueToken<LiteralToken>>(token, "key=value",
+                    token => ValidateKeyword(token, "key"),
+                    token => ValidateSymbol(token, '='),
+                    token => ValidateLiteral(token, "value")),
+                token => ValidateKeyword(token, "key"),
+                token => ValidateLineContinuation(token, '\\', Environment.NewLine),
+                token => ValidateLiteral(token, "literal"),
+                token => ValidateAggregate<MountFlag>(token, "--mount=type=secret,id=id",
+                    token => ValidateSymbol(token, '-'),
+                    token => ValidateSymbol(token, '-'),
+                    token => ValidateAggregate<KeyValueToken<Mount>>(token, "mount=type=secret,id=id",
+                        token => ValidateKeyword(token, "mount"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateAggregate<SecretMount>(token, "type=secret,id=id",
+                            token => ValidateKeyValue(token, "type", "secret"),
+                            token => ValidateSymbol(token, ','),
+                            token => ValidateKeyValue(token, "id", "id")))),
+                token => ValidateNewLine(token, Environment.NewLine),
+                token => ValidateAggregate<PlatformFlag>(token, "--platform=platform",
+                    token => ValidateSymbol(token, '-'),
+                    token => ValidateSymbol(token, '-'),
+                    token => ValidateAggregate<KeyValueToken<LiteralToken>>(token, "platform=platform",
+                        token => ValidateKeyword(token, "platform"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "platform"))),
+                token => ValidateAggregate<RegistryToken>(token, "registry",
+                    token => ValidateString(token, "registry")),
+                token => ValidateAggregate<RepositoryToken>(token, "repo",
+                    token => ValidateString(token, "repo")),
+                token => ValidateAggregate<SecretMount>(token, "type=secret,id=id",
+                    token => ValidateKeyValue(token, "type", "secret"),
+                    token => ValidateSymbol(token, ','),
+                    token => ValidateKeyValue(token, "id", "id")),
+                token => ValidateAggregate<ShellFormRunCommand>(token, "cmd",
+                    token => ValidateLiteral(token, "cmd")),
+                token => ValidateAggregate<StageName>(token, "AS stage",
+                    token => ValidateKeyword(token, "AS"),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateIdentifier(token, "stage")),
+                token => ValidateSymbol(token, '-'),
+                token => ValidateAggregate<TagToken>(token, "tag",
+                    token => ValidateString(token, "tag")),
+                token => ValidateAggregate<VariableRefToken>(token, "$var",
+                    token => ValidateString(token, "var")),
+                token => ValidateWhitespace(token, " ")
+            });
+
+            string expectedResult =
+                "#comment" +
+                "digest" +
+                "[\"cmd1\", \"cmd2\"]" +
+                "id" +
+                "repo" +
+                "key=value" +
+                "key" +
+                "\\\r\n" +
+                "literal" +
+                "--mount=type=secret,id=id" +
+                "\r\n" +
+                "--platform=platform" +
+                "registry" +
+                "repo" +
+                "type=secret,id=id" +
+                "cmd" +
+                "AS stage" +
+                "-" +
+                "tag" +
+                "$var" +
+                " ";
+
+            Assert.Equal(expectedResult, builder.ToString());
+        }
+
+        [Fact]
+        public void DefaultNewLine()
+        {
+            TokenBuilder builder = new TokenBuilder
+            {
+                DefaultNewLine = "\n"
+            };
+
+            string result = builder
+                .NewLine()
+                .LineContinuation()
+                .ToString();
+
+            string expectedResult = "\n\\\n";
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void EscapeChar()
+        {
+            TokenBuilder builder = new TokenBuilder
+            {
+                EscapeChar = '`'
+            };
+
+            string result = builder
+                .LineContinuation()
+                .ToString();
+
+            string expectedResult = "`\r\n";
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
@@ -132,8 +132,8 @@ namespace DockerfileModel
             select instruction.Value;
 
         private static Parser<LineContinuationToken> EndsInLineContinuation(char escapeChar) =>
-            from text in Parse.AnyChar.Except(LineContinuation(escapeChar)).Many().Text()
-            from lineCont in LineContinuation(escapeChar)
+            from text in Parse.AnyChar.Except(LineContinuationToken.GetParser(escapeChar)).Many().Text()
+            from lineCont in LineContinuationToken.GetParser(escapeChar)
             select lineCont;
 
         public static Parser<KeywordToken> InstructionIdentifier(char escapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/GenericInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/GenericInstruction.cs
@@ -38,7 +38,7 @@ namespace DockerfileModel
         private static Parser<IEnumerable<Token>> InstructionParser(char escapeChar) =>
             from leading in Whitespace()
             from instruction in TokenWithTrailingWhitespace(DockerfileParser.InstructionIdentifier(escapeChar))
-            from lineContinuation in LineContinuation(escapeChar).Optional()
+            from lineContinuation in LineContinuationToken.GetParser(escapeChar).Optional()
             from instructionArgs in InstructionArgs(escapeChar)
             select ConcatTokens(leading, instruction, new Token[] { lineContinuation.GetOrDefault() }, instructionArgs);
     }

--- a/src/DockerfileModel/DockerfileModel/ImageName.cs
+++ b/src/DockerfileModel/DockerfileModel/ImageName.cs
@@ -26,6 +26,14 @@ namespace DockerfileModel
             digestToken = Tokens.OfType<DigestToken>().FirstOrDefault();
         }
 
+        internal ImageName(IEnumerable<Token> tokens) : base(tokens)
+        {
+            registryToken = Tokens.OfType<RegistryToken>().FirstOrDefault();
+            repositoryToken = Tokens.OfType<RepositoryToken>().First();
+            tagToken = Tokens.OfType<TagToken>().FirstOrDefault();
+            digestToken = Tokens.OfType<DigestToken>().FirstOrDefault();
+        }
+
         public static ImageName Create(string repository, string? registry = null, string? tag = null, string? digest = null)
         {
             Requires.NotNullOrWhiteSpace(repository, nameof(repository));
@@ -289,11 +297,19 @@ namespace DockerfileModel
         public RegistryToken(string value) : base(value)
         {
         }
+
+        internal RegistryToken(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
     }
 
     public class RepositoryToken : IdentifierToken
     {
         public RepositoryToken(string value) : base(value)
+        {
+        }
+
+        internal RepositoryToken(IEnumerable<Token> tokens) : base(tokens)
         {
         }
     }
@@ -303,11 +319,19 @@ namespace DockerfileModel
         public TagToken(string value) : base(value)
         {
         }
+
+        internal TagToken(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
     }
 
     public class DigestToken : IdentifierToken
     {
         public DigestToken(string value) : base(value)
+        {
+        }
+
+        internal DigestToken(IEnumerable<Token> tokens) : base(tokens)
         {
         }
     }

--- a/src/DockerfileModel/DockerfileModel/Instruction.cs
+++ b/src/DockerfileModel/DockerfileModel/Instruction.cs
@@ -35,8 +35,8 @@ namespace DockerfileModel
             select lineSets.SelectMany(lineSet => lineSet);
 
         private static Parser<IEnumerable<Token>> InstructionArgLine(char escapeChar) =>
-            from text in Parse.AnyChar.Except(LineContinuation(escapeChar)).Except(Parse.LineEnd).Many().Text()
-            from lineContinuation in LineContinuation(escapeChar).Optional()
+            from text in Parse.AnyChar.Except(LineContinuationToken.GetParser(escapeChar)).Except(Parse.LineEnd).Many().Text()
+            from lineContinuation in LineContinuationToken.GetParser(escapeChar).Optional()
             from lineEnd in OptionalNewLine().AsEnumerable()
             select ConcatTokens(
                 GetInstructionArgLineContent(text),

--- a/src/DockerfileModel/DockerfileModel/SecretMount.cs
+++ b/src/DockerfileModel/DockerfileModel/SecretMount.cs
@@ -102,7 +102,7 @@ namespace DockerfileModel
 
             return from type in KeyValueToken<LiteralToken>.GetParser("type", escapeChar, valueParser).AsEnumerable()
                    from comma in CharWithOptionalLineContinuation(escapeChar, Sprache.Parse.Char(','), ch => new SymbolToken(ch))
-                   from lineCont in LineContinuation(escapeChar).AsEnumerable().Optional()
+                   from lineCont in LineContinuationToken.GetParser(escapeChar).AsEnumerable().Optional()
                    from id in KeyValueToken<LiteralToken>.GetParser("id", escapeChar, valueParser).AsEnumerable()
                    from destination in Destination(escapeChar).Optional()
                    select ConcatTokens(type, comma, lineCont.GetOrDefault(), id, destination.GetOrDefault());

--- a/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
@@ -67,7 +67,7 @@ namespace DockerfileModel.Tokens
 
             return from keyword in Keyword(key, escapeChar).AsEnumerable()
                    from equalOperator in CharWithOptionalLineContinuation(escapeChar, Sprache.Parse.Char('='), ch => new SymbolToken(ch))
-                   from lineCont in LineContinuation(escapeChar).AsEnumerable().Optional()
+                   from lineCont in LineContinuationToken.GetParser(escapeChar).AsEnumerable().Optional()
                    from value in valueTokenParser.AsEnumerable()
                    select ConcatTokens(keyword, equalOperator, lineCont.GetOrDefault(), value);
         }

--- a/src/DockerfileModel/DockerfileModel/Tokens/LineContinuationToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/LineContinuationToken.cs
@@ -1,11 +1,47 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sprache;
+using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel.Tokens
 {
     public class LineContinuationToken : AggregateToken
     {
+        private LineContinuationToken(string text, char escapeChar)
+            : base(text, GetInnerParser(escapeChar))
+        {
+        }
+
         internal LineContinuationToken(IEnumerable<Token> tokens) : base(tokens)
         {
         }
+
+        public static LineContinuationToken Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            new LineContinuationToken(text, escapeChar);
+
+        public static LineContinuationToken Create(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Create(Environment.NewLine, escapeChar);
+
+        public static LineContinuationToken Create(string newLine, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse($"{escapeChar}{newLine}", escapeChar);
+
+        /// <summary>
+        /// Parses a line continuation, consisting of an escape character followed by a new line.
+        /// </summary>
+        /// <param name="escapeChar">Escape character.</param>
+        /// <returns>Line continuation tokens.</returns>
+        public static Parser<LineContinuationToken> GetParser(char escapeChar) =>
+           from tokens in GetInnerParser(escapeChar)
+           select new LineContinuationToken(tokens);
+
+        private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
+           from escape in Symbol(escapeChar)
+           from whitespace in Sprache.Parse.WhiteSpace.Except(Sprache.Parse.LineEnd).Many()
+           from lineEnding in Sprache.Parse.LineEnd
+           select ConcatTokens(
+               escape,
+               whitespace.Any() ? new WhitespaceToken(new string(whitespace.ToArray())) : null,
+               new NewLineToken(lineEnding));
     }
 }

--- a/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DockerfileModel.Tokens
+{
+    public class TokenBuilder
+    {
+        public char EscapeChar { get; set; } = Dockerfile.DefaultEscapeChar;
+
+        public string DefaultNewLine { get; set; } = Environment.NewLine;
+
+        public IList<Token> Tokens { get; } = new List<Token>();
+
+        public TokenBuilder Comment(string comment) =>
+            AddToken(CommentToken.Create(comment));
+
+        public TokenBuilder Comment(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new CommentToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder Digest(string digest) =>
+            AddToken(new DigestToken(digest));
+
+        public TokenBuilder Digest(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new DigestToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder ExecFormRunCommand(params string[] commands) =>
+            AddToken(DockerfileModel.ExecFormRunCommand.Create(commands, EscapeChar));
+
+        public TokenBuilder ExecFormRunCommand(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new ExecFormRunCommand(GetTokens(configureBuilder)));
+
+        public TokenBuilder Identifier(string value) =>
+            AddToken(new IdentifierToken(value));
+
+        public TokenBuilder Identifier(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new IdentifierToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder ImageName(string repository, string? registry = null, string? tag = null, string? digest = null) =>
+            AddToken(DockerfileModel.ImageName.Create(repository, registry, tag, digest));
+
+        public TokenBuilder ImageName(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new ImageName(GetTokens(configureBuilder)));
+
+        public TokenBuilder KeyValue<TValue>(string key, string value)
+            where TValue : Token =>
+            AddToken(KeyValueToken<TValue>.Create(key, value, EscapeChar));
+
+        public TokenBuilder KeyValue<TValue>(Action<TokenBuilder> configureBuilder)
+            where TValue : Token =>
+            AddToken(new KeyValueToken<TValue>(GetTokens(configureBuilder)));
+
+        public TokenBuilder Keyword(string value) =>
+            AddToken(new KeywordToken(value));
+
+        public TokenBuilder Keyword(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new KeywordToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder LineContinuation() =>
+            AddToken(LineContinuationToken.Create(DefaultNewLine, EscapeChar));
+
+        public TokenBuilder LineContinuation(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new LineContinuationToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder Literal(string value) =>
+            AddToken(new LiteralToken(value));
+
+        public TokenBuilder Literal(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new LiteralToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder MountFlag(Mount mount) =>
+            AddToken(DockerfileModel.MountFlag.Create(mount, EscapeChar));
+
+        public TokenBuilder MountFlag(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new MountFlag(GetTokens(configureBuilder)));
+
+        public TokenBuilder PlatformFlag(string platform) =>
+            AddToken(DockerfileModel.PlatformFlag.Create(platform, EscapeChar));
+
+        public TokenBuilder PlatformFlag(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new PlatformFlag(GetTokens(configureBuilder)));
+
+        public TokenBuilder Registry(string registry) =>
+            AddToken(new RegistryToken(registry));
+
+        public TokenBuilder Registry(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new RegistryToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder Repository(string repository) =>
+            AddToken(new RepositoryToken(repository));
+
+        public TokenBuilder Repository(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new RepositoryToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder NewLine() =>
+            AddToken(new NewLineToken(DefaultNewLine));
+
+        public TokenBuilder SecretMount(string id, string? destinationPath = null) =>
+            AddToken(DockerfileModel.SecretMount.Create(id, destinationPath, EscapeChar));
+
+        public TokenBuilder SecretMount(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new SecretMount(GetTokens(configureBuilder)));
+
+        public TokenBuilder ShellFormRunCommand(string command) =>
+            AddToken(DockerfileModel.ShellFormRunCommand.Create(command, EscapeChar));
+
+        public TokenBuilder ShellFormRunCommand(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new ShellFormRunCommand(GetTokens(configureBuilder)));
+
+        public TokenBuilder StageName(string stageName) =>
+            AddToken(DockerfileModel.StageName.Create(stageName, EscapeChar));
+
+        public TokenBuilder StageName(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new StageName(GetTokens(configureBuilder)));
+
+        public TokenBuilder String(string value) =>
+            AddToken(new StringToken(value));
+
+        public TokenBuilder Symbol(char EscapeChar) =>
+            AddToken(new SymbolToken(EscapeChar));
+
+        public TokenBuilder Tag(string tag) =>
+            AddToken(new TagToken(tag));
+
+        public TokenBuilder Tag(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new TagToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder VariableRef(string variableName, bool includeBraces = false) =>
+            AddToken(VariableRefToken.Create(variableName, includeBraces, EscapeChar));
+
+        public TokenBuilder VariableRef(string variableName, string modifier, string modifierValue) =>
+            AddToken(VariableRefToken.Create(variableName, modifier, modifierValue, EscapeChar));
+
+        public TokenBuilder VariableRef(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new VariableRefToken(GetTokens(configureBuilder)));
+
+        public TokenBuilder Whitespace(string value) =>
+            AddToken(new WhitespaceToken(value));
+
+        public override string ToString() =>
+            string.Concat(Tokens.Select(token => token.ToString()));
+
+        private TokenBuilder AddToken(Token token)
+        {
+            Tokens.Add(token);
+            return this;
+        }
+
+        private IEnumerable<Token> GetTokens(Action<TokenBuilder> configureBuilder)
+        {
+            TokenBuilder builder = new TokenBuilder
+            {
+                DefaultNewLine = DefaultNewLine,
+                EscapeChar = EscapeChar
+            };
+            configureBuilder(builder);
+            return builder.Tokens;
+        }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel/Tokens/VariableRefToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/VariableRefToken.cs
@@ -25,7 +25,7 @@ namespace DockerfileModel.Tokens
         {
         }
 
-        private VariableRefToken(IEnumerable<Token> tokens) : base(tokens)
+        internal VariableRefToken(IEnumerable<Token> tokens) : base(tokens)
         {
         }
 


### PR DESCRIPTION
Implements a fluent API with `TokenBuilder` that provides a simple interface to create individual tokens.  When used in conjunction with `DockerfileBuilder`, it provides full flexibility to create a Dockerfile containing any content.

