### PR TITLE
Rename ChangeOwner to UserAccount

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CopyInstructionTests.cs
@@ -123,7 +123,7 @@ namespace DockerfileModel.Tests
                             token => ValidateSymbol(token, '-'),
                             token => ValidateKeyword(token, "chown"),
                             token => ValidateSymbol(token, '='),
-                            token => ValidateAggregate<ChangeOwner>(token, "id",
+                            token => ValidateAggregate<UserAccount>(token, "id",
                                 token => ValidateLiteral(token, "id"))),
                         token => ValidateWhitespace(token, " "),
                         token => ValidateLiteral(token, "src"),

--- a/src/DockerfileModel/DockerfileModel.Tests/FileTransferInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/FileTransferInstructionTests.cs
@@ -14,12 +14,12 @@ namespace DockerfileModel.Tests
     {
         private readonly string instructionName;
         private readonly Func<string, char, TInstruction> parse;
-        private readonly Func<IEnumerable<string>, string, ChangeOwner, string, char, TInstruction> create;
+        private readonly Func<IEnumerable<string>, string, UserAccount, string, char, TInstruction> create;
 
         public FileTransferInstructionTests(
             string instructionName,
             Func<string, char, TInstruction> parse,
-            Func<IEnumerable<string>, string, ChangeOwner, string, char, TInstruction> create)
+            Func<IEnumerable<string>, string, UserAccount, string, char, TInstruction> create)
         {
             this.instructionName = instructionName;
             this.parse = parse;
@@ -93,11 +93,11 @@ namespace DockerfileModel.Tests
                 Assert.Equal($"{instructionName} --chown={user} src dst", instruction.ToString());
             }
 
-            ChangeOwner changeOwner = new ChangeOwner("user");
+            UserAccount changeOwner = new UserAccount("user");
             TInstruction instruction = this.create(new string[] { "src" }, "dst", changeOwner, null, Dockerfile.DefaultEscapeChar);
             Validate(instruction, "user");
 
-            instruction.ChangeOwner = new ChangeOwner("user2");
+            instruction.ChangeOwner = new UserAccount("user2");
             Validate(instruction, "user2");
 
             instruction.ChangeOwner = null;
@@ -105,7 +105,7 @@ namespace DockerfileModel.Tests
             Assert.Equal($"{instructionName} src dst", instruction.ToString());
 
             instruction = this.parse($"{instructionName}`\n src dst", '`');
-            instruction.ChangeOwner = new ChangeOwner("user");
+            instruction.ChangeOwner = new UserAccount("user");
             Assert.Equal("user", instruction.ChangeOwner.User);
             Assert.Equal($"{instructionName} --chown=user`\n src dst", instruction.ToString());
 
