### PR TITLE
Support line continuations on input to KeywordToken

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/KeyValueTokenTests.cs
@@ -19,7 +19,7 @@ namespace DockerfileModel.Tests
             {
                 KeyValueToken<KeywordToken, LiteralToken> result = KeyValueToken<KeywordToken, LiteralToken>.Parse(
                     scenario.Text,
-                    ParseHelper.Keyword(scenario.Key, scenario.EscapeChar),
+                    KeywordToken.GetParser(scenario.Key, scenario.EscapeChar),
                     ParseHelper.LiteralWithVariables(scenario.EscapeChar),
                     escapeChar: scenario.EscapeChar);
                 Assert.Equal(scenario.Text, result.ToString());

--- a/src/DockerfileModel/DockerfileModel.Tests/KeywordTokenTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/KeywordTokenTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DockerfileModel.Tokens;
+using Sprache;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
+
+namespace DockerfileModel.Tests
+{
+    public class KeywordTokenTests
+    {
+        [Theory]
+        [MemberData(nameof(ParseTestInput))]
+        public void Parse(KeywordTokenParseTestScenario scenario)
+        {
+            if (scenario.ParseExceptionPosition is null)
+            {
+                KeywordToken result = new KeywordToken(scenario.Text, scenario.EscapeChar);
+                Assert.Equal(scenario.Text, result.ToString());
+                Assert.Collection(result.Tokens, scenario.TokenValidators);
+                scenario.Validate?.Invoke(result);
+            }
+            else
+            {
+                ParseException exception = Assert.Throws<ParseException>(
+                    () => ExposeInstruction.Parse(scenario.Text, scenario.EscapeChar));
+                Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
+                Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
+            }
+        }
+
+        public static IEnumerable<object[]> ParseTestInput()
+        {
+            KeywordTokenParseTestScenario[] testInputs = new KeywordTokenParseTestScenario[]
+            {
+                new KeywordTokenParseTestScenario
+                {
+                    Text = "test",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "test")
+                    }
+                },
+                new KeywordTokenParseTestScenario
+                {
+                    Text = "t`\nest",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateString(token, "t"),
+                        token => ValidateLineContinuation(token, '`', "\n"),
+                        token => ValidateString(token, "est"),
+                    }
+                }
+            };
+
+            return testInputs.Select(input => new object[] { input });
+        }
+    }
+
+    public class KeywordTokenParseTestScenario : ParseTestScenario<KeywordToken>
+    {
+        public char EscapeChar { get; set; }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel/ChangeOwnerFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/ChangeOwnerFlag.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using DockerfileModel.Tokens;
 using Sprache;
-using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel
 {
@@ -18,10 +17,18 @@ namespace DockerfileModel
 
         public static ChangeOwnerFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("chown", escapeChar), ChangeOwnerParser(escapeChar), tokens => new ChangeOwnerFlag(tokens), escapeChar: escapeChar);
+            Parse(text,
+                KeywordToken.GetParser("chown", escapeChar),
+                ChangeOwnerParser(escapeChar),
+                tokens => new ChangeOwnerFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<ChangeOwnerFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("chown", escapeChar), ChangeOwnerParser(escapeChar), tokens => new ChangeOwnerFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("chown", escapeChar),
+                ChangeOwnerParser(escapeChar),
+                tokens => new ChangeOwnerFlag(tokens),
+                escapeChar: escapeChar);
 
         private static Parser<ChangeOwner> ChangeOwnerParser(char escapeChar) =>
             ChangeOwner.GetParser(escapeChar);

--- a/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileParser.cs
@@ -138,7 +138,7 @@ namespace DockerfileModel
 
         public static Parser<KeywordToken> InstructionIdentifier(char escapeChar) =>
             instructionParsers.Keys
-                .Select(instructionName => ParseHelper.Keyword(instructionName, escapeChar))
+                .Select(instructionName => KeywordToken.GetParser(instructionName, escapeChar))
                 .Aggregate((current, next) => current.Or(next));
     }
 }

