### PR TITLE
Fix ENV instruction parsing

### DIFF
--- a/src/Valleysoft.DockerfileModel/EnvInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/EnvInstruction.cs
@@ -70,7 +70,9 @@ public class EnvInstruction : Instruction
             from variable in KeyValueToken<Variable, LiteralToken>.GetParser(
                 Variable.GetParser(escapeChar),
                 MultiVariableFormatValueParser(escapeChar),
-                escapeChar: escapeChar).AsEnumerable()
+                escapeChar: escapeChar,
+                excludeLeadingWhitespaceInValue: true,
+                excludeTrailingWhitespaceInSeparator: true).AsEnumerable()
             select ConcatTokens(whitespace.GetOrDefault(), variable), escapeChar
         ).AtLeastOnce().Flatten();
 
@@ -82,7 +84,7 @@ public class EnvInstruction : Instruction
         ArgTokens(
             KeyValueToken<Variable, LiteralToken>.GetParser(
                 Variable.GetParser(escapeChar),
-                LiteralWithVariables(escapeChar, whitespaceMode: WhitespaceMode.AllowedInQuotes),
+                LiteralWithVariables(escapeChar, whitespaceMode: WhitespaceMode.Allowed),
                 separator: ' ',
                 escapeChar: escapeChar).AsEnumerable(), escapeChar);
 }


### PR DESCRIPTION
Fixes two issues with the parsing of `ENV` instructions:

* Multi-variable format parsing wasn't correctly handling a variable set to an empty value followed by additional variables. It was interpreting the other variables as the value of the variable that was set to an empty value: `ENV VAR1= VAR2=foo`.
* Single variable format parsing wasn't handling line breaks correctly.