### PR TITLE
Fix ENV inst parsing with newline

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
@@ -154,6 +154,20 @@ namespace DockerfileModel.Tests
                 },
                 new EnvInstructionParseTestScenario
                 {
+                    Text = "ENV MY_NAME John\r\n",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateKeyword(token, "ENV"),
+                        token => ValidateWhitespace(token, " "),
+                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME John",
+                            token => ValidateIdentifier(token, "MY_NAME"),
+                            token => ValidateWhitespace(token, " "),
+                            token => ValidateLiteral(token, "John")),
+                        token => ValidateNewLine(token, "\r\n")
+                    }
+                },
+                new EnvInstructionParseTestScenario
+                {
                     Text = "ENV MY_NAME=John",
                     TokenValidators = new Action<Token>[]
                     {

--- a/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
@@ -83,10 +83,11 @@ namespace DockerfileModel
             select literal.GetOrElse(new LiteralToken("", canContainVariables: true, escapeChar));
 
         private static Parser<IEnumerable<Token>> SingleVariableFormat(char escapeChar) =>
-            KeyValueToken<IdentifierToken, LiteralToken>.GetParser(
-                IdentifierToken(VariableRefFirstLetterParser, VariableRefTailParser, escapeChar: escapeChar),
-                LiteralWithVariables(escapeChar),
-                separator: ' ',
-                escapeChar: escapeChar).AsEnumerable();
+            ArgTokens(
+                KeyValueToken<IdentifierToken, LiteralToken>.GetParser(
+                    IdentifierToken(VariableRefFirstLetterParser, VariableRefTailParser, escapeChar: escapeChar),
+                    LiteralWithVariables(escapeChar),
+                    separator: ' ',
+                    escapeChar: escapeChar).AsEnumerable(), escapeChar);
     }
 }


### PR DESCRIPTION
Fixes an issue with `EnvInstruction` where it dropped newline characters from the end of the line if it used the `ENV VAR VALUE` syntax.