### PR TITLE
Redesign identifier token

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/ArgInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ArgInstructionTests.cs
@@ -120,7 +120,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MYARG")
+                        token => ValidateIdentifier<Variable>(token, "MYARG")
                     },
                     Validate = result =>
                     {
@@ -137,7 +137,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MYARG"),
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
                         token => ValidateNewLine(token, "\r\n")
                     },
                     Validate = result =>
@@ -159,7 +159,7 @@ namespace DockerfileModel.Tests
                         token => ValidateAggregate<LineContinuationToken>(token, "`\n",
                             token => ValidateSymbol(token, '`'),
                             token => ValidateNewLine(token, "\n")),
-                        token => ValidateIdentifier(token, "MYARG")
+                        token => ValidateIdentifier<Variable>(token, "MYARG")
                     },
                     Validate = result =>
                     {
@@ -176,7 +176,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MYARG"),
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
                         token => ValidateSymbol(token, '=')
                     },
                     Validate = result =>
@@ -194,7 +194,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MYARG"),
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "", '\"')
                     },
@@ -223,7 +223,7 @@ namespace DockerfileModel.Tests
                             token => ValidateString(token, "my comment"),
                             token => ValidateNewLine(token, "\n")),
                         token => ValidateWhitespace(token, "  "),
-                        token => ValidateIdentifier(token, "MYARG"),
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
                         token => ValidateSymbol(token, '=')
                     },
                     Validate = result =>
@@ -242,7 +242,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "myarg"),
+                        token => ValidateIdentifier<Variable>(token, "myarg"),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "1")
                     },
@@ -262,7 +262,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "myarg"),
+                        token => ValidateIdentifier<Variable>(token, "myarg"),
                         token => ValidateLineContinuation(token, '`', "\n"),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLineContinuation(token, '`', "\n"),
@@ -287,7 +287,7 @@ namespace DockerfileModel.Tests
                         token => ValidateAggregate<LineContinuationToken>(token, "`\n",
                             token => ValidateSymbol(token, '`'),
                             token => ValidateNewLine(token, "\n")),
-                        token => ValidateIdentifier(token, "MYARG"),
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "test", '\"')
                     },
@@ -307,7 +307,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MY_ARG"),
+                        token => ValidateIdentifier<Variable>(token, "MY_ARG"),
                     },
                     Validate = result =>
                     {
@@ -325,7 +325,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MY_ARG", '\"'),
+                        token => ValidateIdentifier<Variable>(token, "MY_ARG", '\"'),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "value", '\''),
                     },
@@ -345,7 +345,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MY`\"_ARG", '\"'),
+                        token => ValidateIdentifier<Variable>(token, "MY`\"_ARG", '\"'),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "va`'lue", '\''),
                     },
@@ -365,7 +365,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MY_ARG"),
+                        token => ValidateIdentifier<Variable>(token, "MY_ARG"),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "va`'lue"),
                     },
@@ -384,7 +384,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "MY_ARG"),
+                        token => ValidateIdentifier<Variable>(token, "MY_ARG"),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "", '\'')
                     },
@@ -427,7 +427,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "TEST1")
+                        token => ValidateIdentifier<Variable>(token, "TEST1")
                     },
                     Validate = result =>
                     {
@@ -459,7 +459,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "TEST1"),
+                        token => ValidateIdentifier<Variable>(token, "TEST1"),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, "b")
                     }
@@ -472,7 +472,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ARG"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "TEST1"),
+                        token => ValidateIdentifier<Variable>(token, "TEST1"),
                         token => ValidateSymbol(token, '=')
                     }
                 }

--- a/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
@@ -152,7 +152,7 @@ namespace DockerfileModel.Tests
                 token => ValidateSymbol(token, '-'),
                 token => ValidateKeyword(token, key),
                 token => ValidateSymbol(token, '='),
-                token => ValidateIdentifier(token, value));
+                token => ValidateIdentifier<StageName>(token, value));
         }
 
         public class CopyInstructionParseTestScenario : ParseTestScenario<CopyInstruction>

--- a/src/DockerfileModel/DockerfileModel.Tests/DockerfileTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/DockerfileTests.cs
@@ -664,8 +664,8 @@ namespace DockerfileModel.Tests
                                     token => ValidateWhitespace(token, "\t "),
                                     token => ValidateNewLine(token, "\n")),
                                 token => ValidateWhitespace(token, " "),
-                                token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "VAR=VAL",
-                                    token => ValidateIdentifier(token, "VAR"),
+                                token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "VAR=VAL",
+                                    token => ValidateIdentifier<Variable>(token, "VAR"),
                                     token => ValidateSymbol(token, '='),
                                     token => ValidateLiteral(token, "VAL"))
                             })

--- a/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/EnvInstructionTests.cs
@@ -55,10 +55,10 @@ namespace DockerfileModel.Tests
                 }
             });
 
-                Assert.Collection(instruction.VariableTokens, new Action<KeyValueToken<IdentifierToken, LiteralToken>>[]
+                Assert.Collection(instruction.VariableTokens, new Action<KeyValueToken<Variable, LiteralToken>>[]
                 {
-                    token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, $"{expectedKey}={expectedValue}",
-                        token => ValidateIdentifier(token, expectedKey),
+                    token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, $"{expectedKey}={expectedValue}",
+                        token => ValidateIdentifier<Variable>(token, expectedKey),
                         token => ValidateSymbol(token, '='),
                         token => ValidateLiteral(token, expectedValue))
                 });
@@ -107,8 +107,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME=",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME=",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, ""))
                     },
@@ -133,8 +133,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME=\"\"",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME=\"\"",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "", '\"'))
                     },
@@ -159,8 +159,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME John",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME John",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateLiteral(token, "John")),
                         token => ValidateNewLine(token, "\r\n")
@@ -173,8 +173,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME=John",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME=John",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "John"))
                     },
