### PR TITLE
LiteralToken constructor can parse value contents

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/ArgInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ArgInstructionTests.cs
@@ -101,6 +101,14 @@ namespace DockerfileModel.Tests
             Assert.False(arg.HasAssignmentOperator);
         }
 
+        [Fact]
+        public void ArgValueWithVariables()
+        {
+            ArgInstruction arg = new ArgInstruction("test", "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => arg.ArgValueToken, token => arg.ArgValueToken = token, val => arg.ArgValue = val, "var", canContainVariables: true);
+        }
+
         public static IEnumerable<object[]> ParseTestInput()
         {
             ArgInstructionParseTestScenario[] testInputs = new ArgInstructionParseTestScenario[]

--- a/src/DockerfileModel/DockerfileModel.Tests/ChangeOwnerTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ChangeOwnerTests.cs
@@ -101,6 +101,22 @@ namespace DockerfileModel.Tests
             Assert.Equal("user", changeOwner.ToString());
         }
 
+        [Fact]
+        public void UserWithVariables()
+        {
+            ChangeOwner changeOwner = new ChangeOwner("$var", "group");
+            TestHelper.TestVariablesWithLiteral(
+                () => changeOwner.UserToken, "var", canContainVariables: true);
+        }
+
+        [Fact]
+        public void GroupWithVariables()
+        {
+            ChangeOwner changeOwner = new ChangeOwner("user", "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => changeOwner.GroupToken, token => changeOwner.GroupToken = token, val => changeOwner.Group = val, "var", canContainVariables: true);
+        }
+
         public static IEnumerable<object[]> ParseTestInput()
         {
             ChangeOwnerParseTestScenario[] testInputs = new ChangeOwnerParseTestScenario[]

--- a/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
@@ -84,6 +84,18 @@ namespace DockerfileModel.Tests
             Validate(result, "VAR3", "bar");
         }
 
+        [Fact]
+        public void EnvVarWithVariables()
+        {
+            EnvInstruction result = new EnvInstruction(
+                new Dictionary<string, string>
+                {
+                    { "VAR1", "$var" }
+                });
+            TestHelper.TestVariablesWithLiteral(
+                () => result.VariableTokens[0].ValueToken, "var", canContainVariables: true);
+        }
+
         public static IEnumerable<object[]> ParseTestInput()
         {
             EnvInstructionParseTestScenario[] testInputs = new EnvInstructionParseTestScenario[]

--- a/src/DockerfileModel/DockerfileModel.Tests/ExecFormCommandTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ExecFormCommandTests.cs
@@ -102,6 +102,16 @@ namespace DockerfileModel.Tests
 
         }
 
+        [Fact]
+        public void CommandArgsWithVariablesNotParsed()
+        {
+            ExecFormCommand result = new ExecFormCommand(new string[]
+            {
+                "$var"
+            });
+            TestHelper.TestVariablesWithLiteral(() => result.CommandArgTokens.First(), "$var", canContainVariables: false);
+        }
+
         public static IEnumerable<object[]> ParseTestInput()
         {
             ExecFormCommandParseTestScenario[] testInputs = new ExecFormCommandParseTestScenario[]

--- a/src/DockerfileModel/DockerfileModel.Tests/ExposeInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ExposeInstructionTests.cs
@@ -40,6 +40,83 @@ namespace DockerfileModel.Tests
             scenario.Validate?.Invoke(result);
         }
 
+        [Fact]
+        public void Port()
+        {
+            ExposeInstruction result = new ExposeInstruction("23", "protocol");
+            Assert.Equal("23", result.Port);
+            Assert.Equal("23", result.PortToken.Value);
+            Assert.Equal("EXPOSE 23/protocol", result.ToString());
+
+            result.Port = "45";
+            Assert.Equal("45", result.Port);
+            Assert.Equal("45", result.PortToken.Value);
+            Assert.Equal("EXPOSE 45/protocol", result.ToString());
+
+            result.PortToken.Value = "67";
+            Assert.Equal("67", result.Port);
+            Assert.Equal("67", result.PortToken.Value);
+            Assert.Equal("EXPOSE 67/protocol", result.ToString());
+
+            result.PortToken = new LiteralToken("78");
+            Assert.Equal("78", result.Port);
+            Assert.Equal("78", result.PortToken.Value);
+            Assert.Equal("EXPOSE 78/protocol", result.ToString());
+
+            Assert.Throws<ArgumentNullException>(() => result.Port = null);
+            Assert.Throws<ArgumentException>(() => result.Port = "");
+            Assert.Throws<ArgumentNullException>(() => result.PortToken = null);
+        }
+
+        [Fact]
+        public void Protocol()
+        {
+            ExposeInstruction result = new ExposeInstruction("23", "test");
+            Assert.Equal("test", result.Protocol);
+            Assert.Equal("test", result.ProtocolToken.Value);
+            Assert.Equal("EXPOSE 23/test", result.ToString());
+
+            result.Protocol = "test2";
+            Assert.Equal("test2", result.Protocol);
+            Assert.Equal("test2", result.ProtocolToken.Value);
+            Assert.Equal("EXPOSE 23/test2", result.ToString());
+
+            result.Protocol = null;
+            Assert.Null(result.Protocol);
+            Assert.Null(result.ProtocolToken);
+            Assert.Equal("EXPOSE 23", result.ToString());
+
+            result.ProtocolToken = new LiteralToken("test3");
+            Assert.Equal("test3", result.Protocol);
+            Assert.Equal("test3", result.ProtocolToken.Value);
+            Assert.Equal("EXPOSE 23/test3", result.ToString());
+
+            result.ProtocolToken.Value = "test4";
+            Assert.Equal("test4", result.Protocol);
+            Assert.Equal("test4", result.ProtocolToken.Value);
+            Assert.Equal("EXPOSE 23/test4", result.ToString());
+
+            result.ProtocolToken = null;
+            Assert.Null(result.Protocol);
+            Assert.Null(result.ProtocolToken);
+            Assert.Equal("EXPOSE 23", result.ToString());
+        }
+
+        [Fact]
+        public void PortWithVariables()
+        {
+            ExposeInstruction result = new ExposeInstruction("$var", "test");
+            TestHelper.TestVariablesWithLiteral(() => result.PortToken, "var", canContainVariables: true);
+        }
+
+        [Fact]
+        public void ProtocolWithVariables()
+        {
+            ExposeInstruction result = new ExposeInstruction("23", "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => result.ProtocolToken, token => result.ProtocolToken = token, val => result.Protocol = val, "var", canContainVariables: true);
+        }
+
         public static IEnumerable<object[]> ParseTestInput()
         {
             ExposeInstructionParseTestScenario[] testInputs = new ExposeInstructionParseTestScenario[]
@@ -118,7 +195,7 @@ namespace DockerfileModel.Tests
             {
                 new CreateTestScenario
                 {
-                    Port = 8080,
+                    Port = "8080",
                     TokenValidators = new Action<Token>[]
                     {
                         token => ValidateKeyword(token, "EXPOSE"),
@@ -128,7 +205,7 @@ namespace DockerfileModel.Tests
                 },
                 new CreateTestScenario
                 {
-                    Port = 80,
+                    Port = "80",
                     Protocol = "udp",
                     TokenValidators = new Action<Token>[]
                     {
@@ -151,7 +228,7 @@ namespace DockerfileModel.Tests
 
         public class CreateTestScenario : TestScenario<ExposeInstruction>
         {
-            public int Port { get; set; }
+            public string Port { get; set; }
             public string Protocol { get; set; }
         }
     }

--- a/src/DockerfileModel/DockerfileModel.Tests/FileTransferInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/FileTransferInstructionTests.cs
@@ -47,6 +47,13 @@ namespace DockerfileModel.Tests
         }
 
         [Fact]
+        public void SourcesWithVariables()
+        {
+            TInstruction instruction = this.create(new string[] { "$var", "src2" }, "dst", null, Dockerfile.DefaultEscapeChar);
+            TestHelper.TestVariablesWithLiteral(() => instruction.SourceTokens[0], "var", canContainVariables: true);
+        }
+
+        [Fact]
         public void Destination()
         {
             TInstruction instruction = this.create(new string[] { "src1", "src2" }, "dst", null, Dockerfile.DefaultEscapeChar);
@@ -68,6 +75,13 @@ namespace DockerfileModel.Tests
             Assert.Throws<ArgumentNullException>(() => instruction.Destination = null);
             Assert.Throws<ArgumentException>(() => instruction.Destination = "");
             Assert.Throws<ArgumentNullException>(() => instruction.DestinationToken = null);
+        }
+
+        [Fact]
+        public void DestinationWithVariables()
+        {
+            TInstruction instruction = this.create(new string[] { "src1", "src2" }, "$var", null, Dockerfile.DefaultEscapeChar);
+            TestHelper.TestVariablesWithLiteral(() => instruction.DestinationToken, "var", canContainVariables: true);
         }
 
         [Fact]

--- a/src/DockerfileModel/DockerfileModel.Tests/FromInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/FromInstructionTests.cs
@@ -65,6 +65,13 @@ namespace DockerfileModel.Tests
         }
 
         [Fact]
+        public void ImageNameWithVariables()
+        {
+            FromInstruction instruction = new FromInstruction("$var");
+            TestHelper.TestVariablesWithLiteral(() => instruction.ImageNameToken, "var", canContainVariables: true);
+        }
+
+        [Fact]
         public void Platform()
         {
             FromInstruction instruction = new FromInstruction("test");
@@ -102,6 +109,14 @@ namespace DockerfileModel.Tests
             instruction = FromInstruction.Parse("FROM `\n`\n --platform=linux/amd64 alpine", '`');
             instruction.PlatformToken = null;
             Assert.Equal("FROM `\n`\n alpine", instruction.ToString());
+        }
+
+        [Fact]
+        public void PlatformWithVariables()
+        {
+            FromInstruction instruction = new FromInstruction("scratch", platform: "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => instruction.PlatformToken, token => instruction.PlatformToken = token, val => instruction.Platform = val, "var", canContainVariables: true);
         }
 
         [Fact]

--- a/src/DockerfileModel/DockerfileModel.Tests/HealthCheckInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/HealthCheckInstructionTests.cs
@@ -89,6 +89,14 @@ namespace DockerfileModel.Tests
         }
 
         [Fact]
+        public void IntervalWithVariables()
+        {
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", interval: "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => instruction.IntervalToken, token => instruction.IntervalToken = token, val => instruction.Interval = val, "var", canContainVariables: true);
+        }
+
+        [Fact]
         public void Timeout()
         {
             HealthCheckInstruction instruction = new HealthCheckInstruction("command", timeout: "10s");
@@ -120,6 +128,14 @@ namespace DockerfileModel.Tests
             Assert.Null(instruction.Timeout);
             Assert.Null(instruction.TimeoutToken);
             Assert.Equal("HEALTHCHECK CMD command", instruction.ToString());
+        }
+
+        [Fact]
+        public void TimeoutWithVariables()
+        {
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", timeout: "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => instruction.TimeoutToken, token => instruction.TimeoutToken = token, val => instruction.Timeout = val, "var", canContainVariables: true);
         }
 
         [Fact]
@@ -157,6 +173,14 @@ namespace DockerfileModel.Tests
         }
 
         [Fact]
+        public void StartPeriodWithVariables()
+        {
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", startPeriod: "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => instruction.StartPeriodToken, token => instruction.StartPeriodToken = token, val => instruction.StartPeriod = val, "var", canContainVariables: true);
+        }
+
+        [Fact]
         public void Retries()
         {
             HealthCheckInstruction instruction = new HealthCheckInstruction("command", retries: "10s");
@@ -188,6 +212,14 @@ namespace DockerfileModel.Tests
             Assert.Null(instruction.Retries);
             Assert.Null(instruction.RetriesToken);
             Assert.Equal("HEALTHCHECK CMD command", instruction.ToString());
+        }
+
+        [Fact]
+        public void RetriesWithVariables()
+        {
+            HealthCheckInstruction instruction = new HealthCheckInstruction("command", retries: "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => instruction.RetriesToken, token => instruction.RetriesToken = token, val => instruction.Retries = val, "var", canContainVariables: true);
         }
 
         [Fact]

--- a/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
@@ -20,7 +20,7 @@ namespace DockerfileModel.Tests
                 KeyValueToken<KeywordToken, LiteralToken> result = KeyValueToken<KeywordToken, LiteralToken>.Parse(
                     scenario.Text,
                     ParseHelper.Keyword(scenario.Key, scenario.EscapeChar),
-                    ParseHelper.LiteralAggregate(scenario.EscapeChar),
+                    ParseHelper.LiteralWithVariables(scenario.EscapeChar),
                     escapeChar: scenario.EscapeChar);
                 Assert.Equal(scenario.Text, result.ToString());
                 Assert.Collection(result.Tokens, scenario.TokenValidators);

--- a/src/DockerfileModel/DockerfileModel.Tests/LiteralTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/LiteralTokenTests.cs
@@ -17,7 +17,7 @@ namespace DockerfileModel.Tests
         {
             if (scenario.ParseExceptionPosition is null)
             {
-                LiteralToken result = LiteralToken.Parse(scenario.Text, scenario.ParseVariableRefs, scenario.EscapeChar);
+                LiteralToken result = new LiteralToken(scenario.Text, scenario.ParseVariableRefs, scenario.EscapeChar);
                 Assert.Equal(scenario.Text, result.ToString());
                 Assert.Collection(result.Tokens, scenario.TokenValidators);
                 scenario.Validate?.Invoke(result);
@@ -29,6 +29,19 @@ namespace DockerfileModel.Tests
                 Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
                 Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
             }
+        }
+
+        [Fact]
+        public void ValueVariable()
+        {
+            LiteralToken token = new LiteralToken("tag", canContainVariables: true);
+            token.Value = "$REPO:tag";
+            token.ResolveVariables(Dockerfile.DefaultEscapeChar, new Dictionary<string, string>
+            {
+                { "REPO", "test" }
+            }, options: new ResolutionOptions { UpdateInline = true});
+
+            Assert.Equal("test:tag", token.Value);
         }
 
         public static IEnumerable<object[]> ParseTestInput()

--- a/src/DockerfileModel/DockerfileModel.Tests/SecretMountTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/SecretMountTests.cs
@@ -65,6 +65,13 @@ namespace DockerfileModel.Tests
         }
 
         [Fact]
+        public void IdWithVariables()
+        {
+            SecretMount secretMount = new SecretMount("$var");
+            TestHelper.TestVariablesWithLiteral(() => secretMount.IdToken.ValueToken, "var", canContainVariables: true);
+        }
+
+        [Fact]
         public void DestinationPath()
         {
             SecretMount secretMount = new SecretMount("foo", "test");
@@ -96,6 +103,14 @@ namespace DockerfileModel.Tests
             Assert.Equal("type=secret,id=foo", secretMount.ToString());
             Assert.Null(secretMount.DestinationPath);
             Assert.Null(secretMount.DestinationPathToken);
+        }
+
+        [Fact]
+        public void DestinationWithVariables()
+        {
+            SecretMount secretMount = new SecretMount("id", "$var");
+            TestHelper.TestVariablesWithLiteral(
+                () => secretMount.DestinationPathToken.ValueToken, "var", canContainVariables: true);
         }
 
         public static IEnumerable<object[]> ParseTestInput()

--- a/src/DockerfileModel/DockerfileModel.Tests/ShellFormCommandTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ShellFormCommandTests.cs
@@ -59,6 +59,13 @@ namespace DockerfileModel.Tests
             Assert.Throws<ArgumentException>(() => result.Value = "");
         }
 