@@ -118,7 +118,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void ChangeOwner_ResolveVariable()
         {
-            ChangeOwner changeOwner = new ChangeOwner("$var");
+            UserAccount changeOwner = new UserAccount("$var");
             TInstruction instruction = this.create(new string[] { "src" }, "dst", changeOwner, null, Dockerfile.DefaultEscapeChar);
 
             Assert.Collection(instruction.Tokens, new Action<Token>[]
@@ -130,7 +130,7 @@ namespace DockerfileModel.Tests
                     token => ValidateSymbol(token, '-'),
                     token => ValidateKeyword(token, "chown"),
                     token => ValidateSymbol(token, '='),
-                    token => ValidateAggregate<ChangeOwner>(token, "$var",
+                    token => ValidateAggregate<UserAccount>(token, "$var",
                         token => ValidateAggregate<LiteralToken>(token, "$var",
                             token => ValidateAggregate<VariableRefToken>(token, "$var",
                                 token => ValidateString(token, "var"))))),
@@ -157,7 +157,7 @@ namespace DockerfileModel.Tests
                     token => ValidateSymbol(token, '-'),
                     token => ValidateKeyword(token, "chown"),
                     token => ValidateSymbol(token, '='),
-                    token => ValidateAggregate<ChangeOwner>(token, "user",
+                    token => ValidateAggregate<UserAccount>(token, "user",
                         token => ValidateLiteral(token, "user"))),
                 token => ValidateWhitespace(token, " "),
                 token => ValidateLiteral(token, "src"),
@@ -258,7 +258,7 @@ namespace DockerfileModel.Tests
                             token => ValidateSymbol(token, '-'),
                             token => ValidateKeyword(token, "chown"),
                             token => ValidateSymbol(token, '='),
-                            token => ValidateAggregate<ChangeOwner>(token, "1:2",
+                            token => ValidateAggregate<UserAccount>(token, "1:2",
                                 token => ValidateLiteral(token, "1"),
                                 token => ValidateSymbol(token, ':'),
                                 token => ValidateLiteral(token, "2"))),
@@ -314,7 +314,7 @@ namespace DockerfileModel.Tests
                             token => ValidateSymbol(token, '-'),
                             token => ValidateKeyword(token, "chown"),
                             token => ValidateSymbol(token, '='),
-                            token => ValidateAggregate<ChangeOwner>(token, "1:2",
+                            token => ValidateAggregate<UserAccount>(token, "1:2",
                                 token => ValidateLiteral(token, "1"),
                                 token => ValidateSymbol(token, ':'),
                                 token => ValidateLiteral(token, "2"))),
@@ -360,7 +360,7 @@ namespace DockerfileModel.Tests
                             token => ValidateSymbol(token, '-'),
                             token => ValidateKeyword(token, "chown"),
                             token => ValidateSymbol(token, '='),
-                            token => ValidateAggregate<ChangeOwner>(token, "1:2",
+                            token => ValidateAggregate<UserAccount>(token, "1:2",
                                 token => ValidateLiteral(token, "1"),
                                 token => ValidateSymbol(token, ':'),
                                 token => ValidateLiteral(token, "2"))),
@@ -591,7 +591,7 @@ namespace DockerfileModel.Tests
                         "src2"
                     },
                     Destination = "dst",
-                    ChangeOwner = new ChangeOwner("user", "group"),
+                    ChangeOwner = new UserAccount("user", "group"),
                     TokenValidators = new Action<Token>[]
                     {
                         token => ValidateKeyword(token, instructionName),
@@ -601,7 +601,7 @@ namespace DockerfileModel.Tests
                             token => ValidateSymbol(token, '-'),
                             token => ValidateKeyword(token, "chown"),
                             token => ValidateSymbol(token, '='),
-                            token => ValidateAggregate<ChangeOwner>(token, "user:group",
+                            token => ValidateAggregate<UserAccount>(token, "user:group",
                                 token => ValidateLiteral(token, "user"),
                                 token => ValidateSymbol(token, ':'),
                                 token => ValidateLiteral(token, "group"))),
@@ -649,7 +649,7 @@ namespace DockerfileModel.Tests
                     },
                     Destination = "dst",
                     Permissions = "777",
-                    ChangeOwner = new ChangeOwner("user", "group"),
+                    ChangeOwner = new UserAccount("user", "group"),
                     TokenValidators = new Action<Token>[]
                     {
                         token => ValidateKeyword(token, instructionName),
@@ -659,7 +659,7 @@ namespace DockerfileModel.Tests
                             token => ValidateSymbol(token, '-'),
                             token => ValidateKeyword(token, "chown"),
                             token => ValidateSymbol(token, '='),
-                            token => ValidateAggregate<ChangeOwner>(token, "user:group",
+                            token => ValidateAggregate<UserAccount>(token, "user:group",
                                 token => ValidateLiteral(token, "user"),
                                 token => ValidateSymbol(token, ':'),
                                 token => ValidateLiteral(token, "group"))),
@@ -692,7 +692,7 @@ namespace DockerfileModel.Tests
         {
             public string Destination { get; set; }
             public IEnumerable<string> Sources { get; set; }
-            public ChangeOwner ChangeOwner { get; set; }
+            public UserAccount ChangeOwner { get; set; }
             public string Permissions { get; set; }
             public char EscapeChar { get; set; } = Dockerfile.DefaultEscapeChar;
         }

--- a/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/TokenBuilderTests.cs
@@ -39,7 +39,7 @@ namespace DockerfileModel.Tests
 
             Assert.Collection(builder.Tokens, new Action<Token>[]
             {
-                token => ValidateAggregate<ChangeOwner>(token, "user",
+                token => ValidateAggregate<UserAccount>(token, "user",
                     token => ValidateLiteral(token, "user")),
                 token => ValidateAggregate<CommentToken>(token, "#comment",
                     token => ValidateSymbol(token, '#'),

--- a/src/DockerfileModel/DockerfileModel.Tests/UserAccountTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/UserAccountTests.cs
@@ -9,15 +9,15 @@ using static DockerfileModel.Tests.TokenValidator;
 
 namespace DockerfileModel.Tests
 {
-    public class ChangeOwnerTests
+    public class UserAccountTests
     {
         [Theory]
         [MemberData(nameof(ParseTestInput))]
-        public void Parse(ChangeOwnerParseTestScenario scenario)
+        public void Parse(UserAccountParseTestScenario scenario)
         {
             if (scenario.ParseExceptionPosition is null)
             {
-                ChangeOwner result = ChangeOwner.Parse(scenario.Text, scenario.EscapeChar);
+                UserAccount result = UserAccount.Parse(scenario.Text, scenario.EscapeChar);
                 Assert.Equal(scenario.Text, result.ToString());
                 Assert.Collection(result.Tokens, scenario.TokenValidators);
                 scenario.Validate?.Invoke(result);
@@ -35,7 +35,7 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            ChangeOwner result = new ChangeOwner(scenario.User, scenario.Group);
+            UserAccount result = new UserAccount(scenario.User, scenario.Group);
             Assert.Collection(result.Tokens, scenario.TokenValidators);
             scenario.Validate?.Invoke(result);
         }
@@ -43,85 +43,85 @@ namespace DockerfileModel.Tests
         [Fact]
         public void User()
         {
-            ChangeOwner changeOwner = new ChangeOwner("test", "group");
-            Assert.Equal("test", changeOwner.User);
-            Assert.Equal("test", changeOwner.UserToken.Value);
+            UserAccount UserAccount = new UserAccount("test", "group");
+            Assert.Equal("test", UserAccount.User);
+            Assert.Equal("test", UserAccount.UserToken.Value);
 
-            changeOwner.User = "test2";
-            Assert.Equal("test2", changeOwner.User);
-            Assert.Equal("test2", changeOwner.UserToken.Value);
+            UserAccount.User = "test2";
+            Assert.Equal("test2", UserAccount.User);
+            Assert.Equal("test2", UserAccount.UserToken.Value);
 
-            changeOwner.UserToken.Value = "test3";
-            Assert.Equal("test3", changeOwner.User);
-            Assert.Equal("test3", changeOwner.UserToken.Value);
+            UserAccount.UserToken.Value = "test3";
+            Assert.Equal("test3", UserAccount.User);
+            Assert.Equal("test3", UserAccount.UserToken.Value);
 
-            changeOwner.UserToken = new LiteralToken("test4");
-            Assert.Equal("test4", changeOwner.User);
-            Assert.Equal("test4", changeOwner.UserToken.Value);
-            Assert.Equal("test4:group", changeOwner.ToString());
+            UserAccount.UserToken = new LiteralToken("test4");
+            Assert.Equal("test4", UserAccount.User);
+            Assert.Equal("test4", UserAccount.UserToken.Value);
+            Assert.Equal("test4:group", UserAccount.ToString());
 
-            Assert.Throws<ArgumentException>(() => changeOwner.User = "");
-            Assert.Throws<ArgumentNullException>(() => changeOwner.User = null);
-            Assert.Throws<ArgumentNullException>(() => changeOwner.UserToken = null);
+            Assert.Throws<ArgumentException>(() => UserAccount.User = "");
+            Assert.Throws<ArgumentNullException>(() => UserAccount.User = null);
+            Assert.Throws<ArgumentNullException>(() => UserAccount.UserToken = null);
         }
 
         [Fact]
         public void Group()
         {
-            ChangeOwner changeOwner = new ChangeOwner("user", "test");
-            Assert.Equal("test", changeOwner.Group);
-            Assert.Equal("test", changeOwner.GroupToken.Value);
+            UserAccount UserAccount = new UserAccount("user", "test");
+            Assert.Equal("test", UserAccount.Group);
+            Assert.Equal("test", UserAccount.GroupToken.Value);
 
-            changeOwner.Group = "test2";
-            Assert.Equal("test2", changeOwner.Group);
-            Assert.Equal("test2", changeOwner.GroupToken.Value);
+            UserAccount.Group = "test2";
+            Assert.Equal("test2", UserAccount.Group);
+            Assert.Equal("test2", UserAccount.GroupToken.Value);
 
-            changeOwner.GroupToken.Value = "test3";
-            Assert.Equal("test3", changeOwner.Group);
-            Assert.Equal("test3", changeOwner.GroupToken.Value);
+            UserAccount.GroupToken.Value = "test3";
+            Assert.Equal("test3", UserAccount.Group);
+            Assert.Equal("test3", UserAccount.GroupToken.Value);
 
-            changeOwner.Group = null;
-            Assert.Null(changeOwner.Group);
-            Assert.Null(changeOwner.GroupToken);
-            Assert.Equal("user", changeOwner.ToString());
+            UserAccount.Group = null;
+            Assert.Null(UserAccount.Group);
+            Assert.Null(UserAccount.GroupToken);
+            Assert.Equal("user", UserAccount.ToString());
 
-            changeOwner.GroupToken = new LiteralToken("test4");
-            Assert.Equal("test4", changeOwner.Group);
-            Assert.Equal("test4", changeOwner.GroupToken.Value);
-            Assert.Equal("user:test4", changeOwner.ToString());
+            UserAccount.GroupToken = new LiteralToken("test4");
+            Assert.Equal("test4", UserAccount.Group);
+            Assert.Equal("test4", UserAccount.GroupToken.Value);
+            Assert.Equal("user:test4", UserAccount.ToString());
 
-            changeOwner.GroupToken = null;
-            Assert.Null(changeOwner.Group);
-            Assert.Null(changeOwner.GroupToken);
-            Assert.Equal("user", changeOwner.ToString());
+            UserAccount.GroupToken = null;
+            Assert.Null(UserAccount.Group);
+            Assert.Null(UserAccount.GroupToken);
+            Assert.Equal("user", UserAccount.ToString());
 
-            changeOwner.Group = "";
-            Assert.Null(changeOwner.Group);
-            Assert.Null(changeOwner.GroupToken);
-            Assert.Equal("user", changeOwner.ToString());
+            UserAccount.Group = "";
+            Assert.Null(UserAccount.Group);
+            Assert.Null(UserAccount.GroupToken);
+            Assert.Equal("user", UserAccount.ToString());
         }
 
         [Fact]
         public void UserWithVariables()
         {
-            ChangeOwner changeOwner = new ChangeOwner("$var", "group");
+            UserAccount UserAccount = new UserAccount("$var", "group");
             TestHelper.TestVariablesWithLiteral(
-                () => changeOwner.UserToken, "var", canContainVariables: true);
+                () => UserAccount.UserToken, "var", canContainVariables: true);
         }
 
         [Fact]
         public void GroupWithVariables()
         {
-            ChangeOwner changeOwner = new ChangeOwner("user", "$var");
+            UserAccount UserAccount = new UserAccount("user", "$var");
             TestHelper.TestVariablesWithNullableLiteral(
-                () => changeOwner.GroupToken, token => changeOwner.GroupToken = token, val => changeOwner.Group = val, "var", canContainVariables: true);
+                () => UserAccount.GroupToken, token => UserAccount.GroupToken = token, val => UserAccount.Group = val, "var", canContainVariables: true);
         }
 
         public static IEnumerable<object[]> ParseTestInput()
         {
-            ChangeOwnerParseTestScenario[] testInputs = new ChangeOwnerParseTestScenario[]
+            UserAccountParseTestScenario[] testInputs = new UserAccountParseTestScenario[]
             {
-                new ChangeOwnerParseTestScenario
+                new UserAccountParseTestScenario
                 {
                     Text = "55:mygroup",
                     TokenValidators = new Action<Token>[]
@@ -136,7 +136,7 @@ namespace DockerfileModel.Tests
                         Assert.Equal("mygroup", result.Group);
                     }
                 },
-                new ChangeOwnerParseTestScenario
+                new UserAccountParseTestScenario
                 {
                     Text = "bin",
                     TokenValidators = new Action<Token>[]
@@ -149,7 +149,7 @@ namespace DockerfileModel.Tests
                         Assert.Null(result.Group);
                     }
                 },
-                new ChangeOwnerParseTestScenario
+                new UserAccountParseTestScenario
                 {
                     EscapeChar = '`',
                     Text = "us`\ner`\n:`\ngr`\noup",
@@ -176,7 +176,7 @@ namespace DockerfileModel.Tests
                         Assert.Equal("us`\ner`\n", result.ToString());
                     }
                 },
-                new ChangeOwnerParseTestScenario
+                new UserAccountParseTestScenario
                 {
                     Text = "$user:group$var",
                     TokenValidators = new Action<Token>[]
@@ -191,12 +191,12 @@ namespace DockerfileModel.Tests
                                 token => ValidateString(token, "var")))
                     }
                 },
-                new ChangeOwnerParseTestScenario
+                new UserAccountParseTestScenario
                 {
                     Text = "user:",
                     ParseExceptionPosition = new Position(1, 1, 1)
                 },
-                new ChangeOwnerParseTestScenario
+                new UserAccountParseTestScenario
                 {
                     Text = ":group",
                     ParseExceptionPosition = new Position(1, 1, 1)
@@ -245,12 +245,12 @@ namespace DockerfileModel.Tests
             return testInputs.Select(input => new object[] { input });
         }
 
-        public class ChangeOwnerParseTestScenario : ParseTestScenario<ChangeOwner>
+        public class UserAccountParseTestScenario : ParseTestScenario<UserAccount>
         {
             public char EscapeChar { get; set; }
         }
 
-        public class CreateTestScenario : TestScenario<ChangeOwner>
+        public class CreateTestScenario : TestScenario<UserAccount>
         {
             public string User { get; set; }
             public string Group { get; set; }

--- a/src/DockerfileModel/DockerfileModel/AddInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/AddInstruction.cs
@@ -10,7 +10,7 @@ namespace DockerfileModel
         private const string Name = "ADD";
 
         public AddInstruction(IEnumerable<string> sources, string destination,
-            ChangeOwner? changeOwner = null, string? permissions = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            UserAccount? changeOwner = null, string? permissions = null, char escapeChar = Dockerfile.DefaultEscapeChar)
             : base(sources, destination, changeOwner, permissions, escapeChar, Name)
         {
         }

--- a/src/DockerfileModel/DockerfileModel/ChangeOwnerFlag.cs
+++ b/src/DockerfileModel/DockerfileModel/ChangeOwnerFlag.cs
@@ -4,9 +4,9 @@ using Sprache;
 
 namespace DockerfileModel
 {
-    public class ChangeOwnerFlag : KeyValueToken<KeywordToken, ChangeOwner>
+    public class ChangeOwnerFlag : KeyValueToken<KeywordToken, UserAccount>
     {
-        public ChangeOwnerFlag(ChangeOwner changeOwner, char escapeChar = Dockerfile.DefaultEscapeChar)
+        public ChangeOwnerFlag(UserAccount changeOwner, char escapeChar = Dockerfile.DefaultEscapeChar)
             : base(new KeywordToken("chown", escapeChar), changeOwner, isFlag: true)
         {
         }
@@ -29,7 +29,7 @@ namespace DockerfileModel
                 tokens => new ChangeOwnerFlag(tokens),
                 escapeChar: escapeChar);
 
-        private static Parser<ChangeOwner> ChangeOwnerParser(char escapeChar) =>
-            ChangeOwner.GetParser(escapeChar);
+        private static Parser<UserAccount> ChangeOwnerParser(char escapeChar) =>
+            UserAccount.GetParser(escapeChar);
     }
 }

--- a/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/CopyInstruction.cs
@@ -11,7 +11,7 @@ namespace DockerfileModel
         private const string Name = "COPY";
 
         public CopyInstruction(IEnumerable<string> sources, string destination,
-            string? fromStageName = null, ChangeOwner? changeOwner = null, string? permissions = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+            string? fromStageName = null, UserAccount? changeOwner = null, string? permissions = null, char escapeChar = Dockerfile.DefaultEscapeChar)
             : base(GetTokens(sources, destination, fromStageName, changeOwner, permissions, escapeChar), escapeChar)
         {
         }
@@ -52,7 +52,7 @@ namespace DockerfileModel
                 ArgTokens(FromFlag.GetParser(escapeChar).AsEnumerable(), escapeChar));
 
         private static IEnumerable<Token> GetTokens(IEnumerable<string> sources, string destination,
-           string? fromStageName, ChangeOwner? changeOwner, string? permissions, char escapeChar)
+           string? fromStageName, UserAccount? changeOwner, string? permissions, char escapeChar)
         {
             string fromFlag = fromStageName is null ? "" : new FromFlag(fromStageName, escapeChar).ToString() + " ";
             string text = CreateInstructionString(sources, destination, changeOwner, permissions, escapeChar, Name, fromFlag);

--- a/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
@@ -40,7 +40,7 @@ namespace DockerfileModel
         public DockerfileBuilder NewLine() =>
             AddConstruct(new Whitespace(DefaultNewLine));
 
-        public DockerfileBuilder AddInstruction(IEnumerable<string> sources, string destination, ChangeOwner? changeOwnerFlag = null,
+        public DockerfileBuilder AddInstruction(IEnumerable<string> sources, string destination, UserAccount? changeOwnerFlag = null,
             string? permissions = null) =>
             AddConstruct(new AddInstruction(sources, destination, changeOwnerFlag, permissions, EscapeChar));
 
@@ -75,7 +75,7 @@ namespace DockerfileModel
             ParseTokens(configureBuilder, DockerfileModel.Comment.Parse);
 
         public DockerfileBuilder CopyInstruction(IEnumerable<string> sources, string destination,
-            string? fromStageName = null, ChangeOwner? changeOwner = null, string? permissions = null) =>
+            string? fromStageName = null, UserAccount? changeOwner = null, string? permissions = null) =>
             AddConstruct(new CopyInstruction(sources, destination, fromStageName, changeOwner, permissions, EscapeChar));
 
         public DockerfileBuilder CopyInstruction(Action<TokenBuilder> configureBuilder) =>

--- a/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
@@ -14,7 +14,7 @@ namespace DockerfileModel
         private readonly TokenList<LiteralToken> sourceTokens;
 
         protected FileTransferInstruction(IEnumerable<string> sources, string destination,
-           ChangeOwner? changeOwner, string? permissions, char escapeChar, string instructionName)
+           UserAccount? changeOwner, string? permissions, char escapeChar, string instructionName)
             : this(GetTokens(sources, destination, changeOwner, permissions, escapeChar, instructionName), escapeChar)
         {
         }
@@ -56,7 +56,7 @@ namespace DockerfileModel
             }
         }
 
