### PR TITLE
Allow port to be parsed in image name

### DIFF
--- a/src/Valleysoft.DockerfileModel.Tests/ImageNameTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ImageNameTests.cs
@@ -15,6 +15,8 @@ namespace Valleysoft.DockerfileModel.Tests
         [InlineData("repo1@" + TestSha, null, "repo1", null, TestSha)]
         [InlineData("docker.io/library/image@" + TestSha, "docker.io", "library/image", null, TestSha)]
         [InlineData("my-registry.com/r_e-po1:tag.1", "my-registry.com", "r_e-po1", "tag.1", null)]
+        [InlineData("host:80/repo:tag1", "host:80", "repo", "tag1", null)]
+        [InlineData("host.com:80/repo:tag1", "host.com:80", "repo", "tag1", null)]
         public void Parse(string input, string expectedRegistry, string expectedRepository, string expectedTag, string expectedDigest)
         {
             ImageName result = ImageName.Parse(input);

--- a/src/Valleysoft.DockerfileModel/ImageName.cs
+++ b/src/Valleysoft.DockerfileModel/ImageName.cs
@@ -407,9 +407,16 @@ namespace Valleysoft.DockerfileModel
                     DelimitedIdentifier(
                         escapeChar,
                         FirstCharParser(),
-                        TailCharParser(),
+                        TailCharParser().Or(Sprache.Parse.Char(':')),
                         '.',
-                        minimumDelimiters: 1);
+                        minimumDelimiters: 1)
+                    .Or(
+                        DelimitedIdentifier(
+                            escapeChar,
+                            FirstCharParser(),
+                            TailCharParser().Or(Sprache.Parse.Char('.')),
+                            ':',
+                            minimumDelimiters: 1));
 
                 private static Parser<char> FirstCharParser() => Sprache.Parse.LetterOrDigit;
 


### PR DESCRIPTION
The registry portion of an image name can contain `:` to designate a port.  This variation needs to be handled in the parser for `ImageName`.