### PR TITLE
Support multiple declarations in a single ARG instruction

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/ArgDeclarationTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ArgDeclarationTests.cs
@@ -1,0 +1,345 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DockerfileModel.Tokens;
+using Sprache;
+using Xunit;
+
+using static DockerfileModel.Tests.TokenValidator;
+
+namespace DockerfileModel.Tests
+{
+    public class ArgDeclarationTests
+    {
+        [Theory]
+        [MemberData(nameof(ParseTestInput))]
+        public void Parse(ArgDeclarationParseTestScenario scenario)
+        {
+            if (scenario.ParseExceptionPosition is null)
+            {
+                ArgDeclaration result = ArgDeclaration.Parse(scenario.Text, scenario.EscapeChar);
+                Assert.Equal(scenario.Text, result.ToString());
+                Assert.Collection(result.Tokens, scenario.TokenValidators);
+                scenario.Validate?.Invoke(result);
+            }
+            else
+            {
+                ParseException exception = Assert.Throws<ParseException>(
+                    () => ArgDeclaration.Parse(scenario.Text, scenario.EscapeChar));
+                Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
+                Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateTestInput))]
+        public void Create(CreateTestScenario scenario)
+        {
+            ArgDeclaration result = new ArgDeclaration(scenario.Name, scenario.Value);
+            Assert.Collection(result.Tokens, scenario.TokenValidators);
+            scenario.Validate?.Invoke(result);
+        }
+
+        [Fact]
+        public void Name()
+        {
+            ArgDeclaration arg = new ArgDeclaration("test");
+            Assert.Equal("test", arg.Name);
+            Assert.Equal("test", arg.NameToken.Value);
+
+            arg.Name = "test2";
+            Assert.Equal("test2", arg.Name);
+            Assert.Equal("test2", arg.NameToken.Value);
+
+            arg.NameToken.Value = "test3";
+            Assert.Equal("test3", arg.Name);
+            Assert.Equal("test3", arg.NameToken.Value);
+
+            Assert.Throws<ArgumentNullException>(() => arg.Name = null);
+            Assert.Throws<ArgumentException>(() => arg.Name = "");
+            Assert.Throws<ArgumentNullException>(() => arg.NameToken = null);
+        }
+
+        [Fact]
+        public void Value()
+        {
+            ArgDeclaration arg = new ArgDeclaration("test");
+            Assert.Null(arg.Value);
+            Assert.Null(arg.ValueToken);
+            Assert.False(arg.HasAssignmentOperator);
+
+            arg.Value = "foo";
+            Assert.Equal("foo", arg.Value);
+            Assert.Equal("foo", arg.ValueToken.Value);
+            Assert.True(arg.HasAssignmentOperator);
+
+            arg.Value = "";
+            Assert.Equal("", arg.Value);
+            Assert.Equal("", arg.ValueToken.Value);
+            Assert.True(arg.HasAssignmentOperator);
+
+            arg.Value = "foo";
+
+            arg.Value = null;
+            Assert.Null(arg.Value);
+            Assert.Null(arg.ValueToken);
+            Assert.False(arg.HasAssignmentOperator);
+
+            arg.ValueToken = new LiteralToken("foo2");
+            Assert.Equal("foo2", arg.Value);
+            Assert.Equal("foo2", arg.ValueToken.Value);
+            Assert.True(arg.HasAssignmentOperator);
+
+            arg.ValueToken = new LiteralToken("foo3");
+            Assert.Equal("foo3", arg.Value);
+            Assert.Equal("foo3", arg.ValueToken.Value);
+            Assert.True(arg.HasAssignmentOperator);
+
+            arg.ValueToken = null;
+            Assert.Null(arg.Value);
+            Assert.Null(arg.ValueToken);
+            Assert.False(arg.HasAssignmentOperator);
+        }
+
+        [Fact]
+        public void ValueWithVariables()
+        {
+            ArgDeclaration arg = new ArgDeclaration("test", "$var");
+            TestHelper.TestVariablesWithNullableLiteral(
+                () => arg.ValueToken, token => arg.ValueToken = token, val => arg.Value = val, "var", canContainVariables: true);
+        }
+
+        public static IEnumerable<object[]> ParseTestInput()
+        {
+            ArgDeclarationParseTestScenario[] testInputs = new ArgDeclarationParseTestScenario[]
+            {
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "MYARG",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MYARG")
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MYARG", result.Name);
+                        Assert.Null(result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "MYARG=",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
+                        token => ValidateSymbol(token, '=')
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MYARG", result.Name);
+                        Assert.Equal("", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "MYARG=\"\"",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "", '\"')
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MYARG", result.Name);
+                        Assert.Equal("", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "myarg=1",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "myarg"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "1")
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("myarg", result.Name);
+                        Assert.Equal("1", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "myarg`\n=`\n1",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "myarg"),
+                        token => ValidateLineContinuation(token, '`', "\n"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLineContinuation(token, '`', "\n"),
+                        token => ValidateLiteral(token, "1")
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("myarg", result.Name);
+                        Assert.Equal("1", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "MYARG=\"test\"",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MYARG"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "test", '\"')
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MYARG", result.Name);
+                        Assert.Equal("test", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "\"MY_ARG\"='value'",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MY_ARG", '\"'),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "value", '\''),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MY_ARG", result.Name);
+                        Assert.Equal("value", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "\"MY`\"_ARG\"='va`'lue'",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MY`\"_ARG", '\"'),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "va`'lue", '\''),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MY`\"_ARG", result.Name);
+                        Assert.Equal("va`'lue", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "MY_ARG=va`'lue",
+                    EscapeChar = '`',
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MY_ARG"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "va`'lue"),
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MY_ARG", result.Name);
+                        Assert.Equal("va`'lue", result.Value);
+                    }
+                },
+                new ArgDeclarationParseTestScenario
+                {
+                    Text = "MY_ARG=\'\'",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "MY_ARG"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "", '\'')
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("MY_ARG", result.Name);
+                        Assert.Empty(result.Value);
+                    }
+                }
+            };
+
+            return testInputs.Select(input => new object[] { input });
+        }
+
+        public static IEnumerable<object[]> CreateTestInput()
+        {
+            CreateTestScenario[] testInputs = new CreateTestScenario[]
+            {
+                new CreateTestScenario
+                {
+                    Name = "TEST1",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "TEST1")
+                    },
+                    Validate = result =>
+                    {
+                        Assert.Equal("TEST1", result.Name);
+                        Assert.Null(result.Value);
+
+                        result.Name = "TEST2";
+                        Assert.Equal("TEST2", result.Name);
+                        Assert.Equal("TEST2", result.ToString());
+
+                        result.Value = "a";
+                        Assert.Equal("a", result.Value);
+                        Assert.Equal("TEST2=a", result.ToString());
+
+                        result.Value = null;
+                        Assert.Null(result.Value);
+                        Assert.Equal("TEST2", result.ToString());
+
+                        result.Value = "";
+                        Assert.Equal("", result.Value);
+                        Assert.Equal("TEST2=", result.ToString());
+                    }
+                },
+                new CreateTestScenario
+                {
+                    Name = "TEST1",
+                    Value = "b",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "TEST1"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateLiteral(token, "b")
+                    }
+                },
+                new CreateTestScenario
+                {
+                    Name = "TEST1",
+                    Value = "",
+                    TokenValidators = new Action<Token>[]
+                    {
+                        token => ValidateIdentifier<Variable>(token, "TEST1"),
+                        token => ValidateSymbol(token, '=')
+                    }
+                }
+            };
+
+            return testInputs.Select(input => new object[] { input });
+        }
+
+        public class ArgDeclarationParseTestScenario : ParseTestScenario<ArgDeclaration>
+        {
+            public char EscapeChar { get; set; }
+        }
+
+        public class CreateTestScenario : TestScenario<ArgDeclaration>
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/DockerfileModel/DockerfileModel.Tests/OnBuildInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/OnBuildInstructionTests.cs
@@ -69,7 +69,8 @@ namespace DockerfileModel.Tests
                         token => ValidateAggregate<ArgInstruction>(token, "ARG name",
                             token => ValidateKeyword(token, "ARG"),
                             token => ValidateWhitespace(token, " "),
-                            token => ValidateIdentifier<Variable>(token, "name"))
+                            token => ValidateAggregate<ArgDeclaration>(token, "name",
+                                token => ValidateIdentifier<Variable>(token, "name")))
                     },
                     Validate = result =>
                     {
@@ -91,7 +92,8 @@ namespace DockerfileModel.Tests
                         token => ValidateAggregate<ArgInstruction>(token, "ARG name",
                             token => ValidateKeyword(token, "ARG"),
                             token => ValidateWhitespace(token, " "),
-                            token => ValidateIdentifier<Variable>(token, "name"))
+                            token => ValidateAggregate<ArgDeclaration>(token, "name",
+                                token => ValidateIdentifier<Variable>(token, "name")))
                     },
                     Validate = result =>
                     {

--- a/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/ScenarioTests.cs
@@ -170,13 +170,11 @@ namespace DockerfileModel.Tests
             
             // Verify the individual tokens that are contained in the ARG instruction
             Token[] repoArgTokens = dockerfileConstructs[0].Tokens.ToArray();
-            Assert.Equal(6, repoArgTokens.Length);
+            Assert.Equal(4, repoArgTokens.Length);
             Assert.IsType<KeywordToken>(repoArgTokens[0]);
             Assert.IsType<WhitespaceToken>(repoArgTokens[1]);
-            Assert.IsType<Variable>(repoArgTokens[2]);
-            Assert.IsType<SymbolToken>(repoArgTokens[3]);
-            Assert.IsType<LiteralToken>(repoArgTokens[4]);
-            Assert.IsType<NewLineToken>(repoArgTokens[5]);
+            Assert.IsType<ArgDeclaration>(repoArgTokens[2]);
+            Assert.IsType<NewLineToken>(repoArgTokens[3]);
 
             // Verify the individual tokens that are contained in the FROM instruction
             Token[] fromInstructionTokens = dockerfileConstructs[1].Tokens.ToArray();

--- a/src/DockerfileModel/DockerfileModel/ArgDeclaration.cs
+++ b/src/DockerfileModel/DockerfileModel/ArgDeclaration.cs
@@ -1,0 +1,156 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DockerfileModel.Tokens;
+using Sprache;
+using Validation;
+using static DockerfileModel.ParseHelper;
+
+namespace DockerfileModel
+{
+    public class ArgDeclaration : AggregateToken, IKeyValuePair
+    {
+        private const char AssignmentOperator = '=';
+        private readonly char escapeChar;
+
+        public ArgDeclaration(string name, string? value= null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(name, value, escapeChar), escapeChar)
+        {
+        }
+
+        internal ArgDeclaration(IEnumerable<Token> tokens, char escapeChar)
+            : base(tokens)
+        {
+            this.escapeChar = escapeChar;
+        }
+
+        public string Name
+        {
+            get => NameToken.Value;
+            set
+            {
+                Requires.NotNullOrEmpty(value, nameof(value));
+                NameToken.Value = value;
+            }
+        }
+
+        string IKeyValuePair.Key
+        {
+            get => Name;
+            set => Name = value;
+        }
+
+        public Variable NameToken
+        {
+            get => Tokens.OfType<Variable>().First();
+            set
+            {
+                Requires.NotNull(value, nameof(value));
+                SetToken(NameToken, value);
+            }
+        }
+
+        public string? Value
+        {
+            get
+            {
+                string? argValue = ValueToken?.Value;
+                if (argValue is null)
+                {
+                    return HasAssignmentOperator ? string.Empty : null;
+                }
+
+                return argValue;
+            }
+            set
+            {
+                LiteralToken? argValue = ValueToken;
+                if (argValue != null && value is not null)
+                {
+                    argValue.Value = value;
+                }
+                else
+                {
+                    ValueToken = value is null ? null : new LiteralToken(value, canContainVariables: true, escapeChar);
+                }
+            }
+        }
+
+        public LiteralToken? ValueToken
+        {
+            get => this.Tokens.OfType<LiteralToken>().FirstOrDefault();
+            set
+            {
+                this.SetToken(ValueToken, value,
+                    addToken: token =>
+                    {
+                        if (HasAssignmentOperator)
+                        {
+                            this.TokenList.Add(token);
+                        }
+                        else
+                        {
+                            this.TokenList.AddRange(new Token[]
+                            {
+                                new SymbolToken(AssignmentOperator),
+                                token
+                            });
+                        }
+                    },
+                    removeToken: token =>
+                    {
+                        TokenList.RemoveRange(
+                            TokenList.FirstPreviousOfType<Token, SymbolToken>(token),
+                            token);
+                    });
+            }
+        }
+
+        public bool HasAssignmentOperator =>
+            Tokens.OfType<SymbolToken>().Where(token => token.Value == AssignmentOperator.ToString()).Any();
+
+        public static ArgDeclaration Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            new ArgDeclaration(GetTokens(text, GetInnerParser(escapeChar)), escapeChar);
+
+        public static Parser<ArgDeclaration> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            from tokens in GetInnerParser(escapeChar)
+            select new ArgDeclaration(tokens, escapeChar);
+
+        private static IEnumerable<Token> GetTokens(string name, string? value, char escapeChar)
+        {
+            Requires.NotNullOrEmpty(name, nameof(name));
+
+            StringBuilder builder = new StringBuilder(name);
+            if (value != null)
+            {
+                builder.Append($"{AssignmentOperator}{value}");
+            }
+
+            return GetTokens(builder.ToString(), GetInnerParser(escapeChar));
+        }
+
+        private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
+            from argName in ArgTokens(
+                Variable.GetParser(escapeChar).AsEnumerable(),
+                escapeChar,
+                excludeTrailingWhitespace: true)
+            from argAssignment in ArgTokens(
+                GetArgAssignmentParser(escapeChar),
+                escapeChar,
+                excludeTrailingWhitespace: true).Optional()
+            select ConcatTokens(
+                argName,
+                argAssignment.GetOrDefault());
+
+        private static Parser<IEnumerable<Token>> GetArgAssignmentParser(char escapeChar) =>
+            from lineContinuation in LineContinuations(escapeChar)
+            from assignment in Symbol(AssignmentOperator).AsEnumerable()
+            from lineContinuation2 in LineContinuations(escapeChar)
+            from value in LiteralWithVariables(escapeChar, whitespaceMode: WhitespaceMode.AllowedInQuotes).AsEnumerable().Optional()
+            select ConcatTokens(
+                lineContinuation,
+                assignment,
+                lineContinuation2,
+                value.GetOrDefault());
+    }
+}

--- a/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
@@ -50,6 +50,9 @@ namespace DockerfileModel
         public DockerfileBuilder ArgInstruction(string argName, string? argValue = null) =>
             AddConstruct(new ArgInstruction(argName, argValue, EscapeChar));
 
+        public DockerfileBuilder ArgInstruction(IDictionary<string, string?> args) =>
+            AddConstruct(new ArgInstruction(args, EscapeChar));
+
         public DockerfileBuilder ArgInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.ArgInstruction.Parse);
 