@@ -199,8 +199,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME=\"John Doe\"",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME=\"John Doe\"",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "John Doe", '\"'))
                     },
@@ -226,8 +226,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME=John` Doe",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME=John` Doe",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "John` Doe"))
                     },
@@ -253,13 +253,13 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME=\"John Doe\"",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME=\"John Doe\"",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "John Doe", '\"')),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_DOG=Rex` The` Dog",
-                            token => ValidateIdentifier(token, "MY_DOG"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_DOG=Rex` The` Dog",
+                            token => ValidateIdentifier<Variable>(token, "MY_DOG"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "Rex` The` Dog")),
                         token => ValidateWhitespace(token, " "),
@@ -268,8 +268,8 @@ namespace DockerfileModel.Tests
                             token => ValidateWhitespace(token, " "),
                             token => ValidateNewLine(token, "\n")),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_CAT=fluffy",
-                            token => ValidateIdentifier(token, "MY_CAT"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_CAT=fluffy",
+                            token => ValidateIdentifier<Variable>(token, "MY_CAT"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "fluffy"))
                     },
@@ -304,8 +304,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_NAME John",
-                            token => ValidateIdentifier(token, "MY_NAME"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_NAME John",
+                            token => ValidateIdentifier<Variable>(token, "MY_NAME"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateLiteral(token, "John"))
                     },
@@ -331,8 +331,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "MY_`\nNAME `\nJo`\nhn",
-                            token => ValidateAggregate<IdentifierToken>(token, "MY_`\nNAME",
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_`\nNAME `\nJo`\nhn",
+                            token => ValidateAggregate<Variable>(token, "MY_`\nNAME",
                                 token => ValidateString(token, "MY_"),
                                 token => ValidateLineContinuation(token, '`', "\n"),
                                 token => ValidateString(token, "NAME")),
@@ -376,8 +376,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "VAR1=test",
-                            token => ValidateIdentifier(token, "VAR1"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "VAR1=test",
+                            token => ValidateIdentifier<Variable>(token, "VAR1"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "test"))
                     }
@@ -392,8 +392,8 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "VAR1=test\\ 123",
-                            token => ValidateIdentifier(token, "VAR1"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "VAR1=test\\ 123",
+                            token => ValidateIdentifier<Variable>(token, "VAR1"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "test\\ 123"))
                     }
@@ -409,13 +409,13 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "ENV"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "VAR1=test",
-                            token => ValidateIdentifier(token, "VAR1"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "VAR1=test",
+                            token => ValidateIdentifier<Variable>(token, "VAR1"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "test")),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<KeyValueToken<IdentifierToken, LiteralToken>>(token, "VAR2=\"testing 1 2 3\"",
-                            token => ValidateIdentifier(token, "VAR2"),
+                        token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "VAR2=\"testing 1 2 3\"",
+                            token => ValidateIdentifier<Variable>(token, "VAR2"),
                             token => ValidateSymbol(token, '='),
                             token => ValidateLiteral(token, "testing 1 2 3", '\"'))
                     }

--- a/src/DockerfileModel/DockerfileModel.Tests/FromInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/FromInstructionTests.cs
@@ -142,7 +142,7 @@ namespace DockerfileModel.Tests
             Assert.Null(instruction.StageName);
             Assert.Null(instruction.StageNameToken);
 
-            instruction.StageNameToken = new IdentifierToken("foo3");
+            instruction.StageNameToken = new StageName("foo3");
             Assert.Equal("foo3", instruction.StageName);
             Assert.Equal("foo3", instruction.StageNameToken.Value);
 
@@ -206,7 +206,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyword(token, "as"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "build")
+                        token => ValidateIdentifier<StageName>(token, "build")
                     },
                     Validate = result =>
                     {
@@ -230,7 +230,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyword(token, "as"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "build")
+                        token => ValidateIdentifier<StageName>(token, "build")
                     },
                     Validate = result =>
                     {
@@ -266,7 +266,7 @@ namespace DockerfileModel.Tests
                             token => ValidateSymbol(token, '#'),
                             token => ValidateString(token, "comment"),
                             token => ValidateNewLine(token, "\n")),
-                        token => ValidateIdentifier(token, "build")
+                        token => ValidateIdentifier<StageName>(token, "build")
                     },
                     Validate = result =>
                     {
@@ -302,7 +302,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyword(token, "as"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "build")
+                        token => ValidateIdentifier<StageName>(token, "build")
                     },
                     Validate = result =>
                     {
@@ -399,7 +399,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyword(token, "AS"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<IdentifierToken>(token, "bui`\nld",
+                        token => ValidateAggregate<StageName>(token, "bui`\nld",
                             token => ValidateString(token, "bui"),
                             token => ValidateLineContinuation(token, '`', "\n"),
                             token => ValidateString(token, "ld"))
@@ -522,7 +522,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyword(token, "AS"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "test")
+                        token => ValidateIdentifier<StageName>(token, "test")
                     }
                 },
                 new CreateTestScenario
@@ -546,7 +546,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyword(token, "AS"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateIdentifier(token, "test")
+                        token => ValidateIdentifier<StageName>(token, "test")
                     }
                 }
             };

--- a/src/DockerfileModel/DockerfileModel.Tests/ImageNameTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ImageNameTests.cs
@@ -77,22 +77,22 @@ namespace DockerfileModel.Tests
             imageName.Tag = null;
             Assert.Null(imageName.Tag);
 
-            imageName.Digest = "digest";
-            Assert.Equal("digest", imageName.Digest);
+            imageName.Digest = "sha256:123";
+            Assert.Equal("sha256:123", imageName.Digest);
 
-            Assert.Equal("registry2.io/repo2@digest", imageName.ToString());
+            Assert.Equal("registry2.io/repo2@sha256:123", imageName.ToString());
 
             imageName.Registry = null;