--- a/src/DockerfileModel/DockerfileModel/FromFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/FromFlag.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using DockerfileModel.Tokens;
 using Sprache;
-using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel
 {
@@ -18,9 +17,17 @@ namespace DockerfileModel
         }
 
         public static FromFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("from", escapeChar), StageName.GetParser(escapeChar), tokens => new FromFlag(tokens), escapeChar: escapeChar);
+            Parse(text,
+                KeywordToken.GetParser("from", escapeChar),
+                StageName.GetParser(escapeChar),
+                tokens => new FromFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<FromFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("from", escapeChar), StageName.GetParser(escapeChar), tokens => new FromFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("from", escapeChar),
+                StageName.GetParser(escapeChar),
+                tokens => new FromFlag(tokens),
+                escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/FromInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/FromInstruction.cs
@@ -146,7 +146,7 @@ namespace DockerfileModel
                 stageName.GetOrDefault())).End();
 
         private static Parser<IEnumerable<Token>> GetStageNameParser(char escapeChar) =>
-           from asKeyword in ArgTokens(Keyword("AS", escapeChar).AsEnumerable(), escapeChar)
+           from asKeyword in ArgTokens(KeywordToken.GetParser("AS", escapeChar).AsEnumerable(), escapeChar)
            from stageName in ArgTokens(DockerfileModel.StageName.GetParser(escapeChar).AsEnumerable(), escapeChar)
            select ConcatTokens(asKeyword, stageName);
 

--- a/src/DockerfileModel/DockerfileModel/HealthCheckInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/HealthCheckInstruction.cs
@@ -198,7 +198,7 @@ namespace DockerfileModel
         private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
             from options in Options(escapeChar)
             from command in CommandInstruction.GetInnerParser(escapeChar)
-                .XOr(ArgTokens(Keyword("NONE", escapeChar).AsEnumerable(), escapeChar))
+                .XOr(ArgTokens(KeywordToken.GetParser("NONE", escapeChar).AsEnumerable(), escapeChar))
             select ConcatTokens(options, command);
 
         private static Parser<IEnumerable<Token>> Options(char escapeChar) =>

--- a/src/DockerfileModel/DockerfileModel/IntervalFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/IntervalFlag.cs
@@ -18,9 +18,18 @@ namespace DockerfileModel
 
         public static IntervalFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("interval", escapeChar), LiteralWithVariables(escapeChar), tokens => new IntervalFlag(tokens), escapeChar: escapeChar);
+            Parse(
+                text,
+                KeywordToken.GetParser("interval", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new IntervalFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<IntervalFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("interval", escapeChar), LiteralWithVariables(escapeChar), tokens => new IntervalFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("interval", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new IntervalFlag(tokens),
+                escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/MountFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/MountFlag.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using DockerfileModel.Tokens;
 using Sprache;
-using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel
 {
@@ -18,10 +17,19 @@ namespace DockerfileModel
 
         public static MountFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("mount", escapeChar), MountParser(escapeChar), tokens => new MountFlag(tokens), escapeChar: escapeChar);
+            Parse(
+                text,
+                KeywordToken.GetParser("mount", escapeChar),
+                MountParser(escapeChar),
+                tokens => new MountFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<MountFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("mount", escapeChar), MountParser(escapeChar), tokens => new MountFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("mount", escapeChar),
+                MountParser(escapeChar),
+                tokens => new MountFlag(tokens),
+                escapeChar: escapeChar);
 
         private static Parser<Mount> MountParser(char escapeChar) =>
             SecretMount.GetParser(escapeChar);

--- a/src/DockerfileModel/DockerfileModel/ParseHelper.cs
+++ b/src/DockerfileModel/DockerfileModel/ParseHelper.cs
@@ -185,16 +185,6 @@ namespace DockerfileModel
         }
 
         /// <summary>
-        /// Parses a keyword.
-        /// </summary>
-        /// <param name="keyword">Name of the keyword.</param>
-        /// <param name="escapeChar">Escape character.</param>
-        /// <returns>Token for the keyword.</returns>
-        public static Parser<KeywordToken> Keyword(string keyword, char escapeChar) =>
-            from tokens in StringToken(keyword, escapeChar)
-            select new KeywordToken(tokens);
-
-        /// <summary>
         /// Parses a string.
         /// </summary>
         /// <param name="value">Value of the string.</param>
@@ -766,7 +756,7 @@ namespace DockerfileModel
         private static Parser<IEnumerable<Token>> InstructionNameWithTrailingContent(string instructionName, char escapeChar) =>
             WithTrailingComments(
                 from leading in Whitespace()
-                from instruction in TokenWithTrailingWhitespace(Keyword(instructionName, escapeChar))
+                from instruction in TokenWithTrailingWhitespace(KeywordToken.GetParser(instructionName, escapeChar))
                 from lineContinuation in LineContinuations(escapeChar).Optional()
                 select ConcatTokens(leading, instruction, lineContinuation.GetOrDefault()));
 

--- a/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/PlatformFlag.cs
@@ -18,9 +18,18 @@ namespace DockerfileModel
         }
 
         public static PlatformFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("platform", escapeChar), LiteralWithVariables(escapeChar), tokens => new PlatformFlag(tokens), escapeChar: escapeChar);