+        [Fact]
+        public void ValueWithVariables()
+        {
+            ShellFormCommand result = new ShellFormCommand("$var");
+            TestHelper.TestVariablesWithLiteral(() => result.ValueToken, "$var", canContainVariables: false);
+        }
+
         public static IEnumerable<object[]> ParseTestInput()
         {
             ShellFormCommandParseTestScenario[] testInputs = new ShellFormCommandParseTestScenario[]

--- a/src/DockerfileModel/DockerfileModel.Tests/TestHelper.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/TestHelper.cs
@@ -1,5 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using DockerfileModel.Tokens;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
 
 namespace DockerfileModel.Tests
 {
@@ -7,5 +12,77 @@ namespace DockerfileModel.Tests
     {
         public static string ConcatLines(IEnumerable<string> lines, string lineEnding = "\n") =>
             string.Join(lineEnding, lines.ToArray());
+
+        public static void TestVariablesWithLiteral(Func<LiteralToken> getLiteral, string initialValue, bool canContainVariables) =>
+            TestVariablesWithLiteral(getLiteral, initialValue, canContainVariables, null, null);
+
+        public static void TestVariablesWithNullableLiteral(Func<LiteralToken> getLiteral, Action<LiteralToken> setLiteral, Action<string> setValue, string initialValue, bool canContainVariables) =>
+            TestVariablesWithLiteral(getLiteral, initialValue, canContainVariables, setLiteral, setValue);
+
+        private static void TestVariablesWithLiteral(Func<LiteralToken> getLiteral, string initialValue, bool canContainVariables, Action<LiteralToken> setLiteral, Action<string> setValue)
+        {
+            if (canContainVariables)
+            {
+                Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                {
+                    token => ValidateAggregate<VariableRefToken>(token, $"${initialValue}",
+                        token => ValidateString(token, initialValue))
+                });
+
+                getLiteral().Value = "foo";
+                Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                {
+                    token => ValidateString(token, "foo")
+                });
+
+                getLiteral().Value = "$var2";
+                Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                {
+                    token => ValidateAggregate<VariableRefToken>(token, "$var2",
+                        token => ValidateString(token, "var2"))
+                });
+
+                if (setLiteral is not null)
+                {
+                    setLiteral(null);
+                    setValue("$var3");
+                    Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                    {
+                        token => ValidateAggregate<VariableRefToken>(token, "$var3",
+                            token => ValidateString(token, "var3"))
+                    });
+
+                    setLiteral(null);
+                    setValue("bar");
+                    Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                    {
+                        token => ValidateString(token, "bar")
+                    });
+                }
+            }
+            else
+            {
+                Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                {
+                    token => ValidateString(token, initialValue)
+                });
+
+                getLiteral().Value = "$var2";
+                Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                {
+                    token => ValidateString(token, "$var2")
+                });
+
+                if (setLiteral is not null)
+                {
+                    setLiteral(null);
+                    setValue("$var3");
+                    Assert.Collection(getLiteral().Tokens, new Action<Token>[]
+                    {
+                        token => ValidateString(token, "$var3")
+                    });
+                }
+            }
+        }
     }
 }