--- a/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/EnvInstruction.cs
@@ -24,7 +24,7 @@ namespace DockerfileModel
                 {
                     Requires.NotNull(keyValuePair, "value");
                     token.Key = keyValuePair.Key;
-                    token.Value = keyValuePair.Value;
+                    token.Value = keyValuePair.Value!;
                 });
         }
 

--- a/src/DockerfileModel/DockerfileModel/IKeyValuePair.cs
+++ b/src/DockerfileModel/DockerfileModel/IKeyValuePair.cs
@@ -3,6 +3,6 @@
     public interface IKeyValuePair
     {
         string Key { get; set; }
-        string Value { get; set; }
+        string? Value { get; set; }
     }
 }

--- a/src/DockerfileModel/DockerfileModel/LabelInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/LabelInstruction.cs
@@ -24,7 +24,7 @@ namespace DockerfileModel
                 {
                     Requires.NotNull(keyValuePair, "value");
                     token.Key = keyValuePair.Key;
-                    token.Value = keyValuePair.Value;
+                    token.Value = keyValuePair.Value!;
                 });
         }
 

--- a/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/KeyValueToken.cs
@@ -51,6 +51,12 @@ namespace DockerfileModel.Tokens
             }
         }
 
+        string? IKeyValuePair.Value
+        {
+            get => Value;
+            set => Value = value!;
+        }
+
         public string Value
         {
             get => ValueToken.ToString(TokenStringOptions.CreateOptionsForValueString());


### PR DESCRIPTION
The `ARG` instruction now [supports](https://github.com/moby/buildkit/pull/1692) multiple declarations:

```Dockerfile
ARG arg1=x arg2=y
```

This updates the `ArgInstruction` class to support this syntax by defining a new `ArgDeclaration` type that encapsulates an arg name and value.