+            Parse(
+                text,
+                KeywordToken.GetParser("platform", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new PlatformFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<PlatformFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("platform", escapeChar), LiteralWithVariables(escapeChar), tokens => new PlatformFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("platform", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new PlatformFlag(tokens),
+                escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/RetriesFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/RetriesFlag.cs
@@ -18,9 +18,18 @@ namespace DockerfileModel
 
         public static RetriesFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("retries", escapeChar), LiteralWithVariables(escapeChar), tokens => new RetriesFlag(tokens), escapeChar: escapeChar);
+            Parse(
+                text,
+                KeywordToken.GetParser("retries", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new RetriesFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<RetriesFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("retries", escapeChar), LiteralWithVariables(escapeChar), tokens => new RetriesFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("retries", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new RetriesFlag(tokens),
+                escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/SecretMount.cs
+++ b/src/DockerfileModel/DockerfileModel/SecretMount.cs
@@ -112,7 +112,7 @@ namespace DockerfileModel
             return
                 from type in ArgTokens(
                     KeyValueToken<KeywordToken, LiteralToken>.GetParser(
-                        Keyword("type", escapeChar), valueParser, escapeChar: escapeChar).AsEnumerable(), escapeChar)
+                        KeywordToken.GetParser("type", escapeChar), valueParser, escapeChar: escapeChar).AsEnumerable(), escapeChar)
                 from comma in ArgTokens(Symbol(',').AsEnumerable(), escapeChar)
                 from idDest in IdAndDestinationParser(valueParser, escapeChar).Or(IdParser(valueParser, escapeChar))
                 select ConcatTokens(type, comma, idDest);
@@ -121,18 +121,18 @@ namespace DockerfileModel
         private static Parser<IEnumerable<Token>> IdAndDestinationParser(Parser<LiteralToken> valueParser, char escapeChar) =>
             from id in ArgTokens(
                 KeyValueToken<KeywordToken, LiteralToken>.GetParser(
-                    Keyword("id", escapeChar), valueParser, escapeChar: escapeChar).AsEnumerable(), escapeChar)
+                    KeywordToken.GetParser("id", escapeChar), valueParser, escapeChar: escapeChar).AsEnumerable(), escapeChar)
             from dest in ArgTokens(DestinationParser(escapeChar), escapeChar, excludeTrailingWhitespace: true)
             select ConcatTokens(id, dest);
 
         private static Parser<IEnumerable<Token>> IdParser(Parser<LiteralToken> valueParser, char escapeChar) =>
             KeyValueToken<KeywordToken, LiteralToken>.GetParser(
-                Keyword("id", escapeChar), valueParser, escapeChar: escapeChar).AsEnumerable();
+                KeywordToken.GetParser("id", escapeChar), valueParser, escapeChar: escapeChar).AsEnumerable();
 
         private static Parser<IEnumerable<Token>> DestinationParser(char escapeChar) =>
             from comma in Symbol(',')
             from dst in KeyValueToken<KeywordToken, LiteralToken>.GetParser(
-                Keyword("dst", escapeChar), LiteralWithVariables(escapeChar), escapeChar: escapeChar)
+                KeywordToken.GetParser("dst", escapeChar), LiteralWithVariables(escapeChar), escapeChar: escapeChar)
             select ConcatTokens(comma, dst);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/StartPeriodFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/StartPeriodFlag.cs