--- a/src/DockerfileModel/DockerfileModel.Tests/VariableRefTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/VariableRefTokenTests.cs
@@ -37,11 +37,11 @@ namespace DockerfileModel.Tests
             VariableRefToken result;
             if (scenario.Modifier is null)
             {
-                result = VariableRefToken.Create(scenario.VariableName);
+                result = new VariableRefToken(scenario.VariableName);
             }
             else
             {
-                result = VariableRefToken.Create(scenario.VariableName, scenario.Modifier, scenario.ModifierValue);
+                result = new VariableRefToken(scenario.VariableName, scenario.Modifier, scenario.ModifierValue);
             }
 
             Assert.Collection(result.Tokens, scenario.TokenValidators);
@@ -51,7 +51,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void VariableName()
         {
-            VariableRefToken token = VariableRefToken.Create("foo");
+            VariableRefToken token = new VariableRefToken("foo");
             Assert.Equal("foo", token.VariableName);
             Assert.Equal("foo", token.VariableNameToken.Value);
 
@@ -75,7 +75,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Modifier()
         {
-            VariableRefToken token = VariableRefToken.Create("foo", "-", "bar");
+            VariableRefToken token = new VariableRefToken("foo", "-", "bar");
             Assert.Equal("-", token.Modifier);
             Assert.Collection(token.ModifierTokens, new Action<SymbolToken>[]
             {
@@ -99,7 +99,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void ModifierValue()
         {
-            VariableRefToken token = VariableRefToken.Create("foo", "-", "bar");
+            VariableRefToken token = new VariableRefToken("foo", "-", "bar");
             Assert.Equal("bar", token.ModifierValue);
             Assert.Equal("bar", token.ModifierValueToken.Value);
             Assert.NotEmpty(token.ModifierTokens);
@@ -137,6 +137,14 @@ namespace DockerfileModel.Tests
             Assert.Null(token.ModifierValueToken);
             Assert.Empty(token.ModifierTokens);
             Assert.Equal("${foo}", token.ToString());
+        }
+
+        [Fact]
+        public void ModifierValueWithVariables()
+        {
+            VariableRefToken token = new VariableRefToken("foo", "-", "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => token.ModifierValueToken, t => token.ModifierValueToken = t, val => token.ModifierValue = val, "var", canContainVariables: true);
         }
 
         public static IEnumerable<object[]> ParseTestInput()

--- a/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
@@ -88,7 +88,7 @@ namespace DockerfileModel
         public DockerfileBuilder EnvInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.EnvInstruction.Parse);
 
-        public DockerfileBuilder ExposeInstruction(int port, string? protocol = null) =>
+        public DockerfileBuilder ExposeInstruction(string port, string? protocol = null) =>
             AddConstruct(new ExposeInstruction(port, protocol, EscapeChar));
 
         public DockerfileBuilder ExposeInstruction(Action<TokenBuilder> configureBuilder) =>
@@ -115,7 +115,7 @@ namespace DockerfileModel
             AddConstruct(new HealthCheckInstruction(commands, interval, timeout, startPeriod, retries, EscapeChar));
 
         public DockerfileBuilder HealthCheckDisabledInstruction() =>
-            AddConstruct(new HealthCheckInstruction());
+            AddConstruct(new HealthCheckInstruction(EscapeChar));
 
         public DockerfileBuilder HealthCheckInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.HealthCheckInstruction.Parse);

--- a/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
@@ -79,13 +79,13 @@ namespace DockerfileModel
             ).AtLeastOnce().Flatten();
 
         private static Parser<LiteralToken> MultiVariableFormatValueParser(char escapeChar) =>
-            from literal in LiteralAggregate(escapeChar, whitespaceMode: WhitespaceMode.AllowedInQuotes).Optional()
-            select literal.GetOrElse(new LiteralToken(""));
+            from literal in LiteralWithVariables(escapeChar, whitespaceMode: WhitespaceMode.AllowedInQuotes).Optional()
+            select literal.GetOrElse(new LiteralToken("", canContainVariables: true, escapeChar));
 
         private static Parser<IEnumerable<Token>> SingleVariableFormat(char escapeChar) =>
             KeyValueToken<IdentifierToken, LiteralToken>.GetParser(
                 IdentifierToken(VariableRefFirstLetterParser, VariableRefTailParser, escapeChar: escapeChar),
-                LiteralAggregate(escapeChar),
+                LiteralWithVariables(escapeChar),
                 separator: ' ',
                 escapeChar: escapeChar).AsEnumerable();
     }

--- a/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
@@ -143,7 +143,7 @@ namespace DockerfileModel
             from whitespace in Whitespace()
             from files in JsonArray(escapeChar, canContainVariables: true).Or(
                 from literals in ArgTokens(
-                    LiteralAggregate(escapeChar).AsEnumerable(),
+                    LiteralWithVariables(escapeChar).AsEnumerable(),
                     escapeChar).Many()
                 select literals.Flatten())
             select ConcatTokens(changeOwner.GetOrDefault(), whitespace, files);

--- a/src/DockerfileModel/DockerfileModel/GenericInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/GenericInstruction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using DockerfileModel.Tokens;
 using Sprache;
@@ -48,5 +49,51 @@ namespace DockerfileModel
             from lineContinuation in LineContinuations(escapeChar).Optional()
             from instructionArgs in InstructionArgs(escapeChar)
             select ConcatTokens(leading, instruction, lineContinuation.GetOrDefault(), instructionArgs);
+
+        protected static Parser<IEnumerable<Token>> InstructionArgs(char escapeChar) =>
+            from lineSets in (CommentText().Or(InstructionArgLine(escapeChar))).Many()
+            select lineSets.SelectMany(lineSet => lineSet);
+
+        private static Parser<IEnumerable<Token>> InstructionArgLine(char escapeChar) =>
+            from text in Sprache.Parse.AnyChar.Except(LineContinuationToken.GetParser(escapeChar)).Except(Sprache.Parse.LineEnd).Many().Text()
+            from lineContinuation in LineContinuations(escapeChar).Optional()
+            from lineEnd in OptionalNewLine().AsEnumerable()
+            select ConcatTokens(
+                GetInstructionArgLineContent(text, escapeChar),
+                lineContinuation.GetOrDefault(),
+                lineEnd);
+
+        private static IEnumerable<Token?> GetInstructionArgLineContent(string text, char escapeChar)
+        {
+            if (text.Length == 0)
+            {
+                yield break;
+            }
+
+            if (text.Trim().Length == 0)
+            {
+                yield return new WhitespaceToken(text);
+                yield break;
+            }
+
+            yield return GetLeadingWhitespaceToken(text);
+            yield return new LiteralToken(text.Trim(), canContainVariables: false, escapeChar);
+            yield return GetTrailingWhitespaceToken(text);
+        }
+
+        private static WhitespaceToken? GetLeadingWhitespaceToken(string text)
+        {
+            string? whitespace = new string(
+                text
+                    .TakeWhile(ch => Char.IsWhiteSpace(ch))
+                    .ToArray());
+
+            if (whitespace == String.Empty)
+            {
+                return null;
+            }
+
+            return new WhitespaceToken(whitespace);
+        }
     }
 }

