### PR TITLE
Add support for the chmod flag

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/AddInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/AddInstructionTests.cs
@@ -7,7 +7,8 @@ namespace DockerfileModel.Tests
     {
         public AddInstructionTests()
             : base("ADD", AddInstruction.Parse,
-                  (sources, destination, changeOwner, escapeChar) => new AddInstruction(sources, destination, changeOwner, escapeChar))
+                (sources, destination, changeOwner, permissions, escapeChar) =>
+                    new AddInstruction(sources, destination, changeOwner, permissions, escapeChar))
         {
         }
 

--- a/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
@@ -13,8 +13,8 @@ namespace DockerfileModel.Tests
     {
         public CopyInstructionTests()
             : base("COPY", CopyInstruction.Parse,
-                  (sources, destination, changeOwner, escapeChar) =>
-                    new CopyInstruction(sources, destination, changeOwner: changeOwner, escapeChar: escapeChar))
+                  (sources, destination, changeOwner, permissions, escapeChar) =>
+                    new CopyInstruction(sources, destination, changeOwner: changeOwner, permissions: permissions, escapeChar: escapeChar))
         {
         }
 

--- a/src/DockerfileModel/DockerfileModel/AddInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/AddInstruction.cs
@@ -10,8 +10,8 @@ namespace DockerfileModel
         private const string Name = "ADD";
 
         public AddInstruction(IEnumerable<string> sources, string destination,
-            ChangeOwner? changeOwner = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : base(sources, destination, changeOwner, escapeChar, Name)
+            ChangeOwner? changeOwner = null, string? permissions = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(sources, destination, changeOwner, permissions, escapeChar, Name)
         {
         }
 

--- a/src/DockerfileModel/DockerfileModel/ChangeModeFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/ChangeModeFlag.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using DockerfileModel.Tokens;
+using Sprache;
+using static DockerfileModel.ParseHelper;
+
+namespace DockerfileModel
+{
+    public class ChangeModeFlag : KeyValueToken<KeywordToken, LiteralToken>
+    {
+        public ChangeModeFlag(string permissions, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(new KeywordToken("chmod", escapeChar), new LiteralToken(permissions, canContainVariables: true, escapeChar), isFlag: true)
+        {
+        }
+
+        internal ChangeModeFlag(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
+
+        public static ChangeModeFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Parse(text,
+                KeywordToken.GetParser("chmod", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new ChangeModeFlag(tokens),
+                escapeChar: escapeChar);
+
+        public static Parser<ChangeModeFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            GetParser(
+                KeywordToken.GetParser("chmod", escapeChar),
+                LiteralWithVariables(escapeChar),
+                tokens => new ChangeModeFlag(tokens),
+                escapeChar: escapeChar);
+    }
+}

--- a/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
@@ -11,8 +11,8 @@ namespace DockerfileModel
         private const string Name = "COPY";
 
         public CopyInstruction(IEnumerable<string> sources, string destination,
-            string? fromStageName = null, ChangeOwner? changeOwner = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : base(GetTokens(sources, destination, fromStageName, changeOwner, escapeChar), escapeChar)
+            string? fromStageName = null, ChangeOwner? changeOwner = null, string? permissions = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : base(GetTokens(sources, destination, fromStageName, changeOwner, permissions, escapeChar), escapeChar)
         {
         }
 
@@ -52,10 +52,10 @@ namespace DockerfileModel
                 ArgTokens(FromFlag.GetParser(escapeChar).AsEnumerable(), escapeChar));
 
         private static IEnumerable<Token> GetTokens(IEnumerable<string> sources, string destination,
-           string? fromStageName, ChangeOwner? changeOwner, char escapeChar)
+           string? fromStageName, ChangeOwner? changeOwner, string? permissions, char escapeChar)
         {
             string fromFlag = fromStageName is null ? "" : new FromFlag(fromStageName, escapeChar).ToString() + " ";
-            string text = CreateInstructionString(sources, destination, changeOwner, escapeChar, Name, fromFlag);
+            string text = CreateInstructionString(sources, destination, changeOwner, permissions, escapeChar, Name, fromFlag);
             return GetTokens(text, GetInnerParser(escapeChar));
         }
     }

--- a/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
@@ -40,8 +40,9 @@ namespace DockerfileModel
         public DockerfileBuilder NewLine() =>
             AddConstruct(new Whitespace(DefaultNewLine));
 
-        public DockerfileBuilder AddInstruction(IEnumerable<string> sources, string destination, ChangeOwner? changeOwnerFlag = null) =>
-            AddConstruct(new AddInstruction(sources, destination, changeOwnerFlag, EscapeChar));
+        public DockerfileBuilder AddInstruction(IEnumerable<string> sources, string destination, ChangeOwner? changeOwnerFlag = null,
+            string? permissions = null) =>
+            AddConstruct(new AddInstruction(sources, destination, changeOwnerFlag, permissions, EscapeChar));
 
         public DockerfileBuilder AddInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.AddInstruction.Parse);
@@ -71,8 +72,8 @@ namespace DockerfileModel
             ParseTokens(configureBuilder, DockerfileModel.Comment.Parse);
 
         public DockerfileBuilder CopyInstruction(IEnumerable<string> sources, string destination,
-            string? fromStageName = null, ChangeOwner? changeOwner = null) =>
-            AddConstruct(new CopyInstruction(sources, destination, fromStageName, changeOwner, EscapeChar));
+            string? fromStageName = null, ChangeOwner? changeOwner = null, string? permissions = null) =>
+            AddConstruct(new CopyInstruction(sources, destination, fromStageName, changeOwner, permissions, EscapeChar));
 
         public DockerfileBuilder CopyInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.CopyInstruction.Parse);


### PR DESCRIPTION
Supports the new [`chmod` flag](https://github.com/moby/buildkit/pull/1492) for the `ADD` and `COPY` instructions.