@@ -18,9 +18,18 @@ namespace DockerfileModel
 
         public static StartPeriodFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("start-period", escapeChar), LiteralWithVariables(escapeChar), tokens => new StartPeriodFlag(tokens), escapeChar: escapeChar);
+            Parse(
+                text,
+                KeywordToken.GetParser("start-period", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new StartPeriodFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<StartPeriodFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("start-period", escapeChar), LiteralWithVariables(escapeChar), tokens => new StartPeriodFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("start-period", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new StartPeriodFlag(tokens),
+                escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/TimeoutFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/TimeoutFlag.cs
@@ -18,9 +18,18 @@ namespace DockerfileModel
 
         public static TimeoutFlag Parse(string text,
             char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            Parse(text, Keyword("timeout", escapeChar), LiteralWithVariables(escapeChar), tokens => new TimeoutFlag(tokens), escapeChar: escapeChar);
+            Parse(
+                text,
+                KeywordToken.GetParser("timeout", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new TimeoutFlag(tokens),
+                escapeChar: escapeChar);
 
         public static Parser<TimeoutFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            GetParser(Keyword("timeout", escapeChar), LiteralWithVariables(escapeChar), tokens => new TimeoutFlag(tokens), escapeChar: escapeChar);
+            GetParser(
+                KeywordToken.GetParser("timeout", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new TimeoutFlag(tokens),
+                escapeChar: escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/Tokens/KeywordToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/KeywordToken.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
+using Sprache;
+
+using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel.Tokens
 {
     public class KeywordToken : AggregateToken, IValueToken
     {
-        public KeywordToken(string value)
-            : base(new Token[] { new StringToken(value) })
+        public KeywordToken(string value, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(GetTokens(value, GetInnerParser(StripLineContinuations(value, escapeChar), escapeChar)))
         {
         }
 
@@ -21,5 +25,28 @@ namespace DockerfileModel.Tokens
             get => Value;
             set => throw new NotSupportedException("The value of a keyword is read-only.");
         }
+
+        public static Parser<KeywordToken> GetParser(string keyword, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            from tokens in GetInnerParser(keyword, escapeChar)
+            select new KeywordToken(tokens);
+
+        private static string StripLineContinuations(string value, char escapeChar)
+        {
+            StringBuilder builder = new StringBuilder();
+            foreach (char ch in value)
+            {
+                if (ch == escapeChar || Char.IsWhiteSpace(ch))
+                {
+                    continue;
+                }
+
+                builder.Append(ch);
+            }
+
+            return builder.ToString();
+        }
+
+        private static Parser<IEnumerable<Token>> GetInnerParser(string value, char escapeChar) =>
+            StringToken(value, escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
@@ -57,7 +57,7 @@ namespace DockerfileModel.Tokens
             AddToken(new KeyValueToken<TKey, TValue>(GetTokens(configureBuilder)));
 
         public TokenBuilder Keyword(string value) =>
-            AddToken(new KeywordToken(value));
+            AddToken(new KeywordToken(value, EscapeChar));
 
         public TokenBuilder Keyword(Action<TokenBuilder> configureBuilder) =>
             AddToken(new KeywordToken(GetTokens(configureBuilder)));


### PR DESCRIPTION
Allows consumers of the constructor of `KeywordToken` to pass a string that contains line continuations and have it parsed out correctly into the sub-tokens.