### PR TITLE
Replace static Create methods with ctors

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/AddInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/AddInstructionTests.cs
@@ -6,7 +6,8 @@ namespace DockerfileModel.Tests
     public class AddInstructionTests : FileTransferInstructionTests<AddInstruction>
     {
         public AddInstructionTests()
-            : base("ADD", AddInstruction.Parse, AddInstruction.Create)
+            : base("ADD", AddInstruction.Parse,
+                  (sources, destination, changeOwner, escapeChar) => new AddInstruction(sources, destination, changeOwner, escapeChar))
         {
         }
 

--- a/src/DockerfileModel/DockerfileModel.Tests/ArgInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ArgInstructionTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            ArgInstruction result = ArgInstruction.Create(scenario.ArgName, scenario.ArgValue);
+            ArgInstruction result = new ArgInstruction(scenario.ArgName, scenario.ArgValue);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }
@@ -43,7 +43,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void ArgName()
         {
-            ArgInstruction arg = ArgInstruction.Create("test");
+            ArgInstruction arg = new ArgInstruction("test");
             Assert.Equal("test", arg.ArgName);
             Assert.Equal("test", arg.ArgNameToken.Value);
 
@@ -63,7 +63,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void ArgValue()
         {
-            ArgInstruction arg = ArgInstruction.Create("test");
+            ArgInstruction arg = new ArgInstruction("test");
             Assert.Null(arg.ArgValue);
             Assert.Null(arg.ArgValueToken);
             Assert.False(arg.HasAssignmentOperator);

--- a/src/DockerfileModel/DockerfileModel.Tests/ChangeOwnerTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ChangeOwnerTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            ChangeOwner result = ChangeOwner.Create(scenario.User, scenario.Group);
+            ChangeOwner result = new ChangeOwner(scenario.User, scenario.Group);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }
@@ -43,7 +43,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void User()
         {
-            ChangeOwner changeOwner = ChangeOwner.Create("test", "group");
+            ChangeOwner changeOwner = new ChangeOwner("test", "group");
             Assert.Equal("test", changeOwner.User);
             Assert.Equal("test", changeOwner.UserToken.Value);
 
@@ -68,7 +68,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Group()
         {
-            ChangeOwner changeOwner = ChangeOwner.Create("user", "test");
+            ChangeOwner changeOwner = new ChangeOwner("user", "test");
             Assert.Equal("test", changeOwner.Group);
             Assert.Equal("test", changeOwner.GroupToken.Value);
 

--- a/src/DockerfileModel/DockerfileModel.Tests/CommandInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CommandInstructionTests.cs
@@ -38,11 +38,11 @@ namespace DockerfileModel.Tests
             CommandInstruction result;
             if (scenario.Command != null)
             {
-                result = CommandInstruction.Create(scenario.Command);
+                result = new CommandInstruction(scenario.Command);
             }
             else
             {
-                result = CommandInstruction.Create(scenario.Commands);
+                result = new CommandInstruction(scenario.Commands);
             }
 
             Assert.Collection(result.Tokens, scenario.TokenValidators);

--- a/src/DockerfileModel/DockerfileModel.Tests/CommentTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CommentTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            Comment result = Comment.Create(scenario.Comment);
+            Comment result = new Comment(scenario.Comment);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate(result);
         }
@@ -43,7 +43,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Text()
         {
-            Comment comment = Comment.Create("test");
+            Comment comment = new Comment("test");
             Assert.Equal("test", comment.Value);
             Assert.Equal("test", comment.ValueToken.Text);
 

--- a/src/DockerfileModel/DockerfileModel.Tests/CommentTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CommentTokenTests.cs
@@ -19,17 +19,17 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Create()
         {
-            CommentToken comment = CommentToken.Create("test");
+            CommentToken comment = new CommentToken("test");
             Assert.Equal("#test", comment.ToString());
 
-            comment = CommentToken.Create(" \ttest");
+            comment = new CommentToken(" \ttest");
             Assert.Equal("# \ttest", comment.ToString());
         }
 
         [Fact]
         public void Text()
         {
-            CommentToken comment = CommentToken.Create("test");
+            CommentToken comment = new CommentToken("test");
 
             Assert.Equal("test", comment.Text);
             Assert.Equal("test", comment.TextToken.Value);

--- a/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
@@ -6,7 +6,8 @@ namespace DockerfileModel.Tests
     public class CopyInstructionTests : FileTransferInstructionTests<CopyInstruction>
     {
         public CopyInstructionTests()
-            : base("COPY", CopyInstruction.Parse, CopyInstruction.Create)
+            : base("COPY", CopyInstruction.Parse,
+                  (sources, destination, changeOwner, escapeChar) => new CopyInstruction(sources, destination, changeOwner, escapeChar))
         {
         }
 

--- a/src/DockerfileModel/DockerfileModel.Tests/EntrypointInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/EntrypointInstructionTests.cs
@@ -38,11 +38,11 @@ namespace DockerfileModel.Tests
             EntrypointInstruction result;
             if (scenario.Command != null)
             {
-                result = EntrypointInstruction.Create(scenario.Command);
+                result = new EntrypointInstruction(scenario.Command);
             }
             else
             {
-                result = EntrypointInstruction.Create(scenario.Commands);
+                result = new EntrypointInstruction(scenario.Commands);
             }
 
             Assert.Collection(result.Tokens, scenario.TokenValidators);

--- a/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            EnvInstruction result = EnvInstruction.Create(scenario.Variables);
+            EnvInstruction result = new EnvInstruction(scenario.Variables);
 
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
@@ -64,7 +64,7 @@ namespace DockerfileModel.Tests
                 });
             }
 
-            EnvInstruction result = EnvInstruction.Create(
+            EnvInstruction result = new EnvInstruction(
                 new Dictionary<string, string>
                 {
                     { "VAR1", "test" }

--- a/src/DockerfileModel/DockerfileModel.Tests/ExecFormCommandTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ExecFormCommandTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            ExecFormCommand result = ExecFormCommand.Create(scenario.Commands);
+            ExecFormCommand result = new ExecFormCommand(scenario.Commands);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }
@@ -43,7 +43,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Commands()
         {
-            ExecFormCommand result = ExecFormCommand.Create(new string[]
+            ExecFormCommand result = new ExecFormCommand(new string[]
             {
                 "/bin/bash",
                 "-c",

--- a/src/DockerfileModel/DockerfileModel.Tests/ExposeInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ExposeInstructionTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            ExposeInstruction result = ExposeInstruction.Create(scenario.Port, scenario.Protocol);
+            ExposeInstruction result = new ExposeInstruction(scenario.Port, scenario.Protocol);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }

--- a/src/DockerfileModel/DockerfileModel.Tests/FileTransferInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/FileTransferInstructionTests.cs
@@ -79,11 +79,11 @@ namespace DockerfileModel.Tests
                 Assert.Equal($"{instructionName} --chown={user} src dst", instruction.ToString());
             }
 
-            ChangeOwner changeOwner = DockerfileModel.ChangeOwner.Create("user");
+            ChangeOwner changeOwner = new ChangeOwner("user");
             TInstruction instruction = this.create(new string[] { "src" }, "dst", changeOwner, Dockerfile.DefaultEscapeChar);
             Validate(instruction, "user");
 
-            instruction.ChangeOwner = DockerfileModel.ChangeOwner.Create("user2");
+            instruction.ChangeOwner = new ChangeOwner("user2");
             Validate(instruction, "user2");
 
             instruction.ChangeOwner = null;
@@ -91,7 +91,7 @@ namespace DockerfileModel.Tests
             Assert.Equal($"{instructionName} src dst", instruction.ToString());
 
             instruction = this.parse($"{instructionName}`\n src dst", '`');
-            instruction.ChangeOwner = DockerfileModel.ChangeOwner.Create("user");
+            instruction.ChangeOwner = new ChangeOwner("user");
             Assert.Equal("user", instruction.ChangeOwner.User);
             Assert.Equal($"{instructionName} --chown=user`\n src dst", instruction.ToString());
 
@@ -354,7 +354,7 @@ namespace DockerfileModel.Tests
                         "src2"
                     },
                     Destination = "dst",
-                    ChangeOwner = DockerfileModel.ChangeOwner.Create("user", "group"),
+                    ChangeOwner = new ChangeOwner("user", "group"),
                     TokenValidators = new Action<Token>[]
                     {
                         token => ValidateKeyword(token, instructionName),

--- a/src/DockerfileModel/DockerfileModel.Tests/FromInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/FromInstructionTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            FromInstruction result = FromInstruction.Create(scenario.ImageName, scenario.Stage, scenario.Platform);
+            FromInstruction result = new FromInstruction(scenario.ImageName, scenario.Stage, scenario.Platform);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }
@@ -43,7 +43,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void ImageName()
         {
-            FromInstruction instruction = FromInstruction.Create("test");
+            FromInstruction instruction = new FromInstruction("test");
             Assert.Equal("test", instruction.ImageName);
             Assert.Equal("test", instruction.ImageNameToken.Value);
 
@@ -67,7 +67,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Platform()
         {
-            FromInstruction instruction = FromInstruction.Create("test");
+            FromInstruction instruction = new FromInstruction("test");
             Assert.Null(instruction.Platform);
             Assert.Null(instruction.PlatformToken);
 
@@ -107,7 +107,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void StageName()
         {
-            FromInstruction instruction = FromInstruction.Create("test");
+            FromInstruction instruction = new FromInstruction("test");
             Assert.Null(instruction.StageName);
             Assert.Null(instruction.StageNameToken);
 

--- a/src/DockerfileModel/DockerfileModel.Tests/GenericInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/GenericInstructionTests.cs
@@ -34,7 +34,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            GenericInstruction result = GenericInstruction.Create(scenario.InstructionName, scenario.Args);
+            GenericInstruction result = new GenericInstruction(scenario.InstructionName, scenario.Args);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate(result);
         }

--- a/src/DockerfileModel/DockerfileModel.Tests/HealthCheckInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/HealthCheckInstructionTests.cs
@@ -39,15 +39,15 @@ namespace DockerfileModel.Tests
             
             if (scenario.Command is not null)
             {
-                result = HealthCheckInstruction.Create(scenario.Command, scenario.Interval, scenario.Timeout, scenario.StartPeriod, scenario.Retries);
+                result = new HealthCheckInstruction(scenario.Command, scenario.Interval, scenario.Timeout, scenario.StartPeriod, scenario.Retries);
             }
             else if (scenario.Commands is not null)
             {
-                result = HealthCheckInstruction.Create(scenario.Commands, scenario.Interval, scenario.Timeout, scenario.StartPeriod, scenario.Retries);
+                result = new HealthCheckInstruction(scenario.Commands, scenario.Interval, scenario.Timeout, scenario.StartPeriod, scenario.Retries);
             }
             else
             {
-                result = HealthCheckInstruction.CreateDisabled();
+                result = new HealthCheckInstruction();
             }
 
             Assert.Collection(result.Tokens, scenario.TokenValidators);
@@ -57,7 +57,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Interval()
         {
-            HealthCheckInstruction instruction = HealthCheckInstruction.Create("command", interval: "10s");
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", interval: "10s");
             Assert.Equal("10s", instruction.Interval);
             Assert.Equal("10s", instruction.IntervalToken.Value);
             Assert.Equal("HEALTHCHECK --interval=10s CMD command", instruction.ToString());
@@ -91,7 +91,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Timeout()
         {
-            HealthCheckInstruction instruction = HealthCheckInstruction.Create("command", timeout: "10s");
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", timeout: "10s");
             Assert.Equal("10s", instruction.Timeout);
             Assert.Equal("10s", instruction.TimeoutToken.Value);
             Assert.Equal("HEALTHCHECK --timeout=10s CMD command", instruction.ToString());
@@ -125,7 +125,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void StartPeriod()
         {
-            HealthCheckInstruction instruction = HealthCheckInstruction.Create("command", startPeriod: "10s");
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", startPeriod: "10s");
             Assert.Equal("10s", instruction.StartPeriod);
             Assert.Equal("10s", instruction.StartPeriodToken.Value);
             Assert.Equal("HEALTHCHECK --start-period=10s CMD command", instruction.ToString());
@@ -159,7 +159,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Retries()
         {
-            HealthCheckInstruction instruction = HealthCheckInstruction.Create("command", retries: "10s");
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", retries: "10s");
             Assert.Equal("10s", instruction.Retries);
             Assert.Equal("10s", instruction.RetriesToken.Value);
             Assert.Equal("HEALTHCHECK --retries=10s CMD command", instruction.ToString());
@@ -193,16 +193,16 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Command()
         {
-            HealthCheckInstruction instruction = HealthCheckInstruction.Create("command1");
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command1");
             Assert.Equal("HEALTHCHECK CMD command1", instruction.ToString());
 
-            instruction.Command = ExecFormCommand.Create(new string[] { "command", "arg" });
+            instruction.Command = new ExecFormCommand(new string[] { "command", "arg" });
             Assert.Equal("HEALTHCHECK CMD [\"command\", \"arg\"]", instruction.ToString());
 
             instruction.Command = null;
             Assert.Equal("HEALTHCHECK NONE", instruction.ToString());
 
-            instruction.Command = ShellFormCommand.Create("cmd");
+            instruction.Command = new ShellFormCommand("cmd");
             Assert.Equal("HEALTHCHECK CMD cmd", instruction.ToString());
         }
 

--- a/src/DockerfileModel/DockerfileModel.Tests/ImageNameTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ImageNameTests.cs
@@ -34,7 +34,7 @@ namespace DockerfileModel.Tests
         [InlineData("docker.io", "library/image", null, TestSha, "docker.io/library/image@" + TestSha)]
         public void Create(string registry, string repository, string tag, string digest, string expectedOutput)
         {
-            ImageName result = ImageName.Create(repository, registry, tag, digest);
+            ImageName result = new ImageName(repository, registry, tag, digest);
             Assert.Equal(expectedOutput, result.ToString());
 
             Assert.Equal(registry, result.Registry);
@@ -46,23 +46,24 @@ namespace DockerfileModel.Tests
         [Fact]
         public void CannotSetTagWhenDigestIsSet()
         {
-            ImageName imageName = ImageName.Create("repo", "registry.io", digest: "sha256:digest");
+            ImageName imageName = new ImageName("repo", "registry.io", digest: "sha256:digest");
             Assert.Throws<InvalidOperationException>(() => imageName.Tag = "tag");
         }
 
         [Fact]
         public void CannotSetDigestWhenTagIsSet()
         {
-            ImageName imageName = ImageName.Create("repo", "registry.io", "tag");
+            ImageName imageName = new ImageName("repo", "registry.io", "tag");
             Assert.Throws<InvalidOperationException>(() => imageName.Digest = "digest");
         }
 
         [Fact]
         public void ChangeValues()
         {
-            ImageName imageName = ImageName.Create("repo", "registry.io", "tag");
-            
-            imageName.Registry = "registry2.io";
+            ImageName imageName = new ImageName("repo", "registry.io", "tag")
+            {
+                Registry = "registry2.io"
+            };
             Assert.Equal("registry2.io", imageName.Registry);
 
             imageName.Repository = "repo2";
@@ -104,7 +105,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Registry()
         {
-            ImageName imageName = ImageName.Create("repo");
+            ImageName imageName = new ImageName("repo");
             Assert.Null(imageName.Registry);
             Assert.Null(imageName.RegistryToken);
 
@@ -132,7 +133,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Repository()
         {
-            ImageName imageName = ImageName.Create("test");
+            ImageName imageName = new ImageName("test");
             Assert.Equal("test", imageName.Repository);
             Assert.Equal("test", imageName.RepositoryToken.Value);
 
@@ -155,7 +156,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Tag()
         {
-            ImageName imageName = ImageName.Create("repo");
+            ImageName imageName = new ImageName("repo");
             Assert.Null(imageName.Tag);
             Assert.Null(imageName.TagToken);
 
@@ -186,7 +187,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Digest()
         {
-            ImageName imageName = ImageName.Create("repo");
+            ImageName imageName = new ImageName("repo");
             Assert.Null(imageName.Digest);
             Assert.Null(imageName.DigestToken);
 

--- a/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
@@ -39,7 +39,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            KeyValueToken<KeywordToken, LiteralToken> result = KeyValueToken<KeywordToken, LiteralToken>.Create(
+            KeyValueToken<KeywordToken, LiteralToken> result = new KeyValueToken<KeywordToken, LiteralToken>(
                 new KeywordToken(scenario.Key), new LiteralToken(scenario.Value));
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
@@ -48,7 +48,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Key()
         {
-            KeyValueToken<KeywordToken, LiteralToken> token = KeyValueToken<KeywordToken, LiteralToken>.Create(
+            KeyValueToken<KeywordToken, LiteralToken> token = new KeyValueToken<KeywordToken, LiteralToken>(
                 new KeywordToken("foo"), new LiteralToken("test"));
             Assert.Equal("foo", token.Key);
             Assert.Equal("foo", token.KeyToken.Value);

--- a/src/DockerfileModel/DockerfileModel.Tests/LineContinuationTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/LineContinuationTokenTests.cs
@@ -15,21 +15,21 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Create()
         {
-            LineContinuationToken token = LineContinuationToken.Create();
+            LineContinuationToken token = new LineContinuationToken();
             Assert.Collection(token.Tokens, new Action<Token>[]
             {
                 token => ValidateSymbol(token, '\\'),
                 token => ValidateNewLine(token, Environment.NewLine)
             });
 
-            token = LineContinuationToken.Create('`');
+            token = new LineContinuationToken('`');
             Assert.Collection(token.Tokens, new Action<Token>[]
             {
                 token => ValidateSymbol(token, '`'),
                 token => ValidateNewLine(token, Environment.NewLine)
             });
 
-            token = LineContinuationToken.Create("\n", '`');
+            token = new LineContinuationToken("\n", '`');
             Assert.Collection(token.Tokens, new Action<Token>[]
             {
                 token => ValidateSymbol(token, '`'),

--- a/src/DockerfileModel/DockerfileModel.Tests/ParserDirectiveTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ParserDirectiveTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            ParserDirective result = ParserDirective.Create(scenario.Directive, scenario.Value);
+            ParserDirective result = new ParserDirective(scenario.Directive, scenario.Value);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate(result);
         }

--- a/src/DockerfileModel/DockerfileModel.Tests/RunInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/RunInstructionTests.cs
@@ -40,22 +40,22 @@ namespace DockerfileModel.Tests
             {
                 if (scenario.Mounts is null)
                 {
-                    result = RunInstruction.Create(scenario.Command);
+                    result = new RunInstruction(scenario.Command);
                 }
                 else
                 {
-                    result = RunInstruction.Create(scenario.Command, scenario.Mounts);
+                    result = new RunInstruction(scenario.Command, scenario.Mounts);
                 }
             }
             else
             {
                 if (scenario.Mounts is null)
                 {
-                    result = RunInstruction.Create(scenario.Commands);
+                    result = new RunInstruction(scenario.Commands);
                 }
                 else
                 {
-                    result = RunInstruction.Create(scenario.Commands, scenario.Mounts);
+                    result = new RunInstruction(scenario.Commands, scenario.Mounts);
                 }
             }
 
@@ -66,14 +66,14 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Mounts()
         {
-            RunInstruction instruction = RunInstruction.Create("echo hello", new Mount[] { SecretMount.Create("id") });
+            RunInstruction instruction = new RunInstruction("echo hello", new Mount[] { new SecretMount("id") });
             Assert.Single(instruction.Mounts);
             Assert.Equal("RUN --mount=type=secret,id=id echo hello", instruction.ToString());
 
             ((SecretMount)instruction.Mounts[0]).Id = "id2";
             Assert.Equal("RUN --mount=type=secret,id=id2 echo hello", instruction.ToString());
 
-            instruction.Mounts[0] = SecretMount.Create("id3");
+            instruction.Mounts[0] = new SecretMount("id3");
             Assert.Equal("RUN --mount=type=secret,id=id3 echo hello", instruction.ToString());
         }
 
@@ -413,7 +413,7 @@ namespace DockerfileModel.Tests
                     Command = "echo hello",
                     Mounts = new Mount[]
                     {
-                        SecretMount.Create("id")
+                        new SecretMount("id")
                     },
                     TokenValidators = new Action<Token>[]
                     {
@@ -438,8 +438,8 @@ namespace DockerfileModel.Tests
                     Command = "echo hello",
                     Mounts = new Mount[]
                     {
-                        SecretMount.Create("id"),
-                        SecretMount.Create("id2")
+                        new SecretMount("id"),
+                        new SecretMount("id2")
                     },
                     TokenValidators = new Action<Token>[]
                     {

--- a/src/DockerfileModel/DockerfileModel.Tests/SecretMountTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/SecretMountTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            SecretMount result = SecretMount.Create(scenario.Id, scenario.DestinationPath);
+            SecretMount result = new SecretMount(scenario.Id, scenario.DestinationPath);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }
@@ -43,7 +43,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Id()
         {
-            SecretMount secretMount = SecretMount.Create("test");
+            SecretMount secretMount = new SecretMount("test");
             Assert.Equal("test", secretMount.Id);
             Assert.Equal("test", secretMount.IdToken.Value);
 
@@ -55,7 +55,7 @@ namespace DockerfileModel.Tests
             Assert.Equal("test3", secretMount.Id);
             Assert.Equal("test3", secretMount.IdToken.Value);
 
-            secretMount.IdToken = KeyValueToken<KeywordToken, LiteralToken>.Create(
+            secretMount.IdToken = new KeyValueToken<KeywordToken, LiteralToken>(
                 new KeywordToken("id"), new LiteralToken("test4"));
             Assert.Equal("test4", secretMount.Id);
             Assert.Equal("test4", secretMount.IdToken.Value);
@@ -67,7 +67,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void DestinationPath()
         {
-            SecretMount secretMount = SecretMount.Create("foo", "test");
+            SecretMount secretMount = new SecretMount("foo", "test");
             Assert.Equal("test", secretMount.DestinationPath);
             Assert.Equal("test", secretMount.DestinationPathToken.Value);
 
@@ -79,7 +79,7 @@ namespace DockerfileModel.Tests
             Assert.Equal("test3", secretMount.DestinationPath);
             Assert.Equal("test3", secretMount.DestinationPathToken.Value);
 
-            secretMount.DestinationPathToken = KeyValueToken<KeywordToken, LiteralToken>.Create(
+            secretMount.DestinationPathToken = new KeyValueToken<KeywordToken, LiteralToken>(
                 new KeywordToken("dst"), new LiteralToken("test4"));
             Assert.Equal("test4", secretMount.DestinationPath);
             Assert.Equal("test4", secretMount.DestinationPathToken.Value);

--- a/src/DockerfileModel/DockerfileModel.Tests/ShellFormCommandTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ShellFormCommandTests.cs
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            ShellFormCommand result = ShellFormCommand.Create(scenario.Command);
+            ShellFormCommand result = new ShellFormCommand(scenario.Command);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }
@@ -43,7 +43,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Value()
         {
-            ShellFormCommand result = ShellFormCommand.Create("echo hello");
+            ShellFormCommand result = new ShellFormCommand("echo hello");
             Assert.Equal("echo hello", result.Value);
             Assert.Equal("echo hello", result.ValueToken.Value);
 

--- a/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
@@ -24,7 +24,7 @@ namespace DockerfileModel.Tests
                 .Keyword("key")
                 .LineContinuation()
                 .Literal("literal")
-                .MountFlag(SecretMount.Create("id"))
+                .MountFlag(new SecretMount("id"))
                 .NewLine()
                 .PlatformFlag("platform")
                 .Registry("registry")

--- a/src/DockerfileModel/DockerfileModel.Tests/WhitespaceTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/WhitespaceTests.cs
@@ -17,7 +17,7 @@ namespace DockerfileModel.Tests
         {
             if (scenario.ParseExceptionPosition is null)
             {
-                Whitespace result = Whitespace.Create(scenario.Text);
+                Whitespace result = new Whitespace(scenario.Text);
                 Assert.Equal(scenario.Text, result.ToString());
                 Assert.Collection(result.Tokens, scenario.TokenValidators);
                 scenario.Validate?.Invoke(result);
@@ -25,7 +25,7 @@ namespace DockerfileModel.Tests
             else
             {
                 ParseException exception = Assert.Throws<ParseException>(
-                    () => Whitespace.Create(scenario.Text));
+                    () => new Whitespace(scenario.Text));
                 Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
                 Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
             }
@@ -34,7 +34,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Value()
         {
-            Whitespace whitespace = Whitespace.Create(" ");
+            Whitespace whitespace = new Whitespace(" ");
             Assert.Equal(" ", whitespace.Value);
             Assert.Equal(" ", whitespace.ValueToken.Value);
 
@@ -62,7 +62,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void NewLine()
         {
-            Whitespace whitespace = Whitespace.Create(" ");
+            Whitespace whitespace = new Whitespace(" ");
             Assert.Null(whitespace.NewLine);
             Assert.Null(whitespace.NewLineToken);
 

--- a/src/DockerfileModel/DockerfileModel/AddInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/AddInstruction.cs
@@ -9,6 +9,12 @@ namespace DockerfileModel
     {
         private const string Name = "ADD";
 
+        public AddInstruction(IEnumerable<string> sources, string destination,
+            ChangeOwner? changeOwner = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(sources, destination, changeOwner, escapeChar, Name)
+        {
+        }
+
         private AddInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
         }
@@ -19,9 +25,5 @@ namespace DockerfileModel
         public static Parser<AddInstruction> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
             from tokens in GetInnerParser(escapeChar, Name)
             select new AddInstruction(tokens);
-
-        public static AddInstruction Create(IEnumerable<string> sources, string destination,
-            ChangeOwner? changeOwner = null, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Create(sources, destination, changeOwner, escapeChar, Name, Parse);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/ChangeOwner.cs
+++ b/src/DockerfileModel/DockerfileModel/ChangeOwner.cs
@@ -10,6 +10,11 @@ namespace DockerfileModel
 {
     public class ChangeOwner : AggregateToken
     {
+        public ChangeOwner(string user, string? group = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(user, group, escapeChar))
+        {
+        }
+
         internal ChangeOwner(IEnumerable<Token> tokens)
             : base(tokens)
         {
@@ -72,15 +77,18 @@ namespace DockerfileModel
             }
         }
 
-        public static ChangeOwner Create(string user, string? group = null, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse($"{user}{(String.IsNullOrEmpty(group) ? "" : $":{group}")}", escapeChar);
-
         public static ChangeOwner Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             new ChangeOwner(GetTokens(text, GetInnerParser(escapeChar)));
 
         public static Parser<ChangeOwner> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
             from tokens in GetInnerParser(escapeChar)
             select new ChangeOwner(tokens);
+
+        private static IEnumerable<Token> GetTokens(string user, string? group, char escapeChar)
+        {
+            Requires.NotNullOrEmpty(user, nameof(user));
+            return GetTokens($"{user}{(String.IsNullOrEmpty(group) ? "" : $":{group}")}", GetInnerParser(escapeChar));
+        }
 
         private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
             UserAndGroup(escapeChar).Or(ArgTokens(UserParser(escapeChar), escapeChar, excludeTrailingWhitespace: true));

--- a/src/DockerfileModel/DockerfileModel/ChangeOwnerFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/ChangeOwnerFlag.cs
@@ -7,12 +7,14 @@ namespace DockerfileModel
 {
     public class ChangeOwnerFlag : KeyValueToken<KeywordToken, ChangeOwner>
     {
-        internal ChangeOwnerFlag(IEnumerable<Token> tokens) : base(tokens)
+        public ChangeOwnerFlag(ChangeOwner changeOwner)
+            : base(new KeywordToken("chown"), changeOwner, isFlag: true)
         {
         }
 
-        public static ChangeOwnerFlag Create(ChangeOwner changeOwner) =>
-            Create(new KeywordToken("chown"), changeOwner, tokens => new ChangeOwnerFlag(tokens), isFlag: true);
+        internal ChangeOwnerFlag(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
 
         public static ChangeOwnerFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/Comment.cs
+++ b/src/DockerfileModel/DockerfileModel/Comment.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using DockerfileModel.Tokens;
 using Sprache;
 using Validation;
@@ -7,8 +8,13 @@ namespace DockerfileModel
 {
     public class Comment : DockerfileConstruct
     {
-        private Comment(string text)
-            : base(GetTokens(text, ParseHelper.CommentText()))
+        public Comment(string comment)
+            : this(GetTokens(comment))
+        {
+        }
+
+        private Comment(IEnumerable<Token> tokens)
+            : base(tokens)
         {
         }
 
@@ -30,13 +36,22 @@ namespace DockerfileModel
 
         public override ConstructType Type => ConstructType.Comment;
 
-        public static Comment Create(string comment) =>
-            new Comment($"#{comment}");
+        public static Comment Parse(string text)
+        {
+            Requires.NotNullOrEmpty(text, nameof(text));
+            return new Comment(GetTokens(text, ParseHelper.CommentText()));
+        }
 
-        public static Comment Parse(string text) =>
-            new Comment(text);
+        private static IEnumerable<Token> GetTokens(string comment)
+        {
+            Requires.NotNullOrEmpty(comment, nameof(comment));
+            return GetTokens($"#{comment}", ParseHelper.CommentText());
+        }
 
-        public static bool IsComment(string text) =>
-            ParseHelper.CommentText().TryParse(text).WasSuccessful;
+        public static bool IsComment(string text)
+        {
+            Requires.NotNullOrEmpty(text, nameof(text));
+            return ParseHelper.CommentText().TryParse(text).WasSuccessful;
+        }
     }
 }

--- a/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
@@ -9,6 +9,12 @@ namespace DockerfileModel
     {
         private const string Name = "COPY";
 
+        public CopyInstruction(IEnumerable<string> sources, string destination,
+            ChangeOwner? changeOwner = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(sources, destination, changeOwner, escapeChar, Name)
+        {
+        }
+
         private CopyInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
         }
@@ -19,9 +25,5 @@ namespace DockerfileModel
         public static Parser<CopyInstruction> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
             from tokens in GetInnerParser(escapeChar, Name)
             select new CopyInstruction(tokens);
-
-        public static CopyInstruction Create(IEnumerable<string> sources, string destination,
-            ChangeOwner? changeOwner = null, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Create(sources, destination, changeOwner, escapeChar, Name, Parse);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
@@ -38,93 +38,90 @@ namespace DockerfileModel
         }
 
         public DockerfileBuilder NewLine() =>
-            AddConstruct(Whitespace.Create(DefaultNewLine));
+            AddConstruct(new Whitespace(DefaultNewLine));
 
         public DockerfileBuilder AddInstruction(IEnumerable<string> sources, string destination, ChangeOwner? changeOwnerFlag = null) =>
-            AddConstruct(DockerfileModel.AddInstruction.Create(sources, destination, changeOwnerFlag, EscapeChar));
+            AddConstruct(new AddInstruction(sources, destination, changeOwnerFlag, EscapeChar));
 
         public DockerfileBuilder AddInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.AddInstruction.Parse);
 
         public DockerfileBuilder ArgInstruction(string argName, string? argValue = null) =>
-            AddConstruct(DockerfileModel.ArgInstruction.Create(argName, argValue, EscapeChar));
+            AddConstruct(new ArgInstruction(argName, argValue, EscapeChar));
 
         public DockerfileBuilder ArgInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.ArgInstruction.Parse);
 
         public DockerfileBuilder CommandInstruction(string command) =>
-            AddConstruct(DockerfileModel.CommandInstruction.Create(command, EscapeChar));
+            AddConstruct(new CommandInstruction(command, EscapeChar));
 
         public DockerfileBuilder CommandInstruction(IEnumerable<string> commands) =>
-            AddConstruct(DockerfileModel.CommandInstruction.Create(commands, EscapeChar));
+            AddConstruct(new CommandInstruction(commands, EscapeChar));
 
         public DockerfileBuilder CommandInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.CommandInstruction.Parse);
 
         public DockerfileBuilder Comment(string comment) =>
-            AddConstruct(
-                DockerfileModel.Comment.Create(CommentSeparator + comment));
+            AddConstruct(new Comment(CommentSeparator + comment));
 
         public DockerfileBuilder Comment(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.Comment.Parse);
 
         public DockerfileBuilder CopyInstruction(IEnumerable<string> sources, string destination, ChangeOwner? changeOwner = null) =>
-            AddConstruct(DockerfileModel.CopyInstruction.Create(sources, destination, changeOwner, EscapeChar));
+            AddConstruct(new CopyInstruction(sources, destination, changeOwner, EscapeChar));
 
         public DockerfileBuilder CopyInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.CopyInstruction.Parse);
 
         public DockerfileBuilder EntrypointInstruction(string command) =>
-            AddConstruct(DockerfileModel.EntrypointInstruction.Create(command, EscapeChar));
+            AddConstruct(new EntrypointInstruction(command, EscapeChar));
 
         public DockerfileBuilder EntrypointInstruction(IEnumerable<string> commands) =>
-            AddConstruct(DockerfileModel.EntrypointInstruction.Create(commands, EscapeChar));
+            AddConstruct(new EntrypointInstruction(commands, EscapeChar));
 
         public DockerfileBuilder EntrypointInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.EntrypointInstruction.Parse);
 
         public DockerfileBuilder EnvInstruction(IDictionary<string, string> variables) =>
-            AddConstruct(DockerfileModel.EnvInstruction.Create(variables, EscapeChar));
+            AddConstruct(new EnvInstruction(variables, EscapeChar));
 
         public DockerfileBuilder EnvInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.EnvInstruction.Parse);
 
         public DockerfileBuilder ExposeInstruction(int port, string? protocol = null) =>
-            AddConstruct(DockerfileModel.ExposeInstruction.Create(port, protocol, EscapeChar));
+            AddConstruct(new ExposeInstruction(port, protocol, EscapeChar));
 
         public DockerfileBuilder ExposeInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.ExposeInstruction.Parse);
 
         public DockerfileBuilder FromInstruction(string imageName, string? stageName = null, string? platform = null) =>
-            AddConstruct(
-                DockerfileModel.FromInstruction.Create(imageName, stageName, platform, EscapeChar));
+            AddConstruct(new FromInstruction(imageName, stageName, platform, EscapeChar));
 
         public DockerfileBuilder FromInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.FromInstruction.Parse);
 
         public DockerfileBuilder GenericInstruction(string instruction, string args) =>
-            AddConstruct(
-                DockerfileModel.GenericInstruction.Create(instruction, args, EscapeChar));
+            AddConstruct(new GenericInstruction(instruction, args, EscapeChar));
 
         public DockerfileBuilder GenericInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.GenericInstruction.Parse);
 
         public DockerfileBuilder HealthCheckInstruction(string command, string? interval = null, string? timeout = null,
             string? startPeriod = null, string? retries = null) =>
-            AddConstruct(DockerfileModel.HealthCheckInstruction.Create(command, interval, timeout, startPeriod, retries, EscapeChar));
+            AddConstruct(new HealthCheckInstruction(command, interval, timeout, startPeriod, retries, EscapeChar));
 
         public DockerfileBuilder HealthCheckInstruction(IEnumerable<string> commands, string? interval = null, string? timeout = null,
             string? startPeriod = null, string? retries = null) =>
-            AddConstruct(DockerfileModel.HealthCheckInstruction.Create(commands, interval, timeout, startPeriod, retries, EscapeChar));
+            AddConstruct(new HealthCheckInstruction(commands, interval, timeout, startPeriod, retries, EscapeChar));
 
         public DockerfileBuilder HealthCheckDisabledInstruction() =>
-            AddConstruct(DockerfileModel.HealthCheckInstruction.CreateDisabled());
+            AddConstruct(new HealthCheckInstruction());
 
         public DockerfileBuilder HealthCheckInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.HealthCheckInstruction.Parse);
 
         public DockerfileBuilder ParserDirective(string directive, string value) =>
-            AddConstruct(DockerfileModel.ParserDirective.Create(CommentSeparator + directive, value));
+            AddConstruct(new ParserDirective(CommentSeparator + directive, value));
 
         public DockerfileBuilder ParserDirective(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.ParserDirective.Parse);
@@ -133,13 +130,13 @@ namespace DockerfileModel
             RunInstruction(command, Enumerable.Empty<Mount>());
 
         public DockerfileBuilder RunInstruction(string command, IEnumerable<Mount> mounts) =>
-            AddConstruct(DockerfileModel.RunInstruction.Create(command, mounts, EscapeChar));
+            AddConstruct(new RunInstruction(command, mounts, EscapeChar));
 
         public DockerfileBuilder RunInstruction(IEnumerable<string> commands) =>
             RunInstruction(commands, Enumerable.Empty<Mount>());
 
         public DockerfileBuilder RunInstruction(IEnumerable<string> commands, IEnumerable<Mount> mounts) =>
-            AddConstruct(DockerfileModel.RunInstruction.Create(commands, mounts, EscapeChar));
+            AddConstruct(new RunInstruction(commands, mounts, EscapeChar));
 
         public DockerfileBuilder RunInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.RunInstruction.Parse);
@@ -177,12 +174,12 @@ namespace DockerfileModel
             if (CanAutoAddEscapeDirective(dockerfileConstruct))
             {
                 Dockerfile.Items.Add(
-                    DockerfileModel.ParserDirective.Create(
+                    new ParserDirective(
                         CommentSeparator + DockerfileModel.ParserDirective.EscapeDirective,
                         EscapeChar.ToString()));
                 if (!DisableAutoNewLines)
                 {
-                    Dockerfile.Items.Add(Whitespace.Create(DefaultNewLine));
+                    Dockerfile.Items.Add(new Whitespace(DefaultNewLine));
                 }
             }
 
@@ -196,7 +193,7 @@ namespace DockerfileModel
 
             if (!DisableAutoNewLines && !(dockerfileConstruct is Whitespace whitespace && whitespace.NewLineToken is not null))
             {
-                Dockerfile.Items.Add(Whitespace.Create(DefaultNewLine));
+                Dockerfile.Items.Add(new Whitespace(DefaultNewLine));
             }
 
             return this;

--- a/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
@@ -101,7 +101,7 @@ namespace DockerfileModel
                 string line = constructLines[i];
                 if (Whitespace.IsWhitespace(line))
                 {
-                    dockerfileConstructs.Add(Whitespace.Create(line));
+                    dockerfileConstructs.Add(new Whitespace(line));
                 }
                 else if (Comment.IsComment(line))
                 {

--- a/src/DockerfileModel/DockerfileModel/EntrypointInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/EntrypointInstruction.cs
@@ -9,6 +9,16 @@ namespace DockerfileModel
 {
     public class EntrypointInstruction : Instruction
     {
+        public EntrypointInstruction(string command, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(command, escapeChar))
+        {
+        }
+
+        public EntrypointInstruction(IEnumerable<string> commands, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(commands, escapeChar))
+        {
+        }
+
         private EntrypointInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
         }
@@ -30,22 +40,22 @@ namespace DockerfileModel
             from tokens in GetInnerParser(escapeChar)
             select new EntrypointInstruction(tokens);
 
-        public static EntrypointInstruction Create(string command, char escapeChar = Dockerfile.DefaultEscapeChar)
-        {
-            Requires.NotNullOrEmpty(command, nameof(command));
-            return Parse($"ENTRYPOINT {command}", escapeChar);
-        }
-
-        public static EntrypointInstruction Create(IEnumerable<string> commands, char escapeChar = Dockerfile.DefaultEscapeChar)
-        {
-            Requires.NotNullEmptyOrNullElements(commands, nameof(commands));
-            return Parse($"ENTRYPOINT {StringHelper.FormatAsJson(commands)}", escapeChar);
-        }
-
         public override string? ResolveVariables(char escapeChar, IDictionary<string, string?>? variables = null, ResolutionOptions? options = null)
         {
             // Do not resolve variables for the command of an ENTRYPOINT instruction. It is shell/runtime-specific.
             return ToString();
+        }
+
+        private static IEnumerable<Token> GetTokens(string command, char escapeChar)
+        {
+            Requires.NotNullOrEmpty(command, nameof(command));
+            return GetTokens($"ENTRYPOINT {command}", GetInnerParser(escapeChar));
+        }
+
+        private static IEnumerable<Token> GetTokens(IEnumerable<string> commands, char escapeChar)
+        {
+            Requires.NotNullEmptyOrNullElements(commands, nameof(commands));
+            return GetTokens($"ENTRYPOINT {StringHelper.FormatAsJson(commands)}", GetInnerParser(escapeChar));
         }
 
         private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
@@ -9,6 +9,11 @@ namespace DockerfileModel
 {
     public class EnvInstruction : Instruction
     {
+        public EnvInstruction(IDictionary<string, string> variables, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(variables, escapeChar))
+        {
+        }
+
         private EnvInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
             VariableTokens = new TokenList<KeyValueToken<IdentifierToken, LiteralToken>>(TokenList);
@@ -34,7 +39,7 @@ namespace DockerfileModel
             from tokens in GetInnerParser(escapeChar)
             select new EnvInstruction(tokens);
 
-        public static EnvInstruction Create(IDictionary<string, string> variables, char escapeChar = Dockerfile.DefaultEscapeChar)
+        private static IEnumerable<Token> GetTokens(IDictionary<string, string> variables, char escapeChar)
         {
             Requires.NotNullOrEmpty(variables, nameof(variables));
 
@@ -51,7 +56,7 @@ namespace DockerfileModel
                 })
                 .ToArray();
 
-            return Parse($"ENV {string.Join(" ", keyValueAssignments)}", escapeChar);
+            return GetTokens($"ENV {string.Join(" ", keyValueAssignments)}", GetInnerParser(escapeChar));
         }
 
         private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/ExecFormCommand.cs
+++ b/src/DockerfileModel/DockerfileModel/ExecFormCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Dynamic;
 using System.Linq;
 using DockerfileModel.Tokens;
 using Sprache;
@@ -10,14 +9,19 @@ namespace DockerfileModel
 {
     public class ExecFormCommand : Command
     {
+        public ExecFormCommand(IEnumerable<string> commands, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(commands, escapeChar))
+        {
+        }
+
         internal ExecFormCommand(IEnumerable<Token> tokens) : base(tokens)
         {
         }
 
-        public static ExecFormCommand Create(IEnumerable<string> commands, char escapeChar = Dockerfile.DefaultEscapeChar)
+        private static IEnumerable<Token> GetTokens(IEnumerable<string> commands, char escapeChar)
         {
             Requires.NotNullEmptyOrNullElements(commands, nameof(commands));
-            return Parse(StringHelper.FormatAsJson(commands), escapeChar);
+            return GetTokens(StringHelper.FormatAsJson(commands), GetInnerParser(escapeChar));
         }
 
         public static ExecFormCommand Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/ExposeInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/ExposeInstruction.cs
@@ -10,6 +10,11 @@ namespace DockerfileModel
 {
     public class ExposeInstruction : Instruction
     {
+        public ExposeInstruction(int port, string? protocol = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(port, protocol, escapeChar))
+        {
+        }
+
         private ExposeInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
         }
@@ -74,10 +79,10 @@ namespace DockerfileModel
             from tokens in GetInnerParser(escapeChar)
             select new ExposeInstruction(tokens);
 
-        public static ExposeInstruction Create(int port, string? protocol = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+        private static IEnumerable<Token> GetTokens(int port, string? protocol, char escapeChar)
         {
             string protocolSegment = protocol is null ? string.Empty : $"/{protocol}";
-            return Parse($"EXPOSE {port}{protocolSegment}", escapeChar);
+            return GetTokens($"EXPOSE {port}{protocolSegment}", GetInnerParser(escapeChar));
         }
 
         private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/ImageName.cs
+++ b/src/DockerfileModel/DockerfileModel/ImageName.cs
@@ -17,42 +17,17 @@ namespace DockerfileModel
         private TagToken? tagToken;
         private DigestToken? digestToken;
 
+        public ImageName(string repository, string? registry = null, string? tag = null, string? digest = null)
+            : this(GetTokens(repository, registry, tag, digest))
+        {
+        }
+
         internal ImageName(IEnumerable<Token> tokens) : base(tokens)
         {
             registryToken = Tokens.OfType<RegistryToken>().FirstOrDefault();
             repositoryToken = Tokens.OfType<RepositoryToken>().First();
             tagToken = Tokens.OfType<TagToken>().FirstOrDefault();
             digestToken = Tokens.OfType<DigestToken>().FirstOrDefault();
-        }
-
-        public static ImageName Create(string repository, string? registry = null, string? tag = null, string? digest = null)
-        {
-            Requires.NotNullOrWhiteSpace(repository, nameof(repository));
-            Requires.ValidState(
-                (tag is null && digest is null) || String.IsNullOrEmpty(tag) ^ String.IsNullOrEmpty(digest),
-                $"Either {nameof(tag)} may be set or {nameof(digest)} may be set but not both.");
-
-            StringBuilder builder = new StringBuilder();
-            if (registry != null)
-            {
-                builder.Append(registry);
-                builder.Append('/');
-            }
-
-            builder.Append(repository);
-
-            if (tag != null)
-            {
-                builder.Append(':');
-                builder.Append(tag);
-            }
-            else if (digest != null)
-            {
-                builder.Append('@');
-                builder.Append(digest);
-            }
-
-            return Parse(builder.ToString());
         }
 
         public static ImageName Parse(string imageName) =>
@@ -219,6 +194,36 @@ namespace DockerfileModel
                         this.TokenList.RemoveRange(this.TokenList.Count - 2, 2);
                     });
             }
+        }
+
+        private static IEnumerable<Token> GetTokens(string repository, string? registry, string? tag, string? digest)
+        {
+            Requires.NotNullOrWhiteSpace(repository, nameof(repository));
+            Requires.ValidState(
+                (tag is null && digest is null) || String.IsNullOrEmpty(tag) ^ String.IsNullOrEmpty(digest),
+                $"Either {nameof(tag)} may be set or {nameof(digest)} may be set but not both.");
+
+            StringBuilder builder = new StringBuilder();
+            if (registry != null)
+            {
+                builder.Append(registry);
+                builder.Append('/');
+            }
+
+            builder.Append(repository);
+
+            if (tag != null)
+            {
+                builder.Append(':');
+                builder.Append(tag);
+            }
+            else if (digest != null)
+            {
+                builder.Append('@');
+                builder.Append(digest);
+            }
+
+            return GetTokens(builder.ToString(), GetParser());
         }
 
         private static class ImageNameParser

--- a/src/DockerfileModel/DockerfileModel/IntervalFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/IntervalFlag.cs
@@ -7,12 +7,14 @@ namespace DockerfileModel
 {
     public class IntervalFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        internal IntervalFlag(IEnumerable<Token> tokens) : base(tokens)
+        public IntervalFlag(string interval)
+            : base(new KeywordToken("interval"), new LiteralToken(interval), isFlag: true)
         {
         }
 
-        public static IntervalFlag Create(string interval) =>
-            Create(new KeywordToken("interval"), new LiteralToken(interval), tokens => new IntervalFlag(tokens), isFlag: true);
+        internal IntervalFlag(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
 
         public static IntervalFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/MountFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/MountFlag.cs
@@ -7,12 +7,14 @@ namespace DockerfileModel
 {
     public class MountFlag : KeyValueToken<KeywordToken, Mount>
     {
-        internal MountFlag(IEnumerable<Token> tokens) : base(tokens)
+        public MountFlag(Mount mount)
+            : base(new KeywordToken("mount"), mount, isFlag: true)
         {
         }
 
-        public static MountFlag Create(Mount mount) =>
-            Create(new KeywordToken("mount"), mount, tokens => new MountFlag(tokens), isFlag: true);
+        internal MountFlag(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
 
         public static MountFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/ParserDirective.cs
+++ b/src/DockerfileModel/DockerfileModel/ParserDirective.cs
@@ -12,8 +12,13 @@ namespace DockerfileModel
         public const string EscapeDirective = "escape";
         public const string SyntaxDirective = "syntax";
 
-        private ParserDirective(string text)
-            : base(GetTokens(text, GetParser()))
+        public ParserDirective(string directive, string value)
+            : this(GetTokens(directive, value))
+        {
+        }
+
+        private ParserDirective(IEnumerable<Token> tokens)
+            : base(tokens)
         {
         }
 
@@ -46,14 +51,8 @@ namespace DockerfileModel
 
         public override ConstructType Type => ConstructType.ParserDirective;
 
-        public static ParserDirective Create(string directive, string value)
-        {
-            Requires.NotNullOrEmpty(directive, nameof(directive));
-            return Parse($"#{directive}={value}"); ;
-        }
-
         public static ParserDirective Parse(string text) =>
-            new ParserDirective(text);
+            new ParserDirective(GetTokens(text, GetParser()));
 
         public static Parser<IEnumerable<Token>> GetParser() =>
             from leading in Whitespace()
@@ -70,6 +69,13 @@ namespace DockerfileModel
 
         internal static bool IsParserDirective(string text) =>
             GetParser().TryParse(text).WasSuccessful;
+
+        private static IEnumerable<Token> GetTokens(string directive, string value)
+        {
+            Requires.NotNullOrEmpty(directive, nameof(directive));
+            Requires.NotNullOrEmpty(value, nameof(value));
+            return GetTokens($"#{directive}={value}", GetParser());
+        }
 
         private static Parser<KeywordToken> DirectiveNameParser() =>
             from name in Sprache.Parse.Identifier(Sprache.Parse.Letter, Sprache.Parse.LetterOrDigit)

--- a/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
@@ -7,13 +7,15 @@ namespace DockerfileModel
 {
     public class PlatformFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
+        public PlatformFlag(string platform)
+            : base(new KeywordToken("platform"), new LiteralToken(platform), isFlag: true)
+        {
+        }
+
         internal PlatformFlag(IEnumerable<Token> tokens)
             : base(tokens)
         {
         }
-
-        public static PlatformFlag Create(string platform) =>
-            Create(new KeywordToken("platform"), new LiteralToken(platform), tokens => new PlatformFlag(tokens), isFlag: true);
 
         public static PlatformFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             Parse(text, Keyword("platform", escapeChar), LiteralAggregate(escapeChar), tokens => new PlatformFlag(tokens), escapeChar: escapeChar);

--- a/src/DockerfileModel/DockerfileModel/RetriesFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/RetriesFlag.cs
@@ -7,12 +7,14 @@ namespace DockerfileModel
 {
     public class RetriesFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        internal RetriesFlag(IEnumerable<Token> tokens) : base(tokens)
+        public RetriesFlag(string retryCount)
+            : base(new KeywordToken("retries"), new LiteralToken(retryCount), isFlag: true)
         {
         }
 
-        public static RetriesFlag Create(string retryCount) =>
-            Create(new KeywordToken("retries"), new LiteralToken(retryCount), tokens => new RetriesFlag(tokens), isFlag: true);
+        internal RetriesFlag(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
 
         public static RetriesFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/SecretMount.cs
+++ b/src/DockerfileModel/DockerfileModel/SecretMount.cs
@@ -10,6 +10,11 @@ namespace DockerfileModel
 {
     public class SecretMount : Mount
     {
+        public SecretMount(string id, string? destinationPath = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(id, destinationPath, escapeChar))
+        {
+        }
+
         internal SecretMount(IEnumerable<Token> tokens)
             : base(tokens)
         {
@@ -49,7 +54,7 @@ namespace DockerfileModel
                 {
                     DestinationPathToken = String.IsNullOrEmpty(value) ?
                         null :
-                        KeyValueToken<KeywordToken, LiteralToken>.Create(new KeywordToken("dst"), new LiteralToken(value!));
+                        new KeyValueToken<KeywordToken, LiteralToken>(new KeywordToken("dst"), new LiteralToken(value!));
                 }
             }
         }
@@ -74,7 +79,7 @@ namespace DockerfileModel
             }
         }
 
-        public static SecretMount Create(string id, string? destinationPath = null,
+        private static IEnumerable<Token> GetTokens(string id, string? destinationPath = null,
             char escapeChar = Dockerfile.DefaultEscapeChar)
         {
             Requires.NotNullOrEmpty(id, nameof(id));
@@ -84,7 +89,7 @@ namespace DockerfileModel
                 destinationSegment = $",dst={destinationPath}";
             }
 
-            return Parse($"type=secret,id={id}{destinationSegment}", escapeChar);
+            return GetTokens($"type=secret,id={id}{destinationSegment}", GetInnerParser(escapeChar));
         }
 
         public static SecretMount Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/ShellFormCommand.cs
+++ b/src/DockerfileModel/DockerfileModel/ShellFormCommand.cs
@@ -10,18 +10,20 @@ namespace DockerfileModel
 {
     public class ShellFormCommand : Command
     {
-        internal ShellFormCommand(IEnumerable<Token> tokens) : base(tokens)
+        public ShellFormCommand(string command, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(command, escapeChar))
         {
         }
 
-        public static ShellFormCommand Create(string command, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(command, escapeChar);
+        internal ShellFormCommand(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
 
         public static ShellFormCommand Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             new ShellFormCommand(GetTokens(text, ArgumentListAsLiteral(escapeChar)));
 
         public static Parser<ShellFormCommand> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            from tokens in ArgumentListAsLiteral(escapeChar)
+            from tokens in GetInnerParser(escapeChar)
             select new ShellFormCommand(tokens);
 
         public override CommandType CommandType => CommandType.ShellForm;
@@ -45,5 +47,14 @@ namespace DockerfileModel
                 SetToken(ValueToken, value);
             }
         }
+
+        private static IEnumerable<Token> GetTokens(string command, char escapeChar)
+        {
+            Requires.NotNullOrEmpty(command, nameof(command));
+            return GetTokens(command, GetInnerParser(escapeChar));
+        }
+
+        private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
+            ArgumentListAsLiteral(escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/StartPeriodFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/StartPeriodFlag.cs
@@ -7,12 +7,14 @@ namespace DockerfileModel
 {
     public class StartPeriodFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        internal StartPeriodFlag(IEnumerable<Token> tokens) : base(tokens)
+        public StartPeriodFlag(string startPeriod)
+            : base(new KeywordToken("start-period"), new LiteralToken(startPeriod), isFlag: true)
         {
         }
 
-        public static StartPeriodFlag Create(string startPeriod) =>
-            Create(new KeywordToken("start-period"), new LiteralToken(startPeriod), tokens => new StartPeriodFlag(tokens), isFlag: true);
+        internal StartPeriodFlag(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
 
         public static StartPeriodFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/TimeoutFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/TimeoutFlag.cs
@@ -7,12 +7,14 @@ namespace DockerfileModel
 {
     public class TimeoutFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        internal TimeoutFlag(IEnumerable<Token> tokens) : base(tokens)
+        public TimeoutFlag(string timeout)
+            : base(new KeywordToken("timeout"), new LiteralToken(timeout), isFlag: true)
         {
         }
 
-        public static TimeoutFlag Create(string timeout) =>
-            Create(new KeywordToken("timeout"), new LiteralToken(timeout), tokens => new TimeoutFlag(tokens), isFlag: true);
+        internal TimeoutFlag(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
 
         public static TimeoutFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/Tokens/CommentToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/CommentToken.cs
@@ -8,6 +8,11 @@ namespace DockerfileModel.Tokens
 {
     public class CommentToken : AggregateToken
     {
+        public CommentToken(string comment)
+            : this(GetTokens($"#{comment}", GetParser()))
+        {
+        }
+
         internal CommentToken(IEnumerable<Token> tokens)
             : base(tokens)
         {
@@ -35,9 +40,6 @@ namespace DockerfileModel.Tokens
             get => Tokens.OfType<StringToken>().FirstOrDefault();
             set => SetToken(TextToken, value);
         }
-
-        public static CommentToken Create(string comment) =>
-            Parse($"#{comment}");
 
         public static CommentToken Parse(string text) =>
             new CommentToken(GetTokens(text, GetParser()));

--- a/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
@@ -13,6 +13,19 @@ namespace DockerfileModel.Tokens
     {
         public const char DefaultSeparator = '=';
 
+        public KeyValueToken(TKey key, TValue value, bool isFlag = false, char separator = DefaultSeparator)
+            : this(
+                ConcatTokens(
+                    isFlag ? new Token[] { new SymbolToken('-'), new SymbolToken('-') } : Enumerable.Empty<Token>(),
+                    new Token[]
+                    {
+                        key,
+                        Char.IsWhiteSpace(separator) ? new WhitespaceToken(separator.ToString()) : new SymbolToken(separator),
+                        value
+                    }))
+        {
+        }
+
         internal KeyValueToken(IEnumerable<Token> tokens)
             : base(tokens)
         {
@@ -66,9 +79,6 @@ namespace DockerfileModel.Tokens
             }
         }
 
-        public static KeyValueToken<TKey, TValue> Create(TKey key, TValue value, bool isFlag = false, char separator = DefaultSeparator) =>
-            Create(key, value, tokens => new KeyValueToken<TKey, TValue>(tokens), isFlag, separator);
-
         public static KeyValueToken<TKey, TValue> Parse(string text, Parser<TKey> keyTokenParser, Parser<TValue> valueTokenParser,
             char separator = DefaultSeparator, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             Parse(text, keyTokenParser, valueTokenParser, tokens => new KeyValueToken<TKey, TValue>(tokens), separator, escapeChar);
@@ -77,18 +87,6 @@ namespace DockerfileModel.Tokens
             Parser<TKey> keyTokenParser, Parser<TValue> valueTokenParser,
             char separator = DefaultSeparator, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             GetParser(keyTokenParser, valueTokenParser, tokens => new KeyValueToken<TKey, TValue>(tokens), separator, escapeChar);
-
-        protected static T Create<T>(TKey key, TValue value, Func<IEnumerable<Token>, T> createToken, bool isFlag = false, char separator = DefaultSeparator)
-            where T : KeyValueToken<TKey, TValue> =>
-            createToken(
-                ConcatTokens(
-                    isFlag ? new Token[] { new SymbolToken('-'), new SymbolToken('-') } : Enumerable.Empty<Token>(),
-                    new Token[]
-                    {
-                        key,
-                        Char.IsWhiteSpace(separator) ? new WhitespaceToken(separator.ToString()) : new SymbolToken(separator),
-                        value
-                    }));
 
         protected static T Parse<T>(string text, Parser<TKey> keyTokenParser, Parser<TValue> valueTokenParser,
             Func<IEnumerable<Token>, T> createToken, char separator = DefaultSeparator, char escapeChar = Dockerfile.DefaultEscapeChar)

--- a/src/DockerfileModel/DockerfileModel/Tokens/LineContinuationToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/LineContinuationToken.cs
@@ -8,18 +8,22 @@ namespace DockerfileModel.Tokens
 {
     public class LineContinuationToken : AggregateToken
     {
+        public LineContinuationToken(char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(Environment.NewLine, escapeChar)
+        {
+        }
+
+        public LineContinuationToken(string newLine, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens($"{escapeChar}{newLine}", GetInnerParser(escapeChar)))
+        {
+        }
+
         internal LineContinuationToken(IEnumerable<Token> tokens) : base(tokens)
         {
         }
 
         public static LineContinuationToken Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             new LineContinuationToken(GetTokens(text, GetInnerParser(escapeChar)));
-
-        public static LineContinuationToken Create(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Create(Environment.NewLine, escapeChar);
-
-        public static LineContinuationToken Create(string newLine, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse($"{escapeChar}{newLine}", escapeChar);
 
         /// <summary>
         /// Parses a line continuation, consisting of an escape character followed by a new line.

--- a/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
@@ -13,10 +13,10 @@ namespace DockerfileModel.Tokens
         public IList<Token> Tokens { get; } = new List<Token>();
 
         public TokenBuilder ChangeOwner(string user, string? group = null) =>
-            AddToken(DockerfileModel.ChangeOwner.Create(user, group, EscapeChar));
+            AddToken(new ChangeOwner(user, group, EscapeChar));
 
         public TokenBuilder Comment(string comment) =>
-            AddToken(CommentToken.Create(comment));
+            AddToken(new CommentToken(comment));
 
         public TokenBuilder Comment(Action<TokenBuilder> configureBuilder) =>
             AddToken(new CommentToken(GetTokens(configureBuilder)));
@@ -28,7 +28,7 @@ namespace DockerfileModel.Tokens
             AddToken(new DigestToken(GetTokens(configureBuilder)));
 
         public TokenBuilder ExecFormCommand(params string[] commands) =>
-            AddToken(DockerfileModel.ExecFormCommand.Create(commands, EscapeChar));
+            AddToken(new ExecFormCommand(commands, EscapeChar));
 
         public TokenBuilder ExecFormCommand(Action<TokenBuilder> configureBuilder) =>
             AddToken(new ExecFormCommand(GetTokens(configureBuilder)));
@@ -40,13 +40,13 @@ namespace DockerfileModel.Tokens
             AddToken(new IdentifierToken(GetTokens(configureBuilder)));
 
         public TokenBuilder ImageName(string repository, string? registry = null, string? tag = null, string? digest = null) =>
-            AddToken(DockerfileModel.ImageName.Create(repository, registry, tag, digest));
+            AddToken(new ImageName(repository, registry, tag, digest));
 
         public TokenBuilder ImageName(Action<TokenBuilder> configureBuilder) =>
             AddToken(new ImageName(GetTokens(configureBuilder)));
 
         public TokenBuilder IntervalFlag(string interval) =>
-            AddToken(DockerfileModel.IntervalFlag.Create(interval));
+            AddToken(new IntervalFlag(interval));
 
         public TokenBuilder IntervalFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new IntervalFlag(GetTokens(configureBuilder)));
@@ -55,7 +55,7 @@ namespace DockerfileModel.Tokens
             char separator = KeyValueToken<TKey, TValue>.DefaultSeparator)
             where TKey : Token, IValueToken
             where TValue : Token =>
-            AddToken(KeyValueToken<TKey, TValue>.Create(key, value, isFlag, separator));
+            AddToken(new KeyValueToken<TKey, TValue>(key, value, isFlag, separator));
 
         public TokenBuilder KeyValue<TKey, TValue>(Action<TokenBuilder> configureBuilder)
             where TKey : Token, IValueToken
@@ -69,7 +69,7 @@ namespace DockerfileModel.Tokens
             AddToken(new KeywordToken(GetTokens(configureBuilder)));
 
         public TokenBuilder LineContinuation() =>
-            AddToken(LineContinuationToken.Create(DefaultNewLine, EscapeChar));
+            AddToken(new LineContinuationToken(DefaultNewLine, EscapeChar));
 
         public TokenBuilder LineContinuation(Action<TokenBuilder> configureBuilder) =>
             AddToken(new LineContinuationToken(GetTokens(configureBuilder)));
@@ -81,13 +81,13 @@ namespace DockerfileModel.Tokens
             AddToken(new LiteralToken(GetTokens(configureBuilder)));
 
         public TokenBuilder MountFlag(Mount mount) =>
-            AddToken(DockerfileModel.MountFlag.Create(mount));
+            AddToken(new MountFlag(mount));
 
         public TokenBuilder MountFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new MountFlag(GetTokens(configureBuilder)));
 
         public TokenBuilder PlatformFlag(string platform) =>
-            AddToken(DockerfileModel.PlatformFlag.Create(platform));
+            AddToken(new PlatformFlag(platform));
 
         public TokenBuilder PlatformFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new PlatformFlag(GetTokens(configureBuilder)));
@@ -105,7 +105,7 @@ namespace DockerfileModel.Tokens
             AddToken(new RepositoryToken(GetTokens(configureBuilder)));
 
         public TokenBuilder RetriesFlag(string retries) =>
-            AddToken(DockerfileModel.RetriesFlag.Create(retries));
+            AddToken(new RetriesFlag(retries));
 
         public TokenBuilder RetriesFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new RetriesFlag(GetTokens(configureBuilder)));
@@ -114,19 +114,19 @@ namespace DockerfileModel.Tokens
             AddToken(new NewLineToken(DefaultNewLine));
 
         public TokenBuilder SecretMount(string id, string? destinationPath = null) =>
-            AddToken(DockerfileModel.SecretMount.Create(id, destinationPath, EscapeChar));
+            AddToken(new SecretMount(id, destinationPath, EscapeChar));
 
         public TokenBuilder SecretMount(Action<TokenBuilder> configureBuilder) =>
             AddToken(new SecretMount(GetTokens(configureBuilder)));
 
         public TokenBuilder ShellFormCommand(string command) =>
-            AddToken(DockerfileModel.ShellFormCommand.Create(command, EscapeChar));
+            AddToken(new ShellFormCommand(command, EscapeChar));
 
         public TokenBuilder ShellFormCommand(Action<TokenBuilder> configureBuilder) =>
             AddToken(new ShellFormCommand(GetTokens(configureBuilder)));
 
         public TokenBuilder StartPeriodFlag(string startPeriod) =>
-            AddToken(DockerfileModel.StartPeriodFlag.Create(startPeriod));
+            AddToken(new StartPeriodFlag(startPeriod));
 
         public TokenBuilder StartPeriodFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new StartPeriodFlag(GetTokens(configureBuilder)));
@@ -144,7 +144,7 @@ namespace DockerfileModel.Tokens
             AddToken(new TagToken(GetTokens(configureBuilder)));
 
         public TokenBuilder TimeoutFlag(string timeout) =>
-            AddToken(DockerfileModel.TimeoutFlag.Create(timeout));
+            AddToken(new TimeoutFlag(timeout));
 
         public TokenBuilder TimeoutFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new TimeoutFlag(GetTokens(configureBuilder)));

--- a/src/DockerfileModel/DockerfileModel/Whitespace.cs
+++ b/src/DockerfileModel/DockerfileModel/Whitespace.cs
@@ -8,7 +8,7 @@ namespace DockerfileModel
 {
     public class Whitespace : DockerfileConstruct
     {
-        private Whitespace(string value)
+        public Whitespace(string value)
             : base(GetTokens(value, GetParser()))
         {
         }
@@ -67,9 +67,6 @@ namespace DockerfileModel
         }
 
         public override ConstructType Type => ConstructType.Whitespace;
-
-        public static Whitespace Create(string value) =>
-            new Whitespace(value);
 
         public static bool IsWhitespace(string value) =>
             GetParser().TryParse(value).WasSuccessful;


### PR DESCRIPTION
`Create` methods were originally used in order to disambiguate from a constructor that was used to parse the full text of the token.  But that pattern has since been removed.  So now the `Create` methods can be refactored as constructors.
