### PR TITLE
Support env option for secret mounts

### DIFF
--- a/src/DockerfileModel/DockerfileModel/SecretMount.cs
+++ b/src/DockerfileModel/DockerfileModel/SecretMount.cs
@@ -12,8 +12,8 @@ namespace DockerfileModel
     {
         private readonly char escapeChar;
 
-        public SecretMount(string id, string? destinationPath = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : this(GetTokens(id, destinationPath, escapeChar), escapeChar)
+        public SecretMount(string id, string? destinationPath = null, string? environmentVariable = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(id, destinationPath, environmentVariable, escapeChar), escapeChar)
         {
         }
 
@@ -48,53 +48,117 @@ namespace DockerfileModel
             get => DestinationPathToken?.Value;
             set
             {
-                KeyValueToken<KeywordToken, LiteralToken>? destinationPath = DestinationPathToken;
-                if (destinationPath is not null && value is not null)
-                {
-                    destinationPath.ValueToken.Value = value;
-                }
-                else
-                {
-                    DestinationPathToken = String.IsNullOrEmpty(value) ?
-                        null :
-                        new KeyValueToken<KeywordToken, LiteralToken>(
-                            new KeywordToken("dst", escapeChar),
-                            new LiteralToken(value!, canContainVariables: true, escapeChar));
-                }
+                ValidateDestination(value, nameof(DestinationPath), EnvironmentVariable, nameof(EnvironmentVariable));
+                SetDestinationValue("dst", DestinationPathToken, value, token => DestinationPathToken = token);
             }
         }
 
         public KeyValueToken<KeywordToken, LiteralToken>? DestinationPathToken
         {
-            get => Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>().Skip(2).FirstOrDefault();
+            get => GetDestinationToken("dst");
             set
             {
-                SetToken(DestinationPathToken, value,
-                    addToken: token =>
-                    {
-                        TokenList.Add(new SymbolToken(','));
-                        TokenList.Add(token);
-                    },
-                    removeToken: token =>
-                    {
-                        TokenList.RemoveRange(
-                            TokenList.FirstPreviousOfType<Token, SymbolToken>(token),
-                            token);
-                    });
+                ValidateDestinationToken(value, nameof(DestinationPath), EnvironmentVariableToken, nameof(EnvironmentVariableToken));
+                SetDestinationToken(DestinationPathToken, value);
             }
         }
 
-        private static IEnumerable<Token> GetTokens(string id, string? destinationPath,
+        public string? EnvironmentVariable
+        {
+            get => EnvironmentVariableToken?.Value;
+            set
+            {
+                ValidateDestination(DestinationPath, nameof(DestinationPath), value, nameof(EnvironmentVariable));
+                SetDestinationValue("env", EnvironmentVariableToken, value, token => EnvironmentVariableToken = token);
+            }
+        }
+
+        public KeyValueToken<KeywordToken, LiteralToken>? EnvironmentVariableToken
+        {
+            get => GetDestinationToken("env");
+            set
+            {
+                ValidateDestinationToken(DestinationPathToken, nameof(DestinationPathToken), value, nameof(EnvironmentVariableToken));
+                SetDestinationToken(EnvironmentVariableToken, value);
+            }
+        }
+
+        private void SetDestinationValue(string destinationKey, KeyValueToken<KeywordToken, LiteralToken>? token, string? newValue,
+            Action<KeyValueToken<KeywordToken, LiteralToken>?> setToken)
+        {
+            if (token is not null && newValue is not null)
+            {
+                token.ValueToken.Value = newValue;
+            }
+            else
+            {
+                setToken(String.IsNullOrEmpty(newValue) ?
+                    null :
+                    new KeyValueToken<KeywordToken, LiteralToken>(
+                        new KeywordToken(destinationKey, escapeChar),
+                        new LiteralToken(newValue!, canContainVariables: true, escapeChar)));
+            }
+        }
+
+        private void SetDestinationToken(KeyValueToken<KeywordToken, LiteralToken>? currentValue, KeyValueToken<KeywordToken, LiteralToken>? newValue) =>
+            SetToken(currentValue, newValue,
+                addToken: token =>
+                {
+                    TokenList.Add(new SymbolToken(','));
+                    TokenList.Add(token);
+                },
+                removeToken: token =>
+                {
+                    TokenList.RemoveRange(
+                        TokenList.FirstPreviousOfType<Token, SymbolToken>(token),
+                        token);
+                });
+
+        private KeyValueToken<KeywordToken, LiteralToken>? GetDestinationToken(string keyName) =>
+            Tokens
+                .OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+                .Skip(2)
+                .FirstOrDefault(token => token.Key.Equals(keyName, StringComparison.OrdinalIgnoreCase));
+
+        private static void ValidateDestination(
+            string? destinationPath,
+            string destinationPathName,
+            string? environmentVariable,
+            string environmentVariableName) =>
+            Requires.ValidState(
+                (destinationPath is null && environmentVariable is null) ||
+                String.IsNullOrEmpty(destinationPath) ^ String.IsNullOrEmpty(environmentVariable),
+                $"Either {destinationPathName} may be set or {environmentVariableName} may be set but not both.");
+
+        private static void ValidateDestinationToken(
+            KeyValueToken<KeywordToken, LiteralToken>? destinationPath,
+            string destinationPathName,
+            KeyValueToken<KeywordToken, LiteralToken>? environmentVariable,
+            string environmentVariableName) =>
+            Requires.ValidState(
+                (destinationPath is null && environmentVariable is null) ||
+                destinationPath is null ^ environmentVariable is null,
+                $"Either {destinationPathName} may be set or {environmentVariableName} may be set but not both.");
+
+        private static IEnumerable<Token> GetTokens(string id, string? destinationPath, string? environmentVariable,
             char escapeChar)
         {
             Requires.NotNullOrEmpty(id, nameof(id));
+            ValidateDestination(destinationPath, nameof(destinationPath), environmentVariable, nameof(environmentVariable));
+
             string? destinationSegment = null;
             if (!String.IsNullOrEmpty(destinationPath))
             {
                 destinationSegment = $",dst={destinationPath}";
             }
 
-            return GetTokens($"type=secret,id={id}{destinationSegment}", GetInnerParser(escapeChar));
+            string? envSegment = null;
+            if (!String.IsNullOrEmpty(environmentVariable))
+            {
+                envSegment = $",env={environmentVariable}";
+            }
+
+            return GetTokens($"type=secret,id={id}{destinationSegment}{envSegment}", GetInnerParser(escapeChar));
         }
 
         public static SecretMount Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
@@ -132,7 +196,9 @@ namespace DockerfileModel
         private static Parser<IEnumerable<Token>> DestinationParser(char escapeChar) =>
             from comma in Symbol(',')
             from dst in KeyValueToken<KeywordToken, LiteralToken>.GetParser(
-                KeywordToken.GetParser("dst", escapeChar), LiteralWithVariables(escapeChar), escapeChar: escapeChar)
+                KeywordToken.GetParser("dst", escapeChar).Or(KeywordToken.GetParser("env", escapeChar)),
+                LiteralWithVariables(escapeChar),
+                escapeChar: escapeChar)
             select ConcatTokens(comma, dst);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
@@ -95,8 +95,8 @@ namespace DockerfileModel.Tokens
         public TokenBuilder NewLine() =>
             AddToken(new NewLineToken(DefaultNewLine));
 
-        public TokenBuilder SecretMount(string id, string? destinationPath = null) =>
-            AddToken(new SecretMount(id, destinationPath, EscapeChar));
+        public TokenBuilder SecretMount(string id, string? destinationPath = null, string? environmentVariable = null) =>
+            AddToken(new SecretMount(id, destinationPath, environmentVariable, EscapeChar));
 
         public TokenBuilder SecretMount(Action<TokenBuilder> configureBuilder) =>
             AddToken(new SecretMount(GetTokens(configureBuilder), EscapeChar));


### PR DESCRIPTION
Adds support for the new `env` option for secret mounts (https://github.com/moby/buildkit/pull/1534).