-            Assert.Equal("repo2@digest", imageName.ToString());
+            Assert.Equal("repo2@sha256:123", imageName.ToString());
 
             imageName.Registry = "myregistry.io";
-            Assert.Equal("myregistry.io/repo2@digest", imageName.ToString());
+            Assert.Equal("myregistry.io/repo2@sha256:123", imageName.ToString());
 
             imageName.Digest = null;
             Assert.Equal("myregistry.io/repo2", imageName.ToString());
 
-            imageName.Digest = "mydigest";
-            Assert.Equal("myregistry.io/repo2@mydigest", imageName.ToString());
+            imageName.Digest = "sha256:456";
+            Assert.Equal("myregistry.io/repo2@sha256:456", imageName.ToString());
 
             imageName.Digest = null;
             imageName.Tag = "mytag";
@@ -107,27 +107,12 @@ namespace DockerfileModel.Tests
         {
             ImageName imageName = new ImageName("repo");
             Assert.Null(imageName.Registry);
-            Assert.Null(imageName.RegistryToken);
 
-            imageName.Registry = "test";
-            Assert.Equal("test", imageName.Registry);
-            Assert.Equal("test", imageName.RegistryToken.Value);
+            imageName.Registry = "test.com";
+            Assert.Equal("test.com", imageName.Registry);
 
             imageName.Registry = null;
             Assert.Null(imageName.Registry);
-            Assert.Null(imageName.RegistryToken);
-
-            imageName.RegistryToken = new RegistryToken("test2");
-            Assert.Equal("test2", imageName.Registry);
-            Assert.Equal("test2", imageName.RegistryToken.Value);
-
-            imageName.RegistryToken.Value = "test3";
-            Assert.Equal("test3", imageName.Registry);
-            Assert.Equal("test3", imageName.RegistryToken.Value);
-
-            imageName.RegistryToken = null;
-            Assert.Null(imageName.Registry);
-            Assert.Null(imageName.RegistryToken);
         }
 
         [Fact]
@@ -135,22 +120,11 @@ namespace DockerfileModel.Tests
         {
             ImageName imageName = new ImageName("test");
             Assert.Equal("test", imageName.Repository);
-            Assert.Equal("test", imageName.RepositoryToken.Value);
 
             imageName.Repository = "test2";
             Assert.Equal("test2", imageName.Repository);
-            Assert.Equal("test2", imageName.RepositoryToken.Value);
-
-            imageName.RepositoryToken = new RepositoryToken("test3");
-            Assert.Equal("test3", imageName.Repository);
-            Assert.Equal("test3", imageName.RepositoryToken.Value);
-
-            imageName.RepositoryToken.Value = "test4";
-            Assert.Equal("test4", imageName.Repository);
-            Assert.Equal("test4", imageName.RepositoryToken.Value);
 
             Assert.Throws<ArgumentNullException>(() => imageName.Repository = null);
-            Assert.Throws<ArgumentNullException>(() => imageName.RepositoryToken = null);
         }
 
         [Fact]
@@ -158,30 +132,14 @@ namespace DockerfileModel.Tests
         {
             ImageName imageName = new ImageName("repo");
             Assert.Null(imageName.Tag);
-            Assert.Null(imageName.TagToken);
 
             imageName.Tag = "test";
             Assert.Equal("test", imageName.Tag);
-            Assert.Equal("test", imageName.TagToken.Value);
+
+            Assert.Throws<InvalidOperationException>(() => imageName.Digest = "sha256:123");
 
             imageName.Tag = null;
             Assert.Null(imageName.Tag);
-            Assert.Null(imageName.TagToken);
-
-            imageName.TagToken = new TagToken("test2");
-            Assert.Equal("test2", imageName.Tag);
-            Assert.Equal("test2", imageName.TagToken.Value);
-
-            imageName.TagToken.Value = "test3";
-            Assert.Equal("test3", imageName.Tag);
-            Assert.Equal("test3", imageName.TagToken.Value);
-
-            Assert.Throws<InvalidOperationException>(() => imageName.Digest = "foo");
-            Assert.Throws<InvalidOperationException>(() => imageName.DigestToken = new DigestToken("foo"));
-
-            imageName.TagToken = null;
-            Assert.Null(imageName.Tag);
-            Assert.Null(imageName.TagToken);
         }
 
         [Fact]
@@ -189,30 +147,14 @@ namespace DockerfileModel.Tests
         {
             ImageName imageName = new ImageName("repo");
             Assert.Null(imageName.Digest);
-            Assert.Null(imageName.DigestToken);
 
-            imageName.Digest = "test";
-            Assert.Equal("test", imageName.Digest);
-            Assert.Equal("test", imageName.DigestToken.Value);
+            imageName.Digest = "sha256:123";
+            Assert.Equal("sha256:123", imageName.Digest);
+
+            Assert.Throws<InvalidOperationException>(() => imageName.Tag = "foo");
 
             imageName.Digest = null;
             Assert.Null(imageName.Digest);
-            Assert.Null(imageName.DigestToken);
-
-            imageName.DigestToken = new DigestToken("test2");
-            Assert.Equal("test2", imageName.Digest);
-            Assert.Equal("test2", imageName.DigestToken.Value);
-
-            imageName.DigestToken.Value = "test3";
-            Assert.Equal("test3", imageName.Digest);
-            Assert.Equal("test3", imageName.DigestToken.Value);
-
-            Assert.Throws<InvalidOperationException>(() => imageName.Tag = "foo");
-            Assert.Throws<InvalidOperationException>(() => imageName.TagToken = new TagToken("foo"));
-
-            imageName.DigestToken = null;
-            Assert.Null(imageName.Digest);
-            Assert.Null(imageName.DigestToken);
         }
     }
 }