--- a/src/DockerfileModel/DockerfileModel/HealthCheckInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/HealthCheckInstruction.cs
@@ -10,37 +10,40 @@ namespace DockerfileModel
 {
     public class HealthCheckInstruction : Instruction
     {
+        private readonly char escapeChar;
+
         public HealthCheckInstruction(string command, string? interval = null, string? timeout = null,
             string? startPeriod = null, string? retries = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : this(GetTokens(command, interval, timeout, startPeriod, retries, escapeChar))
+            : this(GetTokens(command, interval, timeout, startPeriod, retries, escapeChar), escapeChar)
         {
         }
 
         public HealthCheckInstruction(IEnumerable<string> commands, string? interval = null, string? timeout = null,
             string? startPeriod = null, string? retries = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : this(GetTokens(commands, interval, timeout, startPeriod, retries, escapeChar))
+            : this(GetTokens(commands, interval, timeout, startPeriod, retries, escapeChar), escapeChar)
         {
         }
 
-        public HealthCheckInstruction()
+        public HealthCheckInstruction(char escapeChar = Dockerfile.DefaultEscapeChar)
             : this(
                 new Token[]
                 {
                     new KeywordToken("HEALTHCHECK"),
                     new WhitespaceToken(" "),
                     new KeywordToken("NONE")
-                })
+                }, escapeChar)
         {
         }
 
-        private HealthCheckInstruction(IEnumerable<Token> tokens) : base(tokens)
+        private HealthCheckInstruction(IEnumerable<Token> tokens, char escapeChar) : base(tokens)
         {
+            this.escapeChar = escapeChar;
         }
 
         public string? Interval
         {
             get => IntervalToken?.Value;
-            set => SetOptionalLiteralTokenValue(IntervalToken, value, token => IntervalToken = token);
+            set => SetOptionalLiteralTokenValue(IntervalToken, value, token => IntervalToken = token, canContainVariables: true, escapeChar);
         }
 
         public LiteralToken? IntervalToken
@@ -59,7 +62,7 @@ namespace DockerfileModel
         public string? Timeout
         {
             get => TimeoutToken?.Value;
-            set => SetOptionalLiteralTokenValue(TimeoutToken, value, token => TimeoutToken = token);
+            set => SetOptionalLiteralTokenValue(TimeoutToken, value, token => TimeoutToken = token, canContainVariables: true, escapeChar);
         }
 
         public LiteralToken? TimeoutToken
@@ -78,7 +81,7 @@ namespace DockerfileModel
         public string? StartPeriod
         {
             get => StartPeriodToken?.Value;
-            set => SetOptionalLiteralTokenValue(StartPeriodToken, value, token => StartPeriodToken = token);
+            set => SetOptionalLiteralTokenValue(StartPeriodToken, value, token => StartPeriodToken = token, canContainVariables: true, escapeChar);
         }
 
         public LiteralToken? StartPeriodToken
@@ -97,7 +100,7 @@ namespace DockerfileModel
         public string? Retries
         {
             get => RetriesToken?.Value;
-            set => SetOptionalLiteralTokenValue(RetriesToken, value, token => RetriesToken = token);
+            set => SetOptionalLiteralTokenValue(RetriesToken, value, token => RetriesToken = token, canContainVariables: true, escapeChar);
         }
 
         public LiteralToken? RetriesToken
@@ -143,11 +146,11 @@ namespace DockerfileModel
         }
 
         public static HealthCheckInstruction Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            new HealthCheckInstruction(GetTokens(text, GetInnerParser(escapeChar)));
+            new HealthCheckInstruction(GetTokens(text, GetInnerParser(escapeChar)), escapeChar);
 
         public static Parser<HealthCheckInstruction> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
             from tokens in GetInnerParser(escapeChar)
-            select new HealthCheckInstruction(tokens);
+            select new HealthCheckInstruction(tokens, escapeChar);
 
         private static IEnumerable<Token> GetTokens(string command, string? interval, string? timeout,
             string? startPeriod, string? retries, char escapeChar)

--- a/src/DockerfileModel/DockerfileModel/Instruction.cs
+++ b/src/DockerfileModel/DockerfileModel/Instruction.cs
@@ -28,51 +28,5 @@ namespace DockerfileModel
         public IEnumerable<CommentToken> CommentTokens => GetCommentTokens();
 
         public override ConstructType Type => ConstructType.Instruction;
-
-        protected static Parser<IEnumerable<Token>> InstructionArgs(char escapeChar) =>
-            from lineSets in (CommentText().Or(InstructionArgLine(escapeChar))).Many()
-            select lineSets.SelectMany(lineSet => lineSet);
-
-        private static Parser<IEnumerable<Token>> InstructionArgLine(char escapeChar) =>
-            from text in Parse.AnyChar.Except(LineContinuationToken.GetParser(escapeChar)).Except(Parse.LineEnd).Many().Text()
-            from lineContinuation in LineContinuations(escapeChar).Optional()
-            from lineEnd in OptionalNewLine().AsEnumerable()
-            select ConcatTokens(
-                GetInstructionArgLineContent(text),
-                lineContinuation.GetOrDefault(),
-                lineEnd);
-
-        private static IEnumerable<Token?> GetInstructionArgLineContent(string text)
-        {
-            if (text.Length == 0)
-            {
-                yield break;
-            }
-
-            if (text.Trim().Length == 0)
-            {
-                yield return new WhitespaceToken(text);
-                yield break;
-            }
-
-            yield return GetLeadingWhitespaceToken(text);
-            yield return new LiteralToken(text.Trim());
-            yield return GetTrailingWhitespaceToken(text);
-        }
-
-        private static WhitespaceToken? GetLeadingWhitespaceToken(string text)
-        {
-            string? whitespace = new string(
-                text
-                    .TakeWhile(ch => Char.IsWhiteSpace(ch))
-                    .ToArray());
-
-            if (whitespace == String.Empty)
-            {
-                return null;
-            }
-
-            return new WhitespaceToken(whitespace);
-        }
     }
 }

