### PR TITLE
Allow non-uppercase instructions

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/DockerfileTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/DockerfileTests.cs
@@ -505,6 +505,17 @@ namespace DockerfileModel.Tests
             {
                 new ParseTestScenario<Dockerfile>
                 {
+                    Text = "from scratch",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        line => ValidateAggregate<FromInstruction>(line, "from scratch",
+                            token => ValidateKeyword(token, "from"),
+                            token => ValidateWhitespace(token, " "),
+                            token => ValidateLiteral(token, "scratch"))
+                    }
+                },
+                new ParseTestScenario<Dockerfile>
+                {
                     Text = "F\\\nRO\\\nM \\\nscratch",
                     TokenValidators = new Action<Token>[]
                     {

--- a/src/DockerfileModel/DockerfileModel/Instruction.cs
+++ b/src/DockerfileModel/DockerfileModel/Instruction.cs
@@ -10,7 +10,7 @@ namespace DockerfileModel
     public abstract class Instruction : DockerfileConstruct, ICommentable
     {
         private static readonly Dictionary<string, Func<string, char, Instruction>> instructionParsers =
-            new Dictionary<string, Func<string, char, Instruction>>
+            new Dictionary<string, Func<string, char, Instruction>>(StringComparer.OrdinalIgnoreCase)
             {
                 { "ADD", AddInstruction.Parse },
                 { "ARG", ArgInstruction.Parse },


### PR DESCRIPTION
Fix an issue with parsing a Dockerfile where it didn't correctly handle instruction names that were not in upper-case.  