### PR TITLE
Expose IList of exec-form command value tokens

### DIFF
--- a/src/DockerfileModel/DockerfileModel/ExecFormCommand.cs
+++ b/src/DockerfileModel/DockerfileModel/ExecFormCommand.cs
@@ -16,6 +16,11 @@ namespace DockerfileModel
 
         internal ExecFormCommand(IEnumerable<Token> tokens) : base(tokens)
         {
+            ValueTokens = new TokenList<LiteralToken>(TokenList);
+            Values = new ProjectedItemList<LiteralToken, string>(
+                ValueTokens,
+                token => token.Value,
+                (token, value) => token.Value = value);
         }
 
         private static IEnumerable<Token> GetTokens(IEnumerable<string> values, char escapeChar)
@@ -31,13 +36,9 @@ namespace DockerfileModel
             from tokens in GetInnerParser(escapeChar)
             select new ExecFormCommand(tokens);
 
-        public IList<string> Values =>
-            new ProjectedItemList<LiteralToken, string>(
-                ValueTokens,
-                token => token.Value,
-                (token, value) => token.Value = value);
+        public IList<string> Values { get; }
 
-        public IEnumerable<LiteralToken> ValueTokens => Tokens.OfType<LiteralToken>();
+        public IList<LiteralToken> ValueTokens { get; }
 
         public override CommandType CommandType => CommandType.ExecForm;
 

--- a/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/FileTransferInstruction.cs
@@ -11,8 +11,6 @@ namespace DockerfileModel
 {
     public abstract class FileTransferInstruction : Instruction
     {
-        private readonly TokenList<LiteralToken> sourceTokens;
-
         protected FileTransferInstruction(IEnumerable<string> sources, string destination,
            UserAccount? changeOwner, string? permissions, char escapeChar, string instructionName)
             : this(GetTokens(sources, destination, changeOwner, permissions, escapeChar, instructionName), escapeChar)
@@ -21,20 +19,20 @@ namespace DockerfileModel
 
         protected FileTransferInstruction(IEnumerable<Token> tokens, char escapeChar) : base(tokens)
         {
-            this.sourceTokens = new TokenList<LiteralToken>(TokenList,
+            SourceTokens = new TokenList<LiteralToken>(TokenList,
                 literals => literals.Take(literals.Count() - 1));
+            Sources = new ProjectedItemList<LiteralToken, string>(
+                SourceTokens,
+                token => token.Value,
+                (token, value) => token.Value = value);
             EscapeChar = escapeChar;
         }
 
         protected char EscapeChar { get; }
 
-        public IList<string> Sources =>
-            new ProjectedItemList<LiteralToken, string>(
-                SourceTokens,
-                token => token.Value,
-                (token, value) => token.Value = value);
+        public IList<string> Sources { get; }
 
-        public IList<LiteralToken> SourceTokens => sourceTokens;
+        public IList<LiteralToken> SourceTokens { get; }
 
         public string Destination
         {

--- a/src/DockerfileModel/DockerfileModel/GenericInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/GenericInstruction.cs
@@ -19,13 +19,13 @@ namespace DockerfileModel
         private GenericInstruction(IEnumerable<Token> tokens)
             : base(tokens)
         {
-        }
-
-        public IList<string> ArgLines =>
-            new ProjectedItemList<LiteralToken, string>(
+            ArgLines = new ProjectedItemList<LiteralToken, string>(
                 Tokens.OfType<LiteralToken>(),
                 token => token.Value,
                 (token, value) => token.Value = value);
+        }
+
+        public IList<string> ArgLines { get; }
 
         public static GenericInstruction Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             new GenericInstruction(GetTokens(text, GetInnerParser(escapeChar)));

--- a/src/DockerfileModel/DockerfileModel/RunInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/RunInstruction.cs
@@ -10,8 +10,6 @@ namespace DockerfileModel
 {
     public class RunInstruction : Instruction
     {
-        private readonly ProjectedItemList<MountFlag, Mount> mounts;
-
         public RunInstruction(string commandWithArgs, char escapeChar = Dockerfile.DefaultEscapeChar)
             : this(commandWithArgs, Enumerable.Empty<Mount>(), escapeChar)
         {
@@ -34,7 +32,7 @@ namespace DockerfileModel
 
         private RunInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
-            this.mounts = new ProjectedItemList<MountFlag, Mount>(
+            Mounts = new ProjectedItemList<MountFlag, Mount>(
                 new TokenList<MountFlag>(TokenList),
                 flag => flag.ValueToken,
                 (flag, mount) => flag.ValueToken = mount);
@@ -50,7 +48,7 @@ namespace DockerfileModel
             }
         }
 
-        public IList<Mount> Mounts => this.mounts;
+        public IList<Mount> Mounts { get; }
 
         public static RunInstruction Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
             new RunInstruction(GetTokens(text, GetInnerParser(escapeChar)));


### PR DESCRIPTION
`ExecFormCommand` was only exposing its value tokens as `IEnumerable` when it should be `IList` to allow for modification.