### PR TITLE
Rename class for CMD instruction

### DIFF
--- a/src/DockerfileModel/DockerfileModel.Tests/CmdInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/CmdInstructionTests.cs
@@ -9,15 +9,15 @@ using static DockerfileModel.Tests.TokenValidator;
 
 namespace DockerfileModel.Tests
 {
-    public class CommandInstructionTests
+    public class CmdInstructionTests
     {
         [Theory]
         [MemberData(nameof(ParseTestInput))]
-        public void Parse(CommandInstructionParseTestScenario scenario)
+        public void Parse(CmdInstructionParseTestScenario scenario)
         {
             if (scenario.ParseExceptionPosition is null)
             {
-                CommandInstruction result = CommandInstruction.Parse(scenario.Text, scenario.EscapeChar);
+                CmdInstruction result = CmdInstruction.Parse(scenario.Text, scenario.EscapeChar);
                 Assert.Equal(scenario.Text, result.ToString());
                 Assert.Collection(result.Tokens, scenario.TokenValidators);
                 scenario.Validate?.Invoke(result);
@@ -25,7 +25,7 @@ namespace DockerfileModel.Tests
             else
             {
                 ParseException exception = Assert.Throws<ParseException>(
-                    () => CommandInstruction.Parse(scenario.Text, scenario.EscapeChar));
+                    () => CmdInstruction.Parse(scenario.Text, scenario.EscapeChar));
                 Assert.Equal(scenario.ParseExceptionPosition.Line, exception.Position.Line);
                 Assert.Equal(scenario.ParseExceptionPosition.Column, exception.Position.Column);
             }
@@ -35,14 +35,14 @@ namespace DockerfileModel.Tests
         [MemberData(nameof(CreateTestInput))]
         public void Create(CreateTestScenario scenario)
         {
-            CommandInstruction result;
+            CmdInstruction result;
             if (scenario.Command != null)
             {
-                result = new CommandInstruction(scenario.Command);
+                result = new CmdInstruction(scenario.Command);
             }
             else
             {
-                result = new CommandInstruction(scenario.Commands);
+                result = new CmdInstruction(scenario.Commands);
             }
 
             Assert.Collection(result.Tokens, scenario.TokenValidators);
@@ -51,9 +51,9 @@ namespace DockerfileModel.Tests
 
         public static IEnumerable<object[]> ParseTestInput()
         {
-            CommandInstructionParseTestScenario[] testInputs = new CommandInstructionParseTestScenario[]
+            CmdInstructionParseTestScenario[] testInputs = new CmdInstructionParseTestScenario[]
             {
-                new CommandInstructionParseTestScenario
+                new CmdInstructionParseTestScenario
                 {
                     Text = "CMD echo hello",
                     TokenValidators = new Action<Token>[]
@@ -74,7 +74,7 @@ namespace DockerfileModel.Tests
                         Assert.Equal("echo hello", cmd.Value);
                     }
                 },
-                new CommandInstructionParseTestScenario
+                new CmdInstructionParseTestScenario
                 {
                     Text = "CMD $TEST",
                     TokenValidators = new Action<Token>[]
@@ -85,7 +85,7 @@ namespace DockerfileModel.Tests
                             token => ValidateLiteral(token, "$TEST"))
                     }
                 },
-                new CommandInstructionParseTestScenario
+                new CmdInstructionParseTestScenario
                 {
                     Text = "CMD echo $TEST",
                     TokenValidators = new Action<Token>[]
@@ -96,7 +96,7 @@ namespace DockerfileModel.Tests
                             token => ValidateLiteral(token, "echo $TEST"))
                     }
                 },
-                new CommandInstructionParseTestScenario
+                new CmdInstructionParseTestScenario
                 {
                     Text = "CMD T\\$EST",
                     TokenValidators = new Action<Token>[]
@@ -107,7 +107,7 @@ namespace DockerfileModel.Tests
                             token => ValidateLiteral(token, "T\\$EST"))
                     }
                 },
-                new CommandInstructionParseTestScenario
+                new CmdInstructionParseTestScenario
                 {
                     Text = "CMD echo `\n#test comment\nhello",
                     EscapeChar = '`',
@@ -139,7 +139,7 @@ namespace DockerfileModel.Tests
                         Assert.Equal("echo hello", cmd.Value);
                     }
                 },