--- a/src/DockerfileModel/DockerfileModel/IntervalFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/IntervalFlag.cs
@@ -7,8 +7,8 @@ namespace DockerfileModel
 {
     public class IntervalFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        public IntervalFlag(string interval)
-            : base(new KeywordToken("interval"), new LiteralToken(interval), isFlag: true)
+        public IntervalFlag(string interval, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(new KeywordToken("interval"), new LiteralToken(interval, canContainVariables: true, escapeChar), isFlag: true)
         {
         }
 
@@ -18,9 +18,9 @@ namespace DockerfileModel
 
         public static IntervalFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("interval", escapeChar), LiteralAggregate(escapeChar), tokens => new IntervalFlag(tokens), escapeChar: escapeChar);
+            Parse(text, Keyword("interval", escapeChar), LiteralWithVariables(escapeChar), tokens => new IntervalFlag(tokens), escapeChar: escapeChar);
 
         public static Parser<IntervalFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("interval", escapeChar), LiteralAggregate(escapeChar), tokens => new IntervalFlag(tokens), escapeChar: escapeChar);
+            GetParser(Keyword("interval", escapeChar), LiteralWithVariables(escapeChar), tokens => new IntervalFlag(tokens), escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/ParserDirective.cs
+++ b/src/DockerfileModel/DockerfileModel/ParserDirective.cs
@@ -83,6 +83,6 @@ namespace DockerfileModel
 
         private static Parser<LiteralToken> DirectiveValueParser() =>
             from val in NonWhitespace().Many().Text()
-            select new LiteralToken(val);
+            select new LiteralToken(new Token[] { new StringToken(val) }, canContainVariables: false, val[0]);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
@@ -7,8 +7,8 @@ namespace DockerfileModel
 {
     public class PlatformFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        public PlatformFlag(string platform)
-            : base(new KeywordToken("platform"), new LiteralToken(platform), isFlag: true)
+        public PlatformFlag(string platform, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(new KeywordToken("platform"), new LiteralToken(platform, canContainVariables: true, escapeChar), isFlag: true)
         {
         }
 
@@ -18,9 +18,9 @@ namespace DockerfileModel
         }
 
         public static PlatformFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("platform", escapeChar), LiteralAggregate(escapeChar), tokens => new PlatformFlag(tokens), escapeChar: escapeChar);
+            Parse(text, Keyword("platform", escapeChar), LiteralWithVariables(escapeChar), tokens => new PlatformFlag(tokens), escapeChar: escapeChar);
 
         public static Parser<PlatformFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("platform", escapeChar), LiteralAggregate(escapeChar), tokens => new PlatformFlag(tokens), escapeChar: escapeChar);