--- a/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
@@ -173,7 +173,7 @@ namespace DockerfileModel.Tests
             Assert.Equal(6, repoArgTokens.Length);
             Assert.IsType<KeywordToken>(repoArgTokens[0]);
             Assert.IsType<WhitespaceToken>(repoArgTokens[1]);
-            Assert.IsType<IdentifierToken>(repoArgTokens[2]);
+            Assert.IsType<Variable>(repoArgTokens[2]);
             Assert.IsType<SymbolToken>(repoArgTokens[3]);
             Assert.IsType<LiteralToken>(repoArgTokens[4]);
             Assert.IsType<NewLineToken>(repoArgTokens[5]);
@@ -197,7 +197,7 @@ namespace DockerfileModel.Tests
             Assert.IsType<WhitespaceToken>(fromInstructionTokens[5]);
             Assert.IsType<KeywordToken>(fromInstructionTokens[6]);
             Assert.IsType<WhitespaceToken>(fromInstructionTokens[7]);
-            Assert.IsType<IdentifierToken>(fromInstructionTokens[8]);
+            Assert.IsType<StageName>(fromInstructionTokens[8]);
         }
 
         /// <summary>

--- a/src/DockerfileModel/DockerfileModel.Tests/SecretMountTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/SecretMountTests.cs
@@ -25,7 +25,7 @@ namespace DockerfileModel.Tests
             else
             {
                 ParseException exception = Assert.Throws<ParseException>(
-                    () => ArgInstruction.Parse(scenario.Text, scenario.EscapeChar));
+                    () => SecretMount.Parse(scenario.Text, scenario.EscapeChar));
                 Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
                 Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
             }
@@ -202,12 +202,12 @@ namespace DockerfileModel.Tests
                 new SecretMountParseTestScenario
                 {
                     Text = "type=foo",
-                    ParseExceptionPosition = new Position(1, 1, 1)
+                    ParseExceptionPosition = new Position(1, 1, 9)
                 },
                 new SecretMountParseTestScenario
                 {
                     Text = "type=secret",
-                    ParseExceptionPosition = new Position(1, 1, 1)
+                    ParseExceptionPosition = new Position(1, 1, 12)
                 }
             };
 

--- a/src/DockerfileModel/DockerfileModel.Tests/StageNameTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/StageNameTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DockerfileModel.Tokens;
+using Sprache;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
+
+namespace DockerfileModel.Tests
+{
+    public class StageNameTests
+    {
+        [Theory]
+        [MemberData(nameof(ParseTestInput))]
+        public void Parse(StageNameParseTestScenario scenario)
+        {
+            if (scenario.ParseExceptionPosition is null)
+            {
+                StageName result = new StageName(scenario.Text, scenario.EscapeChar);
+                Assert.Equal(scenario.Text, result.ToString());
+                Assert.Collection(result.Tokens, scenario.TokenValidators);
+                scenario.Validate?.Invoke(result);
+            }
+            else
+            {
+                ParseException exception = Assert.Throws<ParseException>(
+                    () => new StageName(scenario.Text, scenario.EscapeChar));
+                Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
+                Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
+            }
+        }
+
+        [Fact]
+        public void Value()
+        {
+            StageName stageName = new StageName("test");
+            Assert.Equal("test", stageName.Value);
+
+            stageName.Value = "test2";
+            Assert.Equal("test2", stageName.Value);
+        }
+
+        public static IEnumerable<object[]> ParseTestInput()
+        {
+            StageNameParseTestScenario[] testInputs = new StageNameParseTestScenario[]
+            {
+                new StageNameParseTestScenario
+                {
+                    Text = "test",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test"),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("test", result.Value);
+                    }
+                },
+                new StageNameParseTestScenario
+                {
+                    Text = "test_-.x",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test_-.x"),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("test_-.x", result.Value);
+                    }
+                },
+                new StageNameParseTestScenario
+                {
+                    Text = "te`\nst",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "te"),
+                        token => ValidateLineContinuation(token, '`', "\n"),
+                        token => ValidateString(token, "st"),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("test", result.Value);
+                    }
+                },
+                new StageNameParseTestScenario
+                {
+                    Text = "-test",
+                    ParseExceptionPosition = new Position(1, 1, 1)
+                }
+            };
+
+            return testInputs.Select(input => new object[] { input });
+        }
+
+        public class StageNameParseTestScenario : ParseTestScenario<StageName>
+        {
+            public char EscapeChar { get; set; }
+        }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
@@ -15,10 +15,8 @@ namespace DockerfileModel.Tests
             builder
                 .ChangeOwner("user")
                 .Comment("comment")
-                .Digest("digest")
                 .ExecFormCommand("cmd1", "cmd2")
                 .FromFlag("stage")
-                .Identifier("id")
                 .ImageName("repo")
                 .IntervalFlag("3m")
                 .KeyValue(new KeywordToken("key"), new LiteralToken("value"))
@@ -28,15 +26,14 @@ namespace DockerfileModel.Tests
                 .MountFlag(new SecretMount("id"))
                 .NewLine()
                 .PlatformFlag("platform")
-                .Registry("registry")
-                .Repository("repo")
                 .RetriesFlag("2")
                 .SecretMount("id")
                 .ShellFormCommand("cmd")
+                .StageName("stage")
                 .StartPeriodFlag("1s")
                 .Symbol('-')
-                .Tag("tag")
                 .TimeoutFlag("2h")
+                .Variable("myvar")
                 .VariableRef("var")
                 .Whitespace(" ");
 
@@ -47,8 +44,6 @@ namespace DockerfileModel.Tests
                 token => ValidateAggregate<CommentToken>(token, "#comment",
                     token => ValidateSymbol(token, '#'),
                     token => ValidateString(token, "comment")),