-                new CommandInstructionParseTestScenario
+                new CmdInstructionParseTestScenario
                 {
                     Text = "CMD [\"/bin/bash\", \"-c\", \"echo hello\"]",
                     TokenValidators = new Action<Token>[]
@@ -224,12 +224,12 @@ namespace DockerfileModel.Tests
             return testInputs.Select(input => new object[] { input });
         }
 
-        public class CommandInstructionParseTestScenario : ParseTestScenario<CommandInstruction>
+        public class CmdInstructionParseTestScenario : ParseTestScenario<CmdInstruction>
         {
             public char EscapeChar { get; set; }
         }
 
-        public class CreateTestScenario : TestScenario<CommandInstruction>
+        public class CreateTestScenario : TestScenario<CmdInstruction>
         {
             public string Command { get; set; }
             public IEnumerable<string> Commands { get; set; }

--- a/src/DockerfileModel/DockerfileModel.Tests/DockerfileBuilderTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/DockerfileBuilderTests.cs
@@ -21,7 +21,7 @@ namespace DockerfileModel.Tests
             builder
                 .AddInstruction(new string[] { "src" }, "dst")
                 .ArgInstruction("ARG", "value")
-                .CommandInstruction("echo hello")
+                .CmdInstruction("echo hello")
                 .Comment("my comment")
                 .CopyInstruction(new string[] { "src" }, "dst")
                 .EntrypointInstruction("cmd")

--- a/src/DockerfileModel/DockerfileModel.Tests/DockerfileTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/DockerfileTests.cs
@@ -687,7 +687,7 @@ namespace DockerfileModel.Tests
                     Text = $"CMD echo hello",
                     TokenValidators = new Action<Token>[]
                     {
-                        line => ValidateAggregate<CommandInstruction>(line, "CMD echo hello", new Action<Token>[]
+                        line => ValidateAggregate<CmdInstruction>(line, "CMD echo hello", new Action<Token>[]
                         {
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),

--- a/src/DockerfileModel/DockerfileModel.Tests/HealthCheckInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/HealthCheckInstructionTests.cs
@@ -231,13 +231,13 @@ namespace DockerfileModel.Tests
             HealthCheckInstruction instruction = new HealthCheckInstruction("command1");
             Assert.Equal("HEALTHCHECK CMD command1", instruction.ToString());
 
-            instruction.CommandInstruction = new CommandInstruction(new string[] { "command", "arg" });
+            instruction.CmdInstruction = new CmdInstruction(new string[] { "command", "arg" });
             Assert.Equal("HEALTHCHECK CMD [\"command\", \"arg\"]", instruction.ToString());
 
-            instruction.CommandInstruction = null;
+            instruction.CmdInstruction = null;
             Assert.Equal("HEALTHCHECK NONE", instruction.ToString());
 
-            instruction.CommandInstruction = new CommandInstruction("cmd");
+            instruction.CmdInstruction = new CmdInstruction("cmd");
             Assert.Equal("HEALTHCHECK CMD cmd", instruction.ToString());
         }
 
@@ -258,7 +258,7 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Empty(result.Comments);
                         Assert.Equal("HEALTHCHECK", result.InstructionName);
-                        Assert.Null(result.CommandInstruction);
+                        Assert.Null(result.CmdInstruction);
                     }
                 },
                 new HealthCheckInstructionParseTestScenario
@@ -268,7 +268,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "HEALTHCHECK"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<CommandInstruction>(token, "CMD /bin/check-running",
+                        token => ValidateAggregate<CmdInstruction>(token, "CMD /bin/check-running",
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateAggregate<ShellFormCommand>(token, "/bin/check-running",
@@ -278,8 +278,8 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Empty(result.Comments);
                         Assert.Equal("HEALTHCHECK", result.InstructionName);
-                        Assert.IsType<ShellFormCommand>(result.CommandInstruction.Command);
-                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CommandInstruction.Command).Value);
+                        Assert.IsType<ShellFormCommand>(result.CmdInstruction.Command);
+                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CmdInstruction.Command).Value);
                     }
                 },
                 new HealthCheckInstructionParseTestScenario