+            GetParser(Keyword("platform", escapeChar), LiteralWithVariables(escapeChar), tokens => new PlatformFlag(tokens), escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/RetriesFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/RetriesFlag.cs
@@ -7,8 +7,8 @@ namespace DockerfileModel
 {
     public class RetriesFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        public RetriesFlag(string retryCount)
-            : base(new KeywordToken("retries"), new LiteralToken(retryCount), isFlag: true)
+        public RetriesFlag(string retryCount, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(new KeywordToken("retries"), new LiteralToken(retryCount, canContainVariables: true, escapeChar), isFlag: true)
         {
         }
 
@@ -18,9 +18,9 @@ namespace DockerfileModel
 
         public static RetriesFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("retries", escapeChar), LiteralAggregate(escapeChar), tokens => new RetriesFlag(tokens), escapeChar: escapeChar);
+            Parse(text, Keyword("retries", escapeChar), LiteralWithVariables(escapeChar), tokens => new RetriesFlag(tokens), escapeChar: escapeChar);
 
         public static Parser<RetriesFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("retries", escapeChar), LiteralAggregate(escapeChar), tokens => new RetriesFlag(tokens), escapeChar: escapeChar);
+            GetParser(Keyword("retries", escapeChar), LiteralWithVariables(escapeChar), tokens => new RetriesFlag(tokens), escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/StartPeriodFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/StartPeriodFlag.cs
@@ -7,8 +7,8 @@ namespace DockerfileModel
 {
     public class StartPeriodFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        public StartPeriodFlag(string startPeriod)
-            : base(new KeywordToken("start-period"), new LiteralToken(startPeriod), isFlag: true)
+        public StartPeriodFlag(string startPeriod, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(new KeywordToken("start-period"), new LiteralToken(startPeriod, canContainVariables: true, escapeChar), isFlag: true)
         {
         }
 
@@ -18,9 +18,9 @@ namespace DockerfileModel
 
         public static StartPeriodFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("start-period", escapeChar), LiteralAggregate(escapeChar), tokens => new StartPeriodFlag(tokens), escapeChar: escapeChar);
+            Parse(text, Keyword("start-period", escapeChar), LiteralWithVariables(escapeChar), tokens => new StartPeriodFlag(tokens), escapeChar: escapeChar);
 
         public static Parser<StartPeriodFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("start-period", escapeChar), LiteralAggregate(escapeChar), tokens => new StartPeriodFlag(tokens), escapeChar: escapeChar);
+            GetParser(Keyword("start-period", escapeChar), LiteralWithVariables(escapeChar), tokens => new StartPeriodFlag(tokens), escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/TimeoutFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/TimeoutFlag.cs
@@ -7,8 +7,8 @@ namespace DockerfileModel
 {
     public class TimeoutFlag : KeyValueToken<KeywordToken, LiteralToken>
     {
-        public TimeoutFlag(string timeout)
-            : base(new KeywordToken("timeout"), new LiteralToken(timeout), isFlag: true)
+        public TimeoutFlag(string timeout, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(new KeywordToken("timeout"), new LiteralToken(timeout, canContainVariables: true, escapeChar), isFlag: true)
         {
         }
 
@@ -18,9 +18,9 @@ namespace DockerfileModel
 
         public static TimeoutFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("timeout", escapeChar), LiteralAggregate(escapeChar), tokens => new TimeoutFlag(tokens), escapeChar: escapeChar);
+            Parse(text, Keyword("timeout", escapeChar), LiteralWithVariables(escapeChar), tokens => new TimeoutFlag(tokens), escapeChar: escapeChar);
 
         public static Parser<TimeoutFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("timeout", escapeChar), LiteralAggregate(escapeChar), tokens => new TimeoutFlag(tokens), escapeChar: escapeChar);
+            GetParser(Keyword("timeout", escapeChar), LiteralWithVariables(escapeChar), tokens => new TimeoutFlag(tokens), escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/Tokens/AggregateToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/AggregateToken.cs
@@ -123,20 +123,13 @@ namespace DockerfileModel.Tokens
         }
 
         protected static void SetOptionalLiteralTokenValue(LiteralToken? currentToken, string? value,
-            Action<LiteralToken?> setToken) =>
-            SetOptionalTokenValue(currentToken, value, val => new LiteralToken(val), setToken);
+            Action<LiteralToken?> setToken, bool canContainVariables, char escapeChar) =>
+            SetOptionalTokenValue(currentToken, value, val => new LiteralToken(val, canContainVariables, escapeChar), setToken);
 
         protected static void SetOptionalKeyValueTokenValue<TKeyValueToken>(TKeyValueToken? currentToken, LiteralToken? value,
             Func<string, TKeyValueToken> createToken, Action<TKeyValueToken?> setToken)
             where TKeyValueToken : KeyValueToken<KeywordToken, LiteralToken> =>
             SetOptionalTokenValue(currentToken, value, token => createToken(token.Value), (token, val) => token.ValueToken = val, setToken);
-
-        protected static void SetOptionalKeyValueTokenValue<TKey, TValue, TKeyValueToken>(TKeyValueToken? currentToken, TValue? value,
-            Func<TValue, TKeyValueToken> createToken, Action<TKeyValueToken?> setToken)
-            where TKeyValueToken : KeyValueToken<TKey, TValue>
-            where TKey : Token, IValueToken
-            where TValue : Token =>
-            SetOptionalTokenValue(currentToken, value, createToken, (token, val) => token.ValueToken = val, setToken);
 
         protected static void SetOptionalTokenValue<TToken>(TToken? currentToken, string? value, Func<string, TToken> createToken,
             Action<TToken?> setToken)
@@ -163,6 +156,12 @@ namespace DockerfileModel.Tokens
         {
             TokenList.Clear();
             TokenList.Add(token);
+        }
+
+        internal void ReplaceWithTokens(IEnumerable<Token> tokens)
+        {
+            TokenList.Clear();
+            TokenList.AddRange(tokens);
         }
 
         private string? ResolveVariablesCore(char escapeChar, IDictionary<string, string?> variables, ResolutionOptions options)

--- a/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
@@ -46,7 +46,7 @@ namespace DockerfileModel.Tokens
             AddToken(new ImageName(GetTokens(configureBuilder)));
 
         public TokenBuilder IntervalFlag(string interval) =>
-            AddToken(new IntervalFlag(interval));
+            AddToken(new IntervalFlag(interval, EscapeChar));
 
         public TokenBuilder IntervalFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new IntervalFlag(GetTokens(configureBuilder)));
@@ -74,11 +74,11 @@ namespace DockerfileModel.Tokens
         public TokenBuilder LineContinuation(Action<TokenBuilder> configureBuilder) =>
             AddToken(new LineContinuationToken(GetTokens(configureBuilder)));
 
-        public TokenBuilder Literal(string value) =>
-            AddToken(new LiteralToken(value));
+        public TokenBuilder Literal(string value, bool canContainVariables = false) =>
+            AddToken(new LiteralToken(value, canContainVariables, EscapeChar));
 
-        public TokenBuilder Literal(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new LiteralToken(GetTokens(configureBuilder)));
+        public TokenBuilder Literal(Action<TokenBuilder> configureBuilder, bool canContainVariables = false) =>
+            AddToken(new LiteralToken(GetTokens(configureBuilder), canContainVariables, EscapeChar));
 
         public TokenBuilder MountFlag(Mount mount) =>
             AddToken(new MountFlag(mount));
@@ -87,7 +87,7 @@ namespace DockerfileModel.Tokens
             AddToken(new MountFlag(GetTokens(configureBuilder)));
 
         public TokenBuilder PlatformFlag(string platform) =>
-            AddToken(new PlatformFlag(platform));
+            AddToken(new PlatformFlag(platform, EscapeChar));
 
         public TokenBuilder PlatformFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new PlatformFlag(GetTokens(configureBuilder)));
@@ -105,7 +105,7 @@ namespace DockerfileModel.Tokens
             AddToken(new RepositoryToken(GetTokens(configureBuilder)));
 
         public TokenBuilder RetriesFlag(string retries) =>
-            AddToken(new RetriesFlag(retries));
+            AddToken(new RetriesFlag(retries, EscapeChar));
 
         public TokenBuilder RetriesFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new RetriesFlag(GetTokens(configureBuilder)));
