### PR TITLE
Upgrade System.Text.RegularExpressions

### DIFF
--- a/src/Valleysoft.DockerfileModel/Valleysoft.DockerfileModel.csproj
+++ b/src/Valleysoft.DockerfileModel/Valleysoft.DockerfileModel.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Sprache" Version="2.3.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Validation" Version="2.5.51" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolves a vulnerability alert from System.Text.RegularExpressions.4.3.0 which was a transitive dependency.