@@ -291,7 +291,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyValueFlag<StartPeriodFlag>(token, "start-period", "10s"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<CommandInstruction>(token, "CMD /bin/check-running",
+                        token => ValidateAggregate<CmdInstruction>(token, "CMD /bin/check-running",
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateAggregate<ShellFormCommand>(token, "/bin/check-running",
@@ -301,8 +301,8 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Empty(result.Comments);
                         Assert.Equal("HEALTHCHECK", result.InstructionName);
-                        Assert.IsType<ShellFormCommand>(result.CommandInstruction.Command);
-                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CommandInstruction.Command).Value);
+                        Assert.IsType<ShellFormCommand>(result.CmdInstruction.Command);
+                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CmdInstruction.Command).Value);
                         Assert.Equal("10s", result.StartPeriod);
                     }
                 },
@@ -321,7 +321,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyValueFlag<TimeoutFlag>(token, "timeout", "1h"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<CommandInstruction>(token, "CMD /bin/check-running",
+                        token => ValidateAggregate<CmdInstruction>(token, "CMD /bin/check-running",
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateAggregate<ShellFormCommand>(token, "/bin/check-running",
@@ -331,8 +331,8 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Empty(result.Comments);
                         Assert.Equal("HEALTHCHECK", result.InstructionName);
-                        Assert.IsType<ShellFormCommand>(result.CommandInstruction.Command);
-                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CommandInstruction.Command).Value);
+                        Assert.IsType<ShellFormCommand>(result.CmdInstruction.Command);
+                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CmdInstruction.Command).Value);
                         Assert.Equal("10s", result.StartPeriod);
                         Assert.Equal("5", result.Retries);
                         Assert.Equal("1m", result.Interval);
@@ -351,7 +351,7 @@ namespace DockerfileModel.Tests
                         token => ValidateKeyValueFlag<StartPeriodFlag>(token, "start-period", "10s"),
                         token => ValidateWhitespace(token, " "),
                         token => ValidateLineContinuation(token, '`', "\n"),
-                        token => ValidateAggregate<CommandInstruction>(token, "CMD /bin/check-running",
+                        token => ValidateAggregate<CmdInstruction>(token, "CMD /bin/check-running",
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateAggregate<ShellFormCommand>(token, "/bin/check-running",
@@ -361,8 +361,8 @@ namespace DockerfileModel.Tests
                     {
                         Assert.Empty(result.Comments);
                         Assert.Equal("HEALTHCHECK", result.InstructionName);
-                        Assert.IsType<ShellFormCommand>(result.CommandInstruction.Command);
-                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CommandInstruction.Command).Value);
+                        Assert.IsType<ShellFormCommand>(result.CmdInstruction.Command);
+                        Assert.Equal("/bin/check-running", ((ShellFormCommand)result.CmdInstruction.Command).Value);
                         Assert.Equal("10s", result.StartPeriod);
                     }
                 },