-                token => ValidateAggregate<DigestToken>(token, "digest",
-                    token => ValidateString(token, "digest")),
                 token => ValidateAggregate<ExecFormCommand>(token, "[\"cmd1\", \"cmd2\"]",
                     token => ValidateSymbol(token, '['),
                     token => ValidateLiteral(token, "cmd1", ParseHelper.DoubleQuote),
@@ -61,11 +56,11 @@ namespace DockerfileModel.Tests
                     token => ValidateSymbol(token, '-'),
                     token => ValidateKeyword(token, "from"),
                     token => ValidateSymbol(token, '='),
-                    token => ValidateIdentifier(token, "stage")),
-                token => ValidateIdentifier(token, "id"),
+                    token => ValidateIdentifier<StageName>(token, "stage")),
                 token => ValidateAggregate<ImageName>(token, "repo",
-                    token => ValidateAggregate<RepositoryToken>(token, "repo",
-                        token => ValidateString(token, "repo"))),
+                    token => {
+                        Assert.Equal("repo", ((LiteralToken)token).Value);
+                    }),
                 token => ValidateKeyValueFlag<IntervalFlag>(token, "interval", "3m"),
                 token => ValidateKeyValue(token, "key", "value"),
                 token => ValidateKeyword(token, "key"),
@@ -87,10 +82,6 @@ namespace DockerfileModel.Tests
                     token => ValidateKeyword(token, "platform"),
                     token => ValidateSymbol(token, '='),
                     token => ValidateLiteral(token, "platform")),
-                token => ValidateAggregate<RegistryToken>(token, "registry",
-                    token => ValidateString(token, "registry")),
-                token => ValidateAggregate<RepositoryToken>(token, "repo",
-                    token => ValidateString(token, "repo")),
                 token => ValidateKeyValueFlag<RetriesFlag>(token, "retries", "2"),
                 token => ValidateAggregate<SecretMount>(token, "type=secret,id=id",
                     token => ValidateKeyValue(token, "type", "secret"),
@@ -98,11 +89,11 @@ namespace DockerfileModel.Tests
                     token => ValidateKeyValue(token, "id", "id")),
                 token => ValidateAggregate<ShellFormCommand>(token, "cmd",
                     token => ValidateLiteral(token, "cmd")),
+                token => ValidateIdentifier<StageName>(token, "stage"),
                 token => ValidateKeyValueFlag<StartPeriodFlag>(token, "start-period", "1s"),
                 token => ValidateSymbol(token, '-'),
-                token => ValidateAggregate<TagToken>(token, "tag",
-                    token => ValidateString(token, "tag")),
                 token => ValidateKeyValueFlag<TimeoutFlag>(token, "timeout", "2h"),
+                token => ValidateIdentifier<Variable>(token, "myvar"),
                 token => ValidateAggregate<VariableRefToken>(token, "$var",
                     token => ValidateString(token, "var")),
                 token => ValidateWhitespace(token, " ")
@@ -111,10 +102,8 @@ namespace DockerfileModel.Tests
             string expectedResult =
                 "user" +
                 "#comment" +
-                "digest" +
                 "[\"cmd1\", \"cmd2\"]" +
                 "--from=stage" +
-                "id" +
                 "repo" +
                 "--interval=3m" +
                 "key=value" +
@@ -124,15 +113,14 @@ namespace DockerfileModel.Tests
                 "--mount=type=secret,id=id" +
                 Environment.NewLine +
                 "--platform=platform" +
-                "registry" +
-                "repo" +
                 "--retries=2" +
                 "type=secret,id=id" +
                 "cmd" +
+                "stage" +
                 "--start-period=1s" +
                 "-" +
-                "tag" +
                 "--timeout=2h" +
+                "myvar" +
                 "$var" +
                 " ";
 

--- a/src/DockerfileModel/DockerfileModel.Tests/TokenValidator.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/TokenValidator.cs
@@ -62,8 +62,9 @@ namespace DockerfileModel.Tests
             ValidateQuotableAggregate<LiteralToken>(token, $"{quoteChar}{literal}{quoteChar}", quoteChar, validators);
         }
             
-        public static void ValidateIdentifier(Token token, string identifier, char? quoteChar = null) =>
-            ValidateQuotableAggregate<IdentifierToken>(token, $"{quoteChar}{identifier}{quoteChar}", quoteChar,
+        public static void ValidateIdentifier<T>(Token token, string identifier, char? quoteChar = null)
+            where T : IdentifierToken =>
+            ValidateQuotableAggregate<T>(token, $"{quoteChar}{identifier}{quoteChar}", quoteChar,
                 token => ValidateString(token, identifier));
 
         public static void ValidateNewLine(Token token, string text)

--- a/src/DockerfileModel/DockerfileModel.Tests/VariableTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/VariableTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DockerfileModel.Tokens;
+using Sprache;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
+
+namespace DockerfileModel.Tests
+{
+    public class VariableTests
+    {
+        [Theory]
+        [MemberData(nameof(ParseTestInput))]
+        public void Parse(VariableParseTestScenario scenario)
+        {
+            if (scenario.ParseExceptionPosition is null)
+            {
+                Variable result = new Variable(scenario.Text, scenario.EscapeChar);
+                Assert.Equal(scenario.Text, result.ToString());
+                Assert.Collection(result.Tokens, scenario.TokenValidators);
+                scenario.Validate?.Invoke(result);
+            }
+            else
+            {
+                ParseException exception = Assert.Throws<ParseException>(
+                    () => new Variable(scenario.Text, scenario.EscapeChar));
+                Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
+                Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
+            }
+        }
+
+        [Fact]
+        public void Value()
+        {
+            Variable variable = new Variable("test");
+            Assert.Equal("test", variable.Value);
+
+            variable.Value = "test2";
+            Assert.Equal("test2", variable.Value);
+        }
+
+        public static IEnumerable<object[]> ParseTestInput()
+        {
+            VariableParseTestScenario[] testInputs = new VariableParseTestScenario[]
+            {
+                new VariableParseTestScenario
+                {
+                    Text = "test",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test"),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("test", result.Value);
+                    }
+                },
+                new VariableParseTestScenario
+                {
+                    Text = "test_x",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test_x"),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("test_x", result.Value);
+                    }
+                },
+                new VariableParseTestScenario
+                {
+                    Text = "te`\nst",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "te"),
+                        token => ValidateLineContinuation(token, '`', "\n"),
+                        token => ValidateString(token, "st"),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("test", result.Value);
+                    }
+                },
+                new VariableParseTestScenario
+                {
+                    Text = "_test",
+                    ParseExceptionPosition = new Position(1, 1, 1)
+                }
+            };
+
+            return testInputs.Select(input => new object[] { input });
+        }
+
+        public class VariableParseTestScenario : ParseTestScenario<Variable>
+        {
+            public char EscapeChar { get; set; }
+        }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel/ArgInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/ArgInstruction.cs
@@ -128,14 +128,11 @@ namespace DockerfileModel
 
         private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
             ArgTokens(
-                from argName in ArgTokens(GetArgNameParser(escapeChar).AsEnumerable(), escapeChar)
+                from argName in ArgTokens(DockerfileModel.Variable.GetParser(escapeChar).AsEnumerable(), escapeChar)
                 from argAssignment in GetArgAssignmentParser(escapeChar).Optional()
                 select ConcatTokens(
                     argName,
                     argAssignment.GetOrDefault()), escapeChar).End();
