### PR TITLE
Fix command parsing for RUN instruction

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/RunInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/RunInstructionTests.cs
@@ -127,6 +127,17 @@ namespace DockerfileModel.Tests
                 },
                 new RunInstructionParseTestScenario
                 {
+                    Text = "RUN [PowerShellType]::Type.Method",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateKeyword(token, "RUN"),
+                        token => ValidateWhitespace(token, " "),
+                        token => ValidateAggregate<ShellFormCommand>(token, "[PowerShellType]::Type.Method",
+                            token => ValidateLiteral(token, "[PowerShellType]::Type.Method"))
+                    }
+                },
+                new RunInstructionParseTestScenario
+                {
                     Text = "RUN T\\$EST",
                     TokenValidators = new Action<Token>[]
                     {

--- a/src/DockerfileModel/DockerfileModel/RunInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/RunInstruction.cs
@@ -105,6 +105,6 @@ namespace DockerfileModel
         private static Parser<Command> GetCommandParser(char escapeChar) =>
             ExecFormCommand.GetParser(escapeChar)
                 .Cast<ExecFormCommand, Command>()
-                .XOr(ShellFormCommand.GetParser(escapeChar));
+                .Or(ShellFormCommand.GetParser(escapeChar));
     }
 }


### PR DESCRIPTION
Fixed an issue with the logic to determine whether a `RUN` instruction's command is shell form or exec form.  It requires more than the first character to determine which form it is.