@@ -391,7 +391,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "HEALTHCHECK"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<CommandInstruction>(token, "CMD /bin/check-running",
+                        token => ValidateAggregate<CmdInstruction>(token, "CMD /bin/check-running",
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateAggregate<ShellFormCommand>(token, "/bin/check-running",
@@ -409,7 +409,7 @@ namespace DockerfileModel.Tests
                     {
                         token => ValidateKeyword(token, "HEALTHCHECK"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<CommandInstruction>(token, "CMD [\"/bin/check-running\", \"-f\"]",
+                        token => ValidateAggregate<CmdInstruction>(token, "CMD [\"/bin/check-running\", \"-f\"]",
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateAggregate<ExecFormCommand>(token, "[\"/bin/check-running\", \"-f\"]",
@@ -440,7 +440,7 @@ namespace DockerfileModel.Tests
                         token => ValidateWhitespace(token, " "),
                         token => ValidateKeyValueFlag<RetriesFlag>(token, "retries", "10"),
                         token => ValidateWhitespace(token, " "),
-                        token => ValidateAggregate<CommandInstruction>(token, "CMD /bin/check-running",
+                        token => ValidateAggregate<CmdInstruction>(token, "CMD /bin/check-running",
                             token => ValidateKeyword(token, "CMD"),
                             token => ValidateWhitespace(token, " "),
                             token => ValidateAggregate<ShellFormCommand>(token, "/bin/check-running",

--- a/src/DockerfileModel/DockerfileModel.Tests/OnBuildInstructionTests.cs
+++ b/src/DockerfileModel/DockerfileModel.Tests/OnBuildInstructionTests.cs
@@ -44,7 +44,7 @@ namespace DockerfileModel.Tests
         [Fact]
         public void Instruction()
         {
-            OnBuildInstruction result = new OnBuildInstruction(new CommandInstruction("test"));
+            OnBuildInstruction result = new OnBuildInstruction(new CmdInstruction("test"));
             Assert.Equal("CMD test", result.Instruction.ToString());
             Assert.Equal("ONBUILD CMD test", result.ToString());
 

--- a/src/DockerfileModel/DockerfileModel/CmdInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/CmdInstruction.cs
@@ -7,24 +7,24 @@ using static DockerfileModel.ParseHelper;
 
 namespace DockerfileModel
 {
-    public class CommandInstruction : Instruction
+    public class CmdInstruction : Instruction
     {
-        public CommandInstruction(string commandWithArgs, char escapeChar = Dockerfile.DefaultEscapeChar)
+        public CmdInstruction(string commandWithArgs, char escapeChar = Dockerfile.DefaultEscapeChar)
             : this(GetTokens(commandWithArgs, escapeChar))
         {
         }
 
-        public CommandInstruction(IEnumerable<string> defaultArgs, char escapeChar = Dockerfile.DefaultEscapeChar)
+        public CmdInstruction(IEnumerable<string> defaultArgs, char escapeChar = Dockerfile.DefaultEscapeChar)
             : this(GetTokens(defaultArgs, escapeChar))
         {
         }
 
-        public CommandInstruction(string command, IEnumerable<string> args, char escapeChar = Dockerfile.DefaultEscapeChar)
+        public CmdInstruction(string command, IEnumerable<string> args, char escapeChar = Dockerfile.DefaultEscapeChar)
             : this(GetTokens(command, args, escapeChar))
         {
         }
 
-        private CommandInstruction(IEnumerable<Token> tokens) : base(tokens)
+        private CmdInstruction(IEnumerable<Token> tokens) : base(tokens)
         {
         }
 
@@ -38,12 +38,12 @@ namespace DockerfileModel
             }
         }
 
-        public static CommandInstruction Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-            new CommandInstruction(GetTokens(text, GetInnerParser(escapeChar)));
+        public static CmdInstruction Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
+            new CmdInstruction(GetTokens(text, GetInnerParser(escapeChar)));
 
-        public static Parser<CommandInstruction> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+        public static Parser<CmdInstruction> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
             from tokens in GetInnerParser(escapeChar)
-            select new CommandInstruction(tokens);
+            select new CmdInstruction(tokens);
 
         public override string? ResolveVariables(char escapeChar, IDictionary<string, string?>? variables = null, ResolutionOptions? options = null)
         {

--- a/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
+++ b/src/DockerfileModel/DockerfileModel/DockerfileBuilder.cs
@@ -56,17 +56,17 @@ namespace DockerfileModel
         public DockerfileBuilder ArgInstruction(Action<TokenBuilder> configureBuilder) =>
             ParseTokens(configureBuilder, DockerfileModel.ArgInstruction.Parse);
 
-        public DockerfileBuilder CommandInstruction(string command) =>
-            AddConstruct(new CommandInstruction(command, EscapeChar));
+        public DockerfileBuilder CmdInstruction(string command) =>
+            AddConstruct(new CmdInstruction(command, EscapeChar));
 
-        public DockerfileBuilder CommandInstruction(IEnumerable<string> defaultArgs) =>
-            AddConstruct(new CommandInstruction(defaultArgs, EscapeChar));
+        public DockerfileBuilder CmdInstruction(IEnumerable<string> defaultArgs) =>
+            AddConstruct(new CmdInstruction(defaultArgs, EscapeChar));
 
-        public DockerfileBuilder CommandInstruction(string command, IEnumerable<string> args) =>
-            AddConstruct(new CommandInstruction(command, args, EscapeChar));
+        public DockerfileBuilder CmdInstruction(string command, IEnumerable<string> args) =>
+            AddConstruct(new CmdInstruction(command, args, EscapeChar));
 
-        public DockerfileBuilder CommandInstruction(Action<TokenBuilder> configureBuilder) =>
-            ParseTokens(configureBuilder, DockerfileModel.CommandInstruction.Parse);
+        public DockerfileBuilder CmdInstruction(Action<TokenBuilder> configureBuilder) =>
+            ParseTokens(configureBuilder, DockerfileModel.CmdInstruction.Parse);
 
         public DockerfileBuilder Comment(string comment) =>
             AddConstruct(new Comment(CommentSeparator + comment));

--- a/src/DockerfileModel/DockerfileModel/HealthCheckInstruction.cs
+++ b/src/DockerfileModel/DockerfileModel/HealthCheckInstruction.cs
@@ -14,19 +14,19 @@ namespace DockerfileModel
 
         public HealthCheckInstruction(string commandWithArgs, string? interval = null, string? timeout = null,
             string? startPeriod = null, string? retries = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : this(GetTokens(new CommandInstruction(commandWithArgs), interval, timeout, startPeriod, retries, escapeChar), escapeChar)
+            : this(GetTokens(new CmdInstruction(commandWithArgs), interval, timeout, startPeriod, retries, escapeChar), escapeChar)
         {
         }
 
         public HealthCheckInstruction(IEnumerable<string> defaultArgs, string? interval = null, string? timeout = null,
             string? startPeriod = null, string? retries = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : this(GetTokens(new CommandInstruction(defaultArgs), interval, timeout, startPeriod, retries, escapeChar), escapeChar)
+            : this(GetTokens(new CmdInstruction(defaultArgs), interval, timeout, startPeriod, retries, escapeChar), escapeChar)
         {
         }
 
         public HealthCheckInstruction(string command, IEnumerable<string> args, string? interval = null, string? timeout = null,
             string? startPeriod = null, string? retries = null, char escapeChar = Dockerfile.DefaultEscapeChar)
-            : this(GetTokens(new CommandInstruction(command, args), interval, timeout, startPeriod, retries, escapeChar), escapeChar)
+            : this(GetTokens(new CmdInstruction(command, args), interval, timeout, startPeriod, retries, escapeChar), escapeChar)
         {
         }
 
@@ -122,12 +122,12 @@ namespace DockerfileModel
             set => SetOptionalFlagToken(RetriesFlag, value);
         }
 
-        public CommandInstruction? CommandInstruction
+        public CmdInstruction? CmdInstruction
         {
-            get => Tokens.OfType<CommandInstruction>().FirstOrDefault();
+            get => Tokens.OfType<CmdInstruction>().FirstOrDefault();
             set
             {
-                SetToken(CommandInstruction, value,
+                SetToken(CmdInstruction, value,
                     addToken: token =>
                     {
                         // Replace the existing NONE keyword
@@ -150,7 +150,7 @@ namespace DockerfileModel
             from tokens in GetInnerParser(escapeChar)
             select new HealthCheckInstruction(tokens, escapeChar);
 
-        private static IEnumerable<Token> GetTokens(CommandInstruction commandInstruction, string? interval, string? timeout,
+        private static IEnumerable<Token> GetTokens(CmdInstruction commandInstruction, string? interval, string? timeout,
             string? startPeriod, string? retries, char escapeChar)
         {
             Requires.NotNull(commandInstruction, nameof(commandInstruction));
@@ -187,7 +187,7 @@ namespace DockerfileModel
 
         private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
             from options in Options(escapeChar)
-            from command in ArgTokens(CommandInstruction.GetParser(escapeChar).AsEnumerable(), escapeChar)
+            from command in ArgTokens(CmdInstruction.GetParser(escapeChar).AsEnumerable(), escapeChar)
                 .Or(ArgTokens(KeywordToken.GetParser("NONE", escapeChar).AsEnumerable(), escapeChar))
             select ConcatTokens(options, command);
 

--- a/src/DockerfileModel/DockerfileModel/Instruction.cs
+++ b/src/DockerfileModel/DockerfileModel/Instruction.cs
@@ -14,7 +14,7 @@ namespace DockerfileModel
             {
                 { "ADD", AddInstruction.Parse },
                 { "ARG", ArgInstruction.Parse },
-                { "CMD", CommandInstruction.Parse },
+                { "CMD", CmdInstruction.Parse },
                 { "COPY", CopyInstruction.Parse },
                 { "ENTRYPOINT", EntrypointInstruction.Parse },
                 { "EXPOSE", ExposeInstruction.Parse },


### PR DESCRIPTION
Renames `CommandInstruction` to `CmdInstruction` to follow the convention of using the actual instruction name in the class name even if it's abbreviated.