@@ -117,7 +117,7 @@ namespace DockerfileModel.Tokens
             AddToken(new SecretMount(id, destinationPath, EscapeChar));
 
         public TokenBuilder SecretMount(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new SecretMount(GetTokens(configureBuilder)));
+            AddToken(new SecretMount(GetTokens(configureBuilder), EscapeChar));
 
         public TokenBuilder ShellFormCommand(string command) =>
             AddToken(new ShellFormCommand(command, EscapeChar));
@@ -126,7 +126,7 @@ namespace DockerfileModel.Tokens
             AddToken(new ShellFormCommand(GetTokens(configureBuilder)));
 
         public TokenBuilder StartPeriodFlag(string startPeriod) =>
-            AddToken(new StartPeriodFlag(startPeriod));
+            AddToken(new StartPeriodFlag(startPeriod, EscapeChar));
 
         public TokenBuilder StartPeriodFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new StartPeriodFlag(GetTokens(configureBuilder)));
@@ -144,19 +144,19 @@ namespace DockerfileModel.Tokens
             AddToken(new TagToken(GetTokens(configureBuilder)));
 
         public TokenBuilder TimeoutFlag(string timeout) =>
-            AddToken(new TimeoutFlag(timeout));
+            AddToken(new TimeoutFlag(timeout, EscapeChar));
 
         public TokenBuilder TimeoutFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new TimeoutFlag(GetTokens(configureBuilder)));
 
         public TokenBuilder VariableRef(string variableName, bool includeBraces = false) =>
-            AddToken(VariableRefToken.Create(variableName, includeBraces, EscapeChar));
+            AddToken(new VariableRefToken(variableName, includeBraces, EscapeChar));
 
         public TokenBuilder VariableRef(string variableName, string modifier, string modifierValue) =>
-            AddToken(VariableRefToken.Create(variableName, modifier, modifierValue, EscapeChar));
+            AddToken(new VariableRefToken(variableName, modifier, modifierValue, EscapeChar));
 
         public TokenBuilder VariableRef(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new VariableRefToken(GetTokens(configureBuilder)));
+            AddToken(new VariableRefToken(GetTokens(configureBuilder), EscapeChar));
 
         public TokenBuilder Whitespace(string value) =>
             AddToken(new WhitespaceToken(value));


### PR DESCRIPTION
Updates the `LiteralToken` class so that it is now capable of parsing the contents of the text value.  This correctly tokenizes any line continuations or variable references.