-        public ChangeOwner? ChangeOwner
+        public UserAccount? ChangeOwner
         {
             get => ChangeOwnerFlagToken?.ValueToken;
             set
@@ -105,14 +105,14 @@ namespace DockerfileModel
             Instruction(instructionName, escapeChar, GetArgsParser(escapeChar, optionalFlagParser));
 
         private static IEnumerable<Token> GetTokens(IEnumerable<string> sources, string destination,
-           ChangeOwner? changeOwner, string? permissions, char escapeChar, string instructionName)
+           UserAccount? changeOwner, string? permissions, char escapeChar, string instructionName)
         {
             string text = CreateInstructionString(sources, destination, changeOwner, permissions, escapeChar, instructionName, null);
             return GetTokens(text, GetInnerParser(escapeChar, instructionName));
         }
 
         protected static string CreateInstructionString(IEnumerable<string> sources, string destination,
-           ChangeOwner? changeOwner, string? permissions, char escapeChar, string instructionName, string? optionalFlag)
+           UserAccount? changeOwner, string? permissions, char escapeChar, string instructionName, string? optionalFlag)
         {
             Requires.NotNullEmptyOrNullElements(sources, nameof(sources));
             Requires.NotNullOrEmpty(destination, nameof(destination));

--- a/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/Tokens/TokenBuilder.cs
@@ -13,7 +13,7 @@ namespace DockerfileModel.Tokens
         public IList<Token> Tokens { get; } = new List<Token>();
 
         public TokenBuilder ChangeOwner(string user, string? group = null) =>
-            AddToken(new ChangeOwner(user, group, EscapeChar));
+            AddToken(new UserAccount(user, group, EscapeChar));
 
         public TokenBuilder Comment(string comment) =>
             AddToken(new CommentToken(comment));

--- a/src/DockerfileModel/DockerfileModel/UserAccount.cs
+++ b/src/DockerfileModel/DockerfileModel/UserAccount.cs
@@ -8,16 +8,16 @@ using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel
 {
-    public class ChangeOwner : AggregateToken
+    public class UserAccount : AggregateToken
     {
         private readonly char escapeChar;
 
-        public ChangeOwner(string user, string? group = null, char escapeChar = Dockerfile.DefaultEscapeChar)
+        public UserAccount(string user, string? group = null, char escapeChar = Dockerfile.DefaultEscapeChar)
             : this(GetTokens(user, group, escapeChar), escapeChar)
         {
         }
 
-        internal ChangeOwner(IEnumerable<Token> tokens, char escapeChar)
+        internal UserAccount(IEnumerable<Token> tokens, char escapeChar)
             : base(tokens)
         {
             this.escapeChar = escapeChar;
@@ -69,12 +69,12 @@ namespace DockerfileModel
             }
         }
 
-        public static ChangeOwner Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            new ChangeOwner(GetTokens(text, GetInnerParser(escapeChar)), escapeChar);
+        public static UserAccount Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            new UserAccount(GetTokens(text, GetInnerParser(escapeChar)), escapeChar);
 
-        public static Parser<ChangeOwner> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+        public static Parser<UserAccount> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
             from tokens in GetInnerParser(escapeChar)
-            select new ChangeOwner(tokens, escapeChar);
+            select new UserAccount(tokens, escapeChar);
 
         private static IEnumerable<Token> GetTokens(string user, string? group, char escapeChar)
         {

--- a/src/DockerfileModel/DockerfileModel/UserInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/UserInstruction.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DockerfileModel.Tokens;
+using Sprache;
+using Validation;
+using static DockerfileModel.ParseHelper;
+
+namespace DockerfileModel
+{
+    public class UserInstruction : Instruction
+    {
+        public UserInstruction(string maintainer, char escapeChar = Dockerfile.DefaultEscapeChar)
+            : this(GetTokens(maintainer, escapeChar))
+        {
+        }
+
+        private UserInstruction(IEnumerable<Token> tokens) : base(tokens)
+        {
+        }
+
+        public string Maintainer
+        {
+            get => MaintainerToken.Value;
+            set
+            {
+                Requires.NotNull(value, nameof(value));
+                MaintainerToken.Value = value;
+            }
+        }
+
+        public LiteralToken MaintainerToken
+        {
+            get => Tokens.OfType<LiteralToken>().First();
+            set
+            {
+                Requires.NotNull(value, nameof(value));
+                SetToken(MaintainerToken, value);
+            }
+        }
+   
+        public static UserInstruction Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            new UserInstruction(GetTokens(text, GetInnerParser(escapeChar)));
+
+        public static Parser<UserInstruction> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            from tokens in GetInnerParser(escapeChar)
+            select new UserInstruction(tokens);
+
+        private static IEnumerable<Token> GetTokens(string maintainer, char escapeChar)
+        {
+            Requires.NotNull(maintainer, nameof(maintainer));
+            return GetTokens($"MAINTAINER {(String.IsNullOrEmpty(maintainer) ? "\"\"" : maintainer)}", GetInnerParser(escapeChar));
+        }
+
+        private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            Instruction("MAINTAINER", escapeChar, GetArgsParser(escapeChar));
+
+        private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
+            ArgTokens(
+                LiteralWithVariables(
+                    escapeChar, whitespaceMode: WhitespaceMode.Allowed).AsEnumerable(), escapeChar, excludeTrailingWhitespace: true);
+    }
+}


### PR DESCRIPTION
Renames the `ChangeOwner` class to `UserAccount` since that's really what it represents, just a user and optional group.  The new name makes it more general purpose so that it can be used to support the `USER` instruction.