### PR TITLE
Add Parse method to LiteralToken

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/LiteralTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/LiteralTokenTests.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DockerfileModel.Tokens;
+using Sprache;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
+
+namespace DockerfileModel.Tests
+{
+    public class LiteralTokenTests
+    {
+        [Theory]
+        [MemberData(nameof(ParseTestInput))]
+        public void Parse(LiteralTokenParseTestScenario scenario)
+        {
+            if (scenario.ParseExceptionPosition is null)
+            {
+                LiteralToken result = LiteralToken.Parse(scenario.Text, scenario.ParseVariableRefs, scenario.EscapeChar);
+                Assert.Equal(scenario.Text, result.ToString());
+                Assert.Collection(result.Tokens, scenario.TokenValidators);
+                scenario.Validate?.Invoke(result);
+            }
+            else
+            {
+                ParseException exception = Assert.Throws<ParseException>(
+                    () => ExposeInstruction.Parse(scenario.Text, scenario.EscapeChar));
+                Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
+                Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
+            }
+        }
+
+        public static IEnumerable<object[]> ParseTestInput()
+        {
+            LiteralTokenParseTestScenario[] testInputs = new LiteralTokenParseTestScenario[]
+            {
+                new LiteralTokenParseTestScenario
+                {
+                    Text = "test-$var",
+                    ParseVariableRefs = true,
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test-"),
+                            token => ValidateAggregate<VariableRefToken>(token, "$var",
+                                token => ValidateString(token, "var"))
+                    }
+                },
+                new LiteralTokenParseTestScenario
+                {
+                    Text = "test-$var this",
+                    ParseVariableRefs = true,
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test-"),
+                        token => ValidateAggregate<VariableRefToken>(token, "$var",
+                            token => ValidateString(token, "var")),
+                        token => ValidateWhitespace(token, " "),
+                        token => ValidateString(token, "this")
+                    }
+                },
+                new LiteralTokenParseTestScenario
+                {
+                    Text = "\"test this\"",
+                    ParseVariableRefs = false,
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test this")
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal('\"', result.QuoteChar);
+                    }
+                },
+                new LiteralTokenParseTestScenario
+                {
+                    Text = "\"test\"",
+                    ParseVariableRefs = false,
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test")
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal('\"', result.QuoteChar);
+                    }
+                },
+                new LiteralTokenParseTestScenario
+                {
+                    Text = "test this",
+                    ParseVariableRefs = false,
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test this")
+                    }
+                },
+                new LiteralTokenParseTestScenario
+                {
+                    Text = "test this $var",
+                    ParseVariableRefs = false,
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test this $var")
+                    }
+                },
+                new LiteralTokenParseTestScenario
+                {
+                    Text = "\"test this $var\"",
+                    ParseVariableRefs = false,
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test this $var")
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal('\"', result.QuoteChar);
+                    }
+                }
+            };
+
+            return testInputs.Select(input => new object[] { input });
+        }
+    }
+
+    public class LiteralTokenParseTestScenario : ParseTestScenario<LiteralToken>
+    {
+        public char EscapeChar { get; set; }
+        public bool ParseVariableRefs { get; set; }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
@@ -284,7 +284,13 @@ namespace DockerfileModel.Tests
                         .Comment(" Output message")
                         .NewLine()
                         .Whitespace("  ")
-                        .ShellFormCommand("echo $MESSAGE");
+                        .ShellFormCommand(tokenBuilder =>
+                        {
+                            tokenBuilder.Literal(tokenBuilder =>
+                                tokenBuilder
+                                    .String("echo ")
+                                    .VariableRef("MESSAGE"));
+                        });
                 });
 
             string expectedOutput =

--- a/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
@@ -74,7 +74,7 @@ namespace DockerfileModel
             ).AtLeastOnce().Flatten();
 
         private static Parser<LiteralToken> MultiVariableFormatValueParser(char escapeChar) =>
-            from literal in LiteralAggregate(escapeChar, isWhitespaceAllowed: true).Optional()
+            from literal in LiteralAggregate(escapeChar, whitespaceMode: WhitespaceMode.AllowedInQuotes).Optional()
             select literal.GetOrElse(new LiteralToken(""));
 
         private static Parser<IEnumerable<Token>> SingleVariableFormat(char escapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
@@ -120,7 +120,7 @@ namespace DockerfileModel
 
         private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
             from changeOwner in ArgTokens(
-                DockerfileModel.ChangeOwnerFlag.GetParser(escapeChar: escapeChar).AsEnumerable(), escapeChar).Optional()
+                ChangeOwnerFlag.GetParser(escapeChar: escapeChar).AsEnumerable(), escapeChar).Optional()
             from whitespace in Whitespace()
             from files in JsonArray(escapeChar, canContainVariables: true).Or(
                 from literals in ArgTokens(

--- a/src/DockerfileModel/DockerfileModel/Tokens/LiteralToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/LiteralToken.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using Sprache;
 using Validation;
+using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel.Tokens
 {
@@ -25,5 +27,20 @@ namespace DockerfileModel.Tokens
         }
 
         public char? QuoteChar { get; set; }
+
+        public static LiteralToken Parse(string text, bool canContainVariables = false, char escapeChar = Dockerfile.DefaultEscapeChar)
+        {
+            Parser<LiteralToken> parser;
+            if (canContainVariables)
+            {
+                parser = LiteralAggregate(escapeChar, whitespaceMode: WhitespaceMode.Allowed);
+            }
+            else
+            {
+                parser = WrappedInOptionalQuotesLiteralStringWithSpaces(escapeChar, excludeVariableRefChars: false);
+            }
+
+            return parser.Parse(text);
+        }
     }
 }


### PR DESCRIPTION
While LiteralToken is typically used to encapsulate simple strings, there are other cases where it ends up being a more complex object graph.  This can't be handled today by simply calling the ctor since it only takes a string and doesn't parse it out into its sub-tokens.  

These changes add a Parse method that is specifically intended to handle strings that are quoted or contain variable references, allowing the LiteralToken instance to be properly configured.