-
-        private static Parser<IdentifierToken> GetArgNameParser(char escapeChar) =>
-            IdentifierToken(VariableRefFirstLetterParser, VariableRefTailParser, escapeChar);
 
         private static Parser<IEnumerable<Token>> GetArgAssignmentParser(char escapeChar) =>
             from assignment in ArgTokens(Symbol(AssignmentOperator).AsEnumerable(), escapeChar)

--- a/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
@@ -26,10 +26,10 @@ namespace DockerfileModel
         {
             get => FromStageNameToken?.Value;
             set => SetOptionalTokenValue(
-                FromStageNameToken, value, val => new IdentifierToken(val), token => FromStageNameToken = token);
+                FromStageNameToken, value, val => new StageName(val), token => FromStageNameToken = token);
         }
 
-        public IdentifierToken? FromStageNameToken
+        public StageName? FromStageNameToken
         {
             get => FromFlag?.ValueToken;
             set => SetOptionalKeyValueTokenValue(

--- a/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
@@ -16,8 +16,8 @@ namespace DockerfileModel
 
         private EnvInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
-            VariableTokens = new TokenList<KeyValueToken<IdentifierToken, LiteralToken>>(TokenList);
-            Variables = new ProjectedItemList<KeyValueToken<IdentifierToken, LiteralToken>, IKeyValuePair>(
+            VariableTokens = new TokenList<KeyValueToken<Variable, LiteralToken>>(TokenList);
+            Variables = new ProjectedItemList<KeyValueToken<Variable, LiteralToken>, IKeyValuePair>(
                 VariableTokens,
                 token => token,
                 (token, keyValuePair) =>
@@ -30,7 +30,7 @@ namespace DockerfileModel
 
         public IList<IKeyValuePair> Variables { get; }
 
-        public IList<KeyValueToken<IdentifierToken, LiteralToken>> VariableTokens { get; }
+        public IList<KeyValueToken<Variable, LiteralToken>> VariableTokens { get; }
 
         public static EnvInstruction Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             new EnvInstruction(GetTokens(text, GetInnerParser(escapeChar)));
@@ -71,8 +71,8 @@ namespace DockerfileModel
         private static Parser<IEnumerable<Token>> MultiVariableFormat(char escapeChar) =>
             ArgTokens(
                 from whitespace in Whitespace().Optional()
-                from variable in KeyValueToken<IdentifierToken, LiteralToken>.GetParser(
-                    IdentifierToken(VariableRefFirstLetterParser, VariableRefTailParser, escapeChar),
+                from variable in KeyValueToken<Variable, LiteralToken>.GetParser(
+                    Variable.GetParser(escapeChar),
                     MultiVariableFormatValueParser(escapeChar),
                     escapeChar: escapeChar).AsEnumerable()
                 select ConcatTokens(whitespace.GetOrDefault(), variable), escapeChar
@@ -84,8 +84,8 @@ namespace DockerfileModel
 
         private static Parser<IEnumerable<Token>> SingleVariableFormat(char escapeChar) =>
             ArgTokens(
-                KeyValueToken<IdentifierToken, LiteralToken>.GetParser(
-                    IdentifierToken(VariableRefFirstLetterParser, VariableRefTailParser, escapeChar: escapeChar),
+                KeyValueToken<Variable, LiteralToken>.GetParser(
+                    Variable.GetParser(escapeChar),
                     LiteralWithVariables(escapeChar),
                     separator: ' ',
                     escapeChar: escapeChar).AsEnumerable(), escapeChar);

--- a/src/DockerfileModel/DockerfileModel/FromFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/FromFlag.cs
@@ -5,10 +5,10 @@ using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel
 {
-    public class FromFlag : KeyValueToken<KeywordToken, IdentifierToken>
+    public class FromFlag : KeyValueToken<KeywordToken, StageName>
     {
         public FromFlag(string stageName, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : base(new KeywordToken("from"), StageNameIdentifier(escapeChar).Parse(stageName), isFlag: true)
+            : base(new KeywordToken("from"), new StageName(stageName, escapeChar), isFlag: true)
         {
         }
 
@@ -18,9 +18,9 @@ namespace DockerfileModel
         }
 
         public static FromFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("from", escapeChar), StageNameIdentifier(escapeChar), tokens => new FromFlag(tokens), escapeChar: escapeChar);
+            Parse(text, Keyword("from", escapeChar), StageName.GetParser(escapeChar), tokens => new FromFlag(tokens), escapeChar: escapeChar);
 
         public static Parser<FromFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("from", escapeChar), StageNameIdentifier(escapeChar), tokens => new FromFlag(tokens), escapeChar: escapeChar);
+            GetParser(Keyword("from", escapeChar), StageName.GetParser(escapeChar), tokens => new FromFlag(tokens), escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/FromInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/FromInstruction.cs
@@ -66,7 +66,7 @@ namespace DockerfileModel
         {
             get => PlatformFlag?.ValueToken;
             set => SetOptionalKeyValueTokenValue(
-                PlatformFlag, value, val => new PlatformFlag(val), token => PlatformFlag = token);
+                PlatformFlag, value, val => new PlatformFlag(val, escapeChar), token => PlatformFlag = token);
         }
 
         private PlatformFlag? PlatformFlag
@@ -78,12 +78,12 @@ namespace DockerfileModel
         public string? StageName
         {
             get => StageNameToken?.Value;
-            set => SetOptionalTokenValue(StageNameToken, value, val => new IdentifierToken(val), token => StageNameToken = token);
+            set => SetOptionalTokenValue(StageNameToken, value, val => new StageName(val, escapeChar), token => StageNameToken = token);
         }
 
-        public IdentifierToken? StageNameToken
+        public StageName? StageNameToken
         {
-            get => this.Tokens.OfType<IdentifierToken>().FirstOrDefault();
+            get => this.Tokens.OfType<StageName>().FirstOrDefault();
             set
             {
                 SetToken(StageNameToken, value,
@@ -147,7 +147,7 @@ namespace DockerfileModel
 
         private static Parser<IEnumerable<Token>> GetStageNameParser(char escapeChar) =>
            from asKeyword in ArgTokens(Keyword("AS", escapeChar).AsEnumerable(), escapeChar)
-           from stageName in ArgTokens(StageNameIdentifier(escapeChar).AsEnumerable(), escapeChar)
+           from stageName in ArgTokens(DockerfileModel.StageName.GetParser(escapeChar).AsEnumerable(), escapeChar)
            select ConcatTokens(asKeyword, stageName);
 
         private static Parser<IEnumerable<Token>> GetPlatformParser(char escapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/StageName.cs
+++ b/src/DockerfileModel/DockerfileModel/StageName.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using DockerfileModel.Tokens;
+using Sprache;
+using static DockerfileModel.ParseHelper;
+
+namespace DockerfileModel
+{
+    public class StageName : IdentifierToken
+    {
+        private readonly char escapeChar;
+
+        internal StageName(IEnumerable<Token> tokens, char escapeChar) : base(tokens)
+        {
+            this.escapeChar = escapeChar;
+        }
+
+        public StageName(string value, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(value, GetInnerParser(escapeChar)), escapeChar)
+        {
+        }
+
+        public static Parser<StageName> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            from tokens in GetInnerParser(escapeChar)
+            select new StageName(tokens, escapeChar);
+
+        protected override IEnumerable<Token> GetInnerTokens(string value) =>
+            GetTokens(value, GetInnerParser(escapeChar));
+
+        private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
+            IdentifierString(escapeChar, FirstCharParser(), TailCharParser());
+
+        private static Parser<char> FirstCharParser() => Sprache.Parse.Letter;
+
+        private static Parser<char> TailCharParser() =>
+            Sprache.Parse.LetterOrDigit
+                .Or(Sprache.Parse.Char('_'))
+                .Or(Sprache.Parse.Char('-'))
+                .Or(Sprache.Parse.Char('.'));
+    }
+}

--- a/src/DockerfileModel/DockerfileModel/Tokens/IdentifierToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/IdentifierToken.cs
@@ -1,16 +1,12 @@
 ﻿using System.Collections.Generic;
+using Sprache;
 using Validation;
 
 namespace DockerfileModel.Tokens
 {
-    public class IdentifierToken : AggregateToken, IQuotableValueToken
+    public abstract class IdentifierToken : AggregateToken, IQuotableValueToken
     {
-        public IdentifierToken(string value)
-             : base(new Token[] { new StringToken(value) })
-        {
-        }
-
-        internal IdentifierToken(IEnumerable<Token> tokens) : base(tokens)
+        protected IdentifierToken(IEnumerable<Token> tokens) : base(tokens)
         {
         }
 
@@ -20,10 +16,19 @@ namespace DockerfileModel.Tokens
             set
             {
                 Requires.NotNullOrEmpty(value, nameof(value));
-                ReplaceWithToken(new StringToken(value));
+                ReplaceWithTokens(GetInnerTokens(value));
             }
         }
 
         public char? QuoteChar { get; set; }
+
+        protected abstract IEnumerable<Token> GetInnerTokens(string value);
+
+        protected static (IEnumerable<Token> Tokens, char? QuoteChar) GetTokens(string value, char escapeChar,
+            Parser<(IEnumerable<Token> Token, char? QuoteChar)> parser)
+        {
+            Requires.NotNull(value, nameof(value));
+            return parser.Parse(value);
+        }
     }
 }

--- a/src/DockerfileModel/DockerfileModel/Tokens/LiteralToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/LiteralToken.cs
@@ -34,11 +34,14 @@ namespace DockerfileModel.Tokens
             set
             {
                 Requires.NotNull(value, nameof(value));
-                ReplaceWithTokens(GetTokens(value, canContainVariables, escapeChar).Tokens);
+                ReplaceWithTokens(GetInnerTokens(value));
             }
         }
 
         public char? QuoteChar { get; set; }
+
+        protected virtual IEnumerable<Token> GetInnerTokens(string value) =>
+            GetTokens(value, canContainVariables, escapeChar).Tokens;
 
         private static (IEnumerable<Token> Tokens, char? QuoteChar) GetTokens(string value, bool canContainVariables, char escapeChar)
         {

--- a/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
@@ -21,12 +21,6 @@ namespace DockerfileModel.Tokens
         public TokenBuilder Comment(Action<TokenBuilder> configureBuilder) =>
             AddToken(new CommentToken(GetTokens(configureBuilder)));
 
-        public TokenBuilder Digest(string digest) =>
-            AddToken(new DigestToken(digest));
-
-        public TokenBuilder Digest(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new DigestToken(GetTokens(configureBuilder)));
-
         public TokenBuilder ExecFormCommand(params string[] commands) =>
             AddToken(new ExecFormCommand(commands, EscapeChar));
 
@@ -38,12 +32,6 @@ namespace DockerfileModel.Tokens
 
         public TokenBuilder FromFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new FromFlag(GetTokens(configureBuilder)));
-
-        public TokenBuilder Identifier(string value) =>
-            AddToken(new IdentifierToken(value));
-
-        public TokenBuilder Identifier(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new IdentifierToken(GetTokens(configureBuilder)));
 
         public TokenBuilder ImageName(string repository, string? registry = null, string? tag = null, string? digest = null) =>
             AddToken(new ImageName(repository, registry, tag, digest));
@@ -98,18 +86,6 @@ namespace DockerfileModel.Tokens
         public TokenBuilder PlatformFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new PlatformFlag(GetTokens(configureBuilder)));
 
-        public TokenBuilder Registry(string registry) =>
-            AddToken(new RegistryToken(registry));
-
-        public TokenBuilder Registry(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new RegistryToken(GetTokens(configureBuilder)));
-
-        public TokenBuilder Repository(string repository) =>
-            AddToken(new RepositoryToken(repository));
-
-        public TokenBuilder Repository(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new RepositoryToken(GetTokens(configureBuilder)));
-
         public TokenBuilder RetriesFlag(string retries) =>
             AddToken(new RetriesFlag(retries, EscapeChar));
 
@@ -131,6 +107,12 @@ namespace DockerfileModel.Tokens
         public TokenBuilder ShellFormCommand(Action<TokenBuilder> configureBuilder) =>
             AddToken(new ShellFormCommand(GetTokens(configureBuilder)));
 
+        public TokenBuilder StageName(string stageName) =>
+            AddToken(new StageName(stageName, EscapeChar));
+
+        public TokenBuilder StageName(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new StageName(GetTokens(configureBuilder), EscapeChar));
+
         public TokenBuilder StartPeriodFlag(string startPeriod) =>
             AddToken(new StartPeriodFlag(startPeriod, EscapeChar));
 
@@ -143,17 +125,17 @@ namespace DockerfileModel.Tokens
         public TokenBuilder Symbol(char EscapeChar) =>
             AddToken(new SymbolToken(EscapeChar));
 
-        public TokenBuilder Tag(string tag) =>
-            AddToken(new TagToken(tag));
-
-        public TokenBuilder Tag(Action<TokenBuilder> configureBuilder) =>
-            AddToken(new TagToken(GetTokens(configureBuilder)));
-
         public TokenBuilder TimeoutFlag(string timeout) =>
             AddToken(new TimeoutFlag(timeout, EscapeChar));
 
         public TokenBuilder TimeoutFlag(Action<TokenBuilder> configureBuilder) =>
             AddToken(new TimeoutFlag(GetTokens(configureBuilder)));
+
+        public TokenBuilder Variable(string name) =>
+            AddToken(new Variable(name, EscapeChar));
+
+        public TokenBuilder Variable(Action<TokenBuilder> configureBuilder) =>
+            AddToken(new Variable(GetTokens(configureBuilder), EscapeChar));
 
         public TokenBuilder VariableRef(string variableName, bool includeBraces = false) =>
             AddToken(new VariableRefToken(variableName, includeBraces, EscapeChar));

--- a/src/DockerfileModel/DockerfileModel/Variable.cs
+++ b/src/DockerfileModel/DockerfileModel/Variable.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using DockerfileModel.Tokens;
+using Sprache;
+using static DockerfileModel.ParseHelper;
+
+namespace DockerfileModel
+{
+    public class Variable : IdentifierToken
+    {
+        private readonly char escapeChar;
+
+        public Variable(string value, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(value, escapeChar, GetInnerParser(escapeChar)), escapeChar)
+        {
+        }
+
+        private Variable((IEnumerable<Token> Tokens, char? QuoteChar) tokensInfo, char escapeChar)
+            : this(tokensInfo.Tokens, escapeChar)
+        {
+            QuoteChar = tokensInfo.QuoteChar;
+        }
+
+        internal Variable(IEnumerable<Token> tokens, char escapeChar)
+            : base(tokens)
+        {
+            this.escapeChar = escapeChar;
+        }
+
+        public static Parser<Variable> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            from tokens in GetInnerParser(escapeChar)
+            select new Variable(tokens, escapeChar);
+
+        protected override IEnumerable<Token> GetInnerTokens(string value) =>
+            GetTokens(value, escapeChar, GetInnerParser(escapeChar)).Tokens;
+
+        private static Parser<(IEnumerable<Token> Tokens, char? QuoteChar)> GetInnerParser(char escapeChar) =>
+            IdentifierTokens(VariableRefFirstLetterParser, VariableRefTailParser, escapeChar);
+    }
+}


### PR DESCRIPTION
Redesigns the class structure of `IdentifierToken`.  This changes the class to be abstract and it now has two derived class: `StageName` and `Variable`.  This was done in order for identifiers to have parsing of the input to handle things like line continuations.  Each identifier type has its own syntax (i.e. allowed characters) so this is encapsulated in the derived classes.  

This also redesigns the `ImageName` class.  Its constituent components were originally publicly exposed and derived from `IdentifierToken`.  This was incorrect.  They now derive from `LiteralToken` and have been made private.  The `ImageName` class no longer exposes its constituent tokens other than via the general purpose `Tokens` property.