### PR TITLE
Fix quoted value parsing to allow opposite quote chars (#125)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+    "attribution": {
+      "pr": "",
+      "commit": ""
+    }
+  }
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 defaults:
   run:

--- a/.squad/orchestration-log/2026-03-05T033612Z-dallas.md
+++ b/.squad/orchestration-log/2026-03-05T033612Z-dallas.md
@@ -1,0 +1,39 @@
+# Orchestration Log: Dallas (Core Dev)
+
+**Session:** 2026-03-05T03:36:12Z
+**Task:** Fix LABEL parsing bug #125
+**Mode:** background
+
+## Work Completed
+
+### Investigation
+- Root cause identified in `ParseHelper.cs`, method `ExceptQuotes` (line 770-771)
+- The method unconditionally excluded both `'` and `"` quote characters from content parsers
+- This caused failure when parsing double-quoted strings containing single quotes, e.g., `LABEL a="foo'bar"`
+- The infrastructure already passed `TokenWrapper` information through the call chain, but inner parsers ignored it
+
+### Implementation
+- Added new `ExceptQuote(parser, wrappingQuoteChar)` method to `ParseHelper.cs`
+  - Excludes only the wrapping quote character when provided
+  - Falls back to `ExceptQuotes` (both quotes) when wrappingQuoteChar is null
+  - Minimal 3-line addition
+- Modified `WrappedInQuotesLiteralString` to accept optional `wrappingQuoteChar` parameter
+- Modified `WrappedInQuotesIdentifier` to accept optional `wrappingQuoteChar` parameter
+- Updated three lambda call sites to pass `tokenWrapper.OpeningString[0]`:
+  1. `LiteralWithVariablesTokens`
+  2. `WrappedInOptionalQuotesLiteralStringWithSpacesCore`
+  3. `IdentifierTokens`
+
+### Testing
+- All 516 existing tests pass without regression
+- Build successful
+- Original `ExceptQuotes` method preserved for backward compatibility
+
+## Files Modified
+- `src/Valleysoft.DockerfileModel/ParseHelper.cs`
+
+## Decision Made
+Fixed quote exclusion to be context-aware (see decisions.md)
+
+## Status
+✓ Complete and tested

--- a/.squad/orchestration-log/2026-03-05T033612Z-lambert.md
+++ b/.squad/orchestration-log/2026-03-05T033612Z-lambert.md
@@ -1,0 +1,37 @@
+# Orchestration Log: Lambert (Tester)
+
+**Session:** 2026-03-05T03:36:12Z
+**Task:** Regression tests for LABEL parsing bug #125
+**Mode:** background
+
+## Work Completed
+
+### Test Coverage
+- Created `QuotesInsideQuotesTests.cs` with 13 regression tests
+- Coverage includes:
+  - LABEL instruction with single quotes in double-quoted values
+  - LABEL instruction with double quotes in single-quoted values
+  - ENV instruction with single quotes in double-quoted values
+  - ENV instruction with double quotes in single-quoted values
+  - ARG instruction with single quotes in double-quoted values
+  - ARG instruction with double quotes in single-quoted values
+  - Dockerfile-level round-trip parsing and serialization
+
+### Test Design
+- Each test case validates both:
+  1. Correct parsing of quoted values containing opposite quote type
+  2. Round-trip fidelity: ToString() output matches original input exactly
+- Uses xUnit Theory/InlineData pattern consistent with project test conventions
+- `ValidateLiteral` helper for token value assertions with quote character tracking
+
+### Testing Results
+- All 13 new tests passing
+- All 516 existing tests remain passing
+- No regressions detected
+- Full round-trip fidelity verified across instruction types
+
+## Files Created
+- `src/Valleysoft.DockerfileModel.Tests/QuotesInsideQuotesTests.cs`
+
+## Status
+✓ Complete and all tests passing

--- a/src/Valleysoft.DockerfileModel.Tests/QuotesInsideQuotesTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/QuotesInsideQuotesTests.cs
@@ -1,0 +1,351 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+using static Valleysoft.DockerfileModel.Tests.TokenValidator;
+
+namespace Valleysoft.DockerfileModel.Tests;
+
+/// <summary>
+/// Regression tests for GitHub issue #125: LABEL parsing fails when single quotes
+/// appear inside double-quoted values (and vice versa). The parser should only exclude
+/// the wrapping quote character from allowed characters inside quoted strings, not both
+/// quote types.
+/// </summary>
+public class QuotesInsideQuotesTests
+{
+    #region LABEL instruction tests
+
+    /// <summary>
+    /// Core bug case from issue #125: single quote inside double-quoted LABEL value.
+    /// </summary>
+    [Fact]
+    public void Label_SingleQuoteInsideDoubleQuotedValue()
+    {
+        string text = "LABEL a=\"foo'bar\"";
+        LabelInstruction result = LabelInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Token structure
+        Assert.Collection(result.Tokens,
+            token => ValidateKeyword(token, "LABEL"),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<KeyValueToken<LiteralToken, LiteralToken>>(token, "a=\"foo'bar\"",
+                token => ValidateLiteral(token, "a"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "foo'bar", '\"')));
+
+        // Semantic validation
+        Assert.Single(result.Labels);
+        Assert.Equal("a", result.Labels[0].Key);
+        Assert.Equal("foo'bar", result.Labels[0].Value);
+    }
+
+    /// <summary>
+    /// Reverse case: double quote inside single-quoted LABEL value.
+    /// </summary>
+    [Fact]
+    public void Label_DoubleQuoteInsideSingleQuotedValue()
+    {
+        string text = "LABEL a='foo\"bar'";
+        LabelInstruction result = LabelInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Token structure
+        Assert.Collection(result.Tokens,
+            token => ValidateKeyword(token, "LABEL"),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<KeyValueToken<LiteralToken, LiteralToken>>(token, "a='foo\"bar'",
+                token => ValidateLiteral(token, "a"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "foo\"bar", '\'')));
+
+        // Semantic validation
+        Assert.Single(result.Labels);
+        Assert.Equal("a", result.Labels[0].Key);
+        Assert.Equal("foo\"bar", result.Labels[0].Value);
+    }
+
+    /// <summary>
+    /// Real-world case from issue #125: Azure CLI LABEL with apostrophe in description.
+    /// </summary>
+    [Fact]
+    public void Label_AzureCliRealWorldCase()
+    {
+        string text = "LABEL maintainer=\"Microsoft\" org.label-schema.description=\"A great cloud needs great tools; we're excited to introduce Azure CLI, our next generation multi-platform command line experience for Azure.\"";
+        LabelInstruction result = LabelInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Semantic validation
+        Assert.Equal(2, result.Labels.Count);
+        Assert.Equal("maintainer", result.Labels[0].Key);
+        Assert.Equal("Microsoft", result.Labels[0].Value);
+        Assert.Equal("org.label-schema.description", result.Labels[1].Key);
+        Assert.Equal("A great cloud needs great tools; we're excited to introduce Azure CLI, our next generation multi-platform command line experience for Azure.", result.Labels[1].Value);
+    }
+
+    /// <summary>
+    /// Multiple values with mixed quote styles containing the opposite quote character.
+    /// </summary>
+    [Fact]
+    public void Label_MultipleValuesWithMixedQuotes()
+    {
+        string text = "LABEL a=\"it's\" b='say \"hello\"'";
+        LabelInstruction result = LabelInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Token structure
+        Assert.Collection(result.Tokens,
+            token => ValidateKeyword(token, "LABEL"),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<KeyValueToken<LiteralToken, LiteralToken>>(token, "a=\"it's\"",
+                token => ValidateLiteral(token, "a"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "it's", '\"')),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<KeyValueToken<LiteralToken, LiteralToken>>(token, "b='say \"hello\"'",
+                token => ValidateLiteral(token, "b"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "say \"hello\"", '\'')));
+
+        // Semantic validation
+        Assert.Equal(2, result.Labels.Count);
+        Assert.Equal("a", result.Labels[0].Key);
+        Assert.Equal("it's", result.Labels[0].Value);
+        Assert.Equal("b", result.Labels[1].Key);
+        Assert.Equal("say \"hello\"", result.Labels[1].Value);
+    }
+
+    #endregion
+
+    #region ENV instruction tests
+
+    /// <summary>
+    /// ENV with single quote inside double-quoted value.
+    /// </summary>
+    [Fact]
+    public void Env_SingleQuoteInsideDoubleQuotedValue()
+    {
+        string text = "ENV MY_VAR=\"it's a test\"";
+        EnvInstruction result = EnvInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Token structure
+        Assert.Collection(result.Tokens,
+            token => ValidateKeyword(token, "ENV"),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_VAR=\"it's a test\"",
+                token => ValidateIdentifier<Variable>(token, "MY_VAR"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "it's a test", '\"')));
+
+        // Semantic validation
+        Assert.Single(result.Variables);
+        Assert.Equal("MY_VAR", result.Variables[0].Key);
+        Assert.Equal("it's a test", result.Variables[0].Value);
+    }
+
+    /// <summary>
+    /// ENV with double quote inside single-quoted value.
+    /// </summary>
+    [Fact]
+    public void Env_DoubleQuoteInsideSingleQuotedValue()
+    {
+        string text = "ENV MY_VAR='say \"hello\"'";
+        EnvInstruction result = EnvInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Token structure
+        Assert.Collection(result.Tokens,
+            token => ValidateKeyword(token, "ENV"),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "MY_VAR='say \"hello\"'",
+                token => ValidateIdentifier<Variable>(token, "MY_VAR"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "say \"hello\"", '\'')));
+
+        // Semantic validation
+        Assert.Single(result.Variables);
+        Assert.Equal("MY_VAR", result.Variables[0].Key);
+        Assert.Equal("say \"hello\"", result.Variables[0].Value);
+    }
+
+    #endregion
+
+    #region ARG instruction tests
+
+    /// <summary>
+    /// ARG with single quote inside double-quoted default value.
+    /// </summary>
+    [Fact]
+    public void Arg_SingleQuoteInsideDoubleQuotedValue()
+    {
+        string text = "ARG MY_ARG=\"it's default\"";
+        ArgInstruction result = ArgInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Token structure
+        Assert.Collection(result.Tokens,
+            token => ValidateKeyword(token, "ARG"),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<ArgDeclaration>(token, "MY_ARG=\"it's default\"",
+                token => ValidateIdentifier<Variable>(token, "MY_ARG"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "it's default", '\"')));
+
+        // Semantic validation
+        Assert.Single(result.Args);
+        Assert.Equal("MY_ARG", result.Args[0].Key);
+        Assert.Equal("it's default", result.Args[0].Value);
+    }
+
+    /// <summary>
+    /// ARG with double quote inside single-quoted default value.
+    /// </summary>
+    [Fact]
+    public void Arg_DoubleQuoteInsideSingleQuotedValue()
+    {
+        string text = "ARG MY_ARG='say \"hello\"'";
+        ArgInstruction result = ArgInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Token structure
+        Assert.Collection(result.Tokens,
+            token => ValidateKeyword(token, "ARG"),
+            token => ValidateWhitespace(token, " "),
+            token => ValidateAggregate<ArgDeclaration>(token, "MY_ARG='say \"hello\"'",
+                token => ValidateIdentifier<Variable>(token, "MY_ARG"),
+                token => ValidateSymbol(token, '='),
+                token => ValidateLiteral(token, "say \"hello\"", '\'')));
+
+        // Semantic validation
+        Assert.Single(result.Args);
+        Assert.Equal("MY_ARG", result.Args[0].Key);
+        Assert.Equal("say \"hello\"", result.Args[0].Value);
+    }
+
+    #endregion
+
+    #region Dockerfile-level round-trip tests
+
+    /// <summary>
+    /// Full Dockerfile round-trip with LABEL containing quotes-inside-quotes, verifying
+    /// that Dockerfile.Parse() followed by ToString() preserves the exact input.
+    /// </summary>
+    [Fact]
+    public void Dockerfile_RoundTrip_LabelWithQuotesInsideQuotes()
+    {
+        string dockerfileContent = TestHelper.ConcatLines(new List<string>
+        {
+            "FROM scratch",
+            "LABEL maintainer=\"Microsoft\" org.label-schema.description=\"A great cloud needs great tools; we're excited to introduce Azure CLI, our next generation multi-platform command line experience for Azure.\""
+        });
+
+        Dockerfile dockerfile = Dockerfile.Parse(dockerfileContent);
+
+        // Round-trip fidelity at Dockerfile level
+        Assert.Equal(dockerfileContent, dockerfile.ToString());
+
+        // Verify the LABEL instruction was correctly parsed
+        LabelInstruction labelInstruction = dockerfile.Items.OfType<LabelInstruction>().First();
+        Assert.Equal(2, labelInstruction.Labels.Count);
+        Assert.Equal("maintainer", labelInstruction.Labels[0].Key);
+        Assert.Equal("Microsoft", labelInstruction.Labels[0].Value);
+        Assert.Equal("org.label-schema.description", labelInstruction.Labels[1].Key);
+        Assert.Equal("A great cloud needs great tools; we're excited to introduce Azure CLI, our next generation multi-platform command line experience for Azure.", labelInstruction.Labels[1].Value);
+    }
+
+    /// <summary>
+    /// Full Dockerfile round-trip with multiple instructions using mixed quotes-inside-quotes.
+    /// </summary>
+    [Fact]
+    public void Dockerfile_RoundTrip_MixedInstructionsWithQuotesInsideQuotes()
+    {
+        string dockerfileContent = TestHelper.ConcatLines(new List<string>
+        {
+            "FROM scratch",
+            "ARG DESC=\"it's a test\"",
+            "ENV GREETING='say \"hello\"'",
+            "LABEL description=\"it's great\" notes='he said \"yes\"'"
+        });
+
+        Dockerfile dockerfile = Dockerfile.Parse(dockerfileContent);
+
+        // Round-trip fidelity at Dockerfile level
+        Assert.Equal(dockerfileContent, dockerfile.ToString());
+    }
+
+    #endregion
+
+    #region Edge cases
+
+    /// <summary>
+    /// Single quote inside double-quoted key (keys can be quoted too).
+    /// </summary>
+    [Fact]
+    public void Label_SingleQuoteInsideDoubleQuotedKey()
+    {
+        string text = "LABEL \"it's\"=value";
+        LabelInstruction result = LabelInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Semantic validation
+        Assert.Single(result.Labels);
+        Assert.Equal("it's", result.Labels[0].Key);
+        Assert.Equal("value", result.Labels[0].Value);
+    }
+
+    /// <summary>
+    /// Multiple single quotes inside a double-quoted value.
+    /// </summary>
+    [Fact]
+    public void Label_MultipleSingleQuotesInsideDoubleQuotedValue()
+    {
+        string text = "LABEL msg=\"it's John's dog's toy\"";
+        LabelInstruction result = LabelInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Semantic validation
+        Assert.Single(result.Labels);
+        Assert.Equal("msg", result.Labels[0].Key);
+        Assert.Equal("it's John's dog's toy", result.Labels[0].Value);
+    }
+
+    /// <summary>
+    /// Multiple double quotes inside a single-quoted value.
+    /// </summary>
+    [Fact]
+    public void Label_MultipleDoubleQuotesInsideSingleQuotedValue()
+    {
+        string text = "LABEL msg='he said \"hi\" then \"bye\"'";
+        LabelInstruction result = LabelInstruction.Parse(text);
+
+        // Round-trip fidelity
+        Assert.Equal(text, result.ToString());
+
+        // Semantic validation
+        Assert.Single(result.Labels);
+        Assert.Equal("msg", result.Labels[0].Key);
+        Assert.Equal("he said \"hi\" then \"bye\"", result.Labels[0].Value);
+    }
+
+    #endregion
+}

--- a/src/Valleysoft.DockerfileModel/ParseHelper.cs
+++ b/src/Valleysoft.DockerfileModel/ParseHelper.cs
@@ -292,7 +292,8 @@ internal static class ParseHelper
     public static Parser<(IEnumerable<Token> Tokens, char? QuoteChar)> IdentifierTokens(Parser<char> firstCharacterParser, Parser<char> tailCharacterParser, char escapeChar) =>
         WrappedInOptionalQuotes(
             (char escapeChar, IEnumerable<char> excludedChars, TokenWrapper tokenWrapper) =>
-                WrappedInQuotesIdentifier(escapeChar, firstCharacterParser, tailCharacterParser),
+                WrappedInQuotesIdentifier(escapeChar, firstCharacterParser, tailCharacterParser,
+                    wrappingQuoteChar: tokenWrapper.OpeningString[0]),
             (char escapeChar, IEnumerable<char> excludedChars) =>
                 IdentifierString(escapeChar, firstCharacterParser, tailCharacterParser),
             escapeChar,
@@ -389,7 +390,8 @@ internal static class ParseHelper
                         WrappedInQuotesLiteralString(
                             escapeChar,
                             excludedChars.Union(additionalExcludedChars),
-                            whitespaceMode == WhitespaceMode.AllowedInQuotes || whitespaceMode == WhitespaceMode.Allowed),
+                            whitespaceMode == WhitespaceMode.AllowedInQuotes || whitespaceMode == WhitespaceMode.Allowed,
+                            wrappingQuoteChar: tokenWrapper.OpeningString[0]),
                     excludedChars)
                     .Many()
                     .Flatten()
@@ -429,7 +431,8 @@ internal static class ParseHelper
         char escapeChar, bool excludeVariableRefChars) =>
         WrappedInOptionalQuotes(
             (char escapeChar, IEnumerable<char> excludedChars, TokenWrapper tokenWrapper) =>
-                WrappedInQuotesLiteralString(escapeChar, excludedChars, isWhitespaceAllowed: true, excludeVariableRefChars: excludeVariableRefChars),
+                WrappedInQuotesLiteralString(escapeChar, excludedChars, isWhitespaceAllowed: true,
+                    excludeVariableRefChars: excludeVariableRefChars, wrappingQuoteChar: tokenWrapper.OpeningString[0]),
             (char escapeChar, IEnumerable<char> excludedChars) =>
                 from tokens in LiteralString(escapeChar, excludedChars, excludeVariableRefChars: excludeVariableRefChars)
                     .Or(Whitespace()).Many().Flatten()
@@ -606,13 +609,14 @@ internal static class ParseHelper
     /// <param name="escapeChar">Escape character.</param>
     /// <param name="firstCharacterParser">Parser of the first character of the identifier.</param>
     /// <param name="tailCharacterParser">Parser of the rest of the characters of the identifier.</param>
+    /// <param name="wrappingQuoteChar">The quote character wrapping this identifier. Only this quote is excluded from content.</param>
     /// <returns>Parser for an identifier string wrapped in quotes.</returns>
     private static Parser<IEnumerable<Token>> WrappedInQuotesIdentifier(char escapeChar, Parser<char> firstCharacterParser,
-        Parser<char> tailCharacterParser) =>
+        Parser<char> tailCharacterParser, char? wrappingQuoteChar = null) =>
         IdentifierString(
             escapeChar,
-            ExceptQuotes(firstCharacterParser),
-            ExceptQuotes(tailCharacterParser));
+            ExceptQuote(firstCharacterParser, wrappingQuoteChar),
+            ExceptQuote(tailCharacterParser, wrappingQuoteChar));
 
     /// <summary>
     /// Parses an identifier string.
@@ -646,11 +650,12 @@ internal static class ParseHelper
     /// <param name="excludedChars">Characters to exclude from the parsing.</param>
     /// <param name="isWhitespaceAllowed">A value indicating whether whitespace is allowed in the string.</param>
     /// <param name="excludeVariableRefChars">A value indicating whether to exclude the variable ref characters.</param>
+    /// <param name="wrappingQuoteChar">The quote character wrapping this string. Only this quote is excluded from content.</param>
     /// <returns>Parser for a literal string wrapped in quotes.</returns>
     private static Parser<IEnumerable<Token>> WrappedInQuotesLiteralString(char escapeChar, IEnumerable<char> excludedChars,
-        bool isWhitespaceAllowed = false, bool excludeVariableRefChars = true)
+        bool isWhitespaceAllowed = false, bool excludeVariableRefChars = true, char? wrappingQuoteChar = null)
     {
-        Parser<char> parser = ExceptQuotes(LiteralChar(escapeChar, excludedChars, isWhitespaceAllowed, excludeVariableRefChars));
+        Parser<char> parser = ExceptQuote(LiteralChar(escapeChar, excludedChars, isWhitespaceAllowed, excludeVariableRefChars), wrappingQuoteChar);
         return
             from first in ToStringTokens(parser).Or(EscapedChar(escapeChar))
             from rest in OrConcat(
@@ -769,6 +774,17 @@ internal static class ParseHelper
     /// <param name="parser">A character parser to exclude quotes from.</param>
     private static Parser<char> ExceptQuotes(Parser<char> parser) =>
         parser.ExceptChars(Quotes);
+
+    /// <summary>
+    /// Parses a character that excludes only the specified wrapping quote character.
+    /// If no wrapping quote is specified, falls back to excluding both quote types.
+    /// </summary>
+    /// <param name="parser">A character parser to exclude the quote from.</param>
+    /// <param name="wrappingQuoteChar">The wrapping quote character to exclude, or null to exclude both.</param>
+    private static Parser<char> ExceptQuote(Parser<char> parser, char? wrappingQuoteChar) =>
+        wrappingQuoteChar.HasValue
+            ? parser.Except(Parse.Char(wrappingQuoteChar.Value))
+            : ExceptQuotes(parser);
 
     /// <summary>
     /// Parses a token that is wrapped by a set of characters.


### PR DESCRIPTION
## Summary

- **Root cause:** `ExceptQuotes` in `ParseHelper.cs` excluded both `'` and `"` from allowed content inside any quoted string — so `LABEL a="foo'bar"` failed when hitting the single quote
- **Fix:** Added `ExceptQuote(parser, wrappingQuoteChar)` that excludes only the wrapping quote, and threaded it through `WrappedInQuotesLiteralString`, `WrappedInQuotesIdentifier`, and all 3 call sites
- **Scope:** Affects all instructions that parse quoted values (LABEL, ENV, ARG, FROM, COPY, etc.), not just LABEL

## Test plan

- [x] 13 new regression tests in `QuotesInsideQuotesTests.cs`
- [x] Single quote inside double-quoted LABEL value
- [x] Double quote inside single-quoted LABEL value
- [x] Real-world Azure CLI LABEL from issue report
- [x] Multiple values with mixed quotes
- [x] ENV and ARG with quotes-inside-quotes
- [x] Round-trip fidelity verified on all cases
- [x] All 516 tests pass (0 regressions)

Fixes #125
