### PR TITLE
Do not require comma delimiters for exec form

### DIFF
--- a/src/Valleysoft.DockerfileModel.Tests/ExecFormCommandTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ExecFormCommandTests.cs
@@ -143,6 +143,34 @@ public class ExecFormCommandTests
             },
             new ExecFormCommandParseTestScenario
             {
+                Text = "[\"/bin/bash\" \"-c\" \"echo hello\"]\n",
+                TokenValidators = new Action<Token>[]
+                {
+                    token => ValidateSymbol(token, '['),
+                    token => ValidateLiteral(token, "/bin/bash", ParseHelper.DoubleQuote),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateLiteral(token, "-c", ParseHelper.DoubleQuote),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateLiteral(token, "echo hello", ParseHelper.DoubleQuote),
+                    token => ValidateSymbol(token, ']'),
+                    token => ValidateNewLine(token, "\n")
+                },
+                Validate = result =>
+                {
+                    Assert.Equal(CommandType.ExecForm, result.CommandType);
+                    Assert.Equal("[\"/bin/bash\" \"-c\" \"echo hello\"]\n", result.ToString());
+                    Assert.Equal(
+                        new string[]
+                        {
+                            "/bin/bash",
+                            "-c",
+                            "echo hello"
+                        },
+                        result.Values.ToArray());
+                }
+            },
+            new ExecFormCommandParseTestScenario
+            {
                 Text = "[ \"/bi`\nn/bash\", `\n \"-c\" , \"echo he`\"llo\"]",
                 EscapeChar = '`',
                 TokenValidators = new Action<Token>[]

--- a/src/Valleysoft.DockerfileModel.Tests/FileTransferInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/FileTransferInstructionTests.cs
@@ -429,6 +429,22 @@ public abstract class FileTransferInstructionTests<TInstruction>
             },
             new FileTransferInstructionParseTestScenario
             {
+                Text = $"{instructionName} [\"$src\" \"dst\"]",
+                TokenValidators = new Action<Token>[]
+                {
+                    token => ValidateKeyword(token, instructionName),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateSymbol(token, '['),
+                    token => ValidateQuotableAggregate<LiteralToken>(token, "$src", ParseHelper.DoubleQuote,
+                        token => ValidateAggregate<VariableRefToken>(token, "$src",
+                            token => ValidateString(token, "src"))),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateLiteral(token, "dst", ParseHelper.DoubleQuote),
+                    token => ValidateSymbol(token, ']')
+                }
+            },
+            new FileTransferInstructionParseTestScenario
+            {
                 Text = $"{instructionName} [\"$src\", \"dst\"]\n",
                 TokenValidators = new Action<Token>[]
                 {

--- a/src/Valleysoft.DockerfileModel/ParseHelper.cs
+++ b/src/Valleysoft.DockerfileModel/ParseHelper.cs
@@ -547,11 +547,11 @@ internal static class ParseHelper
     /// <param name="escapeChar">Escape character.</param>
     private static Parser<IEnumerable<Token>> JsonArrayElementDelimiter(char escapeChar) =>
         from leading in OptionalWhitespaceOrLineContinuation(escapeChar)
-        from comma in Symbol(',').AsEnumerable()
+        from comma in Symbol(',').AsEnumerable().Optional()
         from trailing in OptionalWhitespaceOrLineContinuation(escapeChar)
         select ConcatTokens(
             leading,
-            comma,
+            comma.GetOrDefault(),
             trailing);
 
     /// <summary>


### PR DESCRIPTION
In order to better facilitate parsing of the output from the `docker history` command, it's necessary to loosen the requirements of parsing exec form instructions such as `CMD`.

As an example, a Dockerfile containing the instruction `CMD ["echo", "Hello"]` will be represented as `CMD ["echo" "Hello"]` in the output of the `docker history` command (notice the lack of a comma). So it's not truly a valid JSON array syntax.

This updates the parsing logic to allow the comma to be optional in this case.