### PR TITLE
Add differential testing harness (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,29 @@ jobs:
       - name: Run property tests
         working-directory: lean
         run: lake exe DockerfileModelTests
+
+  diff-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5.0.1
+
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Build Lean CLI
+        working-directory: lean
+        run: lake build DockerfileModelDiffTest
+
+      - name: Build .NET DiffTest
+        working-directory: src
+        run: dotnet build Valleysoft.DockerfileModel.DiffTest -c Release
+
+      - name: Run differential tests
+        working-directory: src
+        run: dotnet run --project Valleysoft.DockerfileModel.DiffTest -c Release -- --compare --lean-cli ../lean/.lake/build/bin/DockerfileModelDiffTest --count 10000

--- a/lean/DockerfileModel/Json.lean
+++ b/lean/DockerfileModel/Json.lean
@@ -1,0 +1,85 @@
+/-
+  Json.lean — Canonical JSON serialization for Token trees.
+
+  Produces compact, deterministic JSON matching the canonical format used by the
+  C# differential test harness. Both sides must produce byte-identical output.
+
+  Primitive tokens:
+    {"type":"primitive","kind":"<kind>","value":"<escaped>"}
+
+  Aggregate tokens:
+    {"type":"aggregate","kind":"<kind>","quoteChar":<null|"char">,"children":[...]}
+
+  Rules: no trailing commas, no extra whitespace, JSON-standard string escaping.
+-/
+
+import DockerfileModel.Token
+
+namespace DockerfileModel
+
+/-- Convert a PrimitiveKind to its canonical JSON kind string. -/
+def PrimitiveKind.toJsonName : PrimitiveKind → String
+  | .string     => "string"
+  | .whitespace => "whitespace"
+  | .symbol     => "symbol"
+  | .newLine    => "newLine"
+
+/-- Convert an AggregateKind to its canonical JSON kind string. -/
+def AggregateKind.toJsonName : AggregateKind → String
+  | .keyword          => "keyword"
+  | .literal          => "literal"
+  | .identifier       => "identifier"
+  | .variableRef      => "variableRef"
+  | .comment          => "comment"
+  | .lineContinuation => "lineContinuation"
+  | .keyValue         => "keyValue"
+  | .instruction      => "instruction"
+  | .construct        => "construct"
+
+namespace Json
+
+private def toHex4 (n : Nat) : List Char :=
+  let hexDigit (d : Nat) : Char :=
+    if d < 10 then Char.ofNat (48 + d)  -- '0' + d
+    else Char.ofNat (97 + d - 10)       -- 'a' + (d - 10)
+  [hexDigit ((n / 4096) % 16),
+   hexDigit ((n / 256) % 16),
+   hexDigit ((n / 16) % 16),
+   hexDigit (n % 16)]
+
+/-- Escape a string for JSON output.
+    Handles: \\ \" \n \r \t and control chars < 0x20 as \uXXXX. -/
+def jsonEscapeString (s : String) : String :=
+  let rec loop (cs : List Char) (acc : List Char) : List Char :=
+    match cs with
+    | [] => acc.reverse
+    | c :: rest =>
+      if c == '\\' then loop rest ('\\' :: '\\' :: acc)
+      else if c == '"' then loop rest ('"' :: '\\' :: acc)
+      else if c == '\n' then loop rest ('n' :: '\\' :: acc)
+      else if c == '\r' then loop rest ('r' :: '\\' :: acc)
+      else if c == '\t' then loop rest ('t' :: '\\' :: acc)
+      else if c.val < 0x20 then
+        -- \uXXXX encoding for control characters
+        let hexChars := toHex4 c.val.toNat
+        loop rest (hexChars.reverse ++ ('u' :: '\\' :: acc))
+      else loop rest (c :: acc)
+  String.ofList (loop s.toList [])
+
+/-- Serialize a Token to canonical compact JSON. -/
+def Token.toJson : Token → String
+  | .primitive kind value =>
+    "{\"type\":\"primitive\",\"kind\":\"" ++ kind.toJsonName ++
+    "\",\"value\":\"" ++ jsonEscapeString value ++ "\"}"
+  | .aggregate kind children quoteInfo =>
+    let childrenJson := "[" ++ String.intercalate "," (children.map Token.toJson) ++ "]"
+    let quoteCharJson := match quoteInfo with
+      | some qi => "\"" ++ jsonEscapeString (String.singleton qi.quoteChar) ++ "\""
+      | none => "null"
+    "{\"type\":\"aggregate\",\"kind\":\"" ++ kind.toJsonName ++
+    "\",\"quoteChar\":" ++ quoteCharJson ++
+    ",\"children\":" ++ childrenJson ++ "}"
+
+end Json
+
+end DockerfileModel

--- a/lean/DockerfileModel/Main.lean
+++ b/lean/DockerfileModel/Main.lean
@@ -1,0 +1,63 @@
+/-
+  Main.lean — CLI entry point for differential testing.
+
+  Reads all of stdin, detects instruction type from first keyword (case-insensitive),
+  calls the appropriate parser, and outputs canonical JSON to stdout.
+
+  Exit code 0 on success, 1 on parse failure (with error to stderr).
+
+  Usage:
+    echo "FROM alpine" | DockerfileModelDiffTest
+    echo "ARG MY_VAR=hello" | DockerfileModelDiffTest
+-/
+
+import DockerfileModel.Json
+import DockerfileModel.Parser.Instructions.From
+import DockerfileModel.Parser.Instructions.Arg
+
+open DockerfileModel
+open DockerfileModel.Parser.Instructions
+
+/-- Extract the first whitespace-delimited word from a string. -/
+def firstWord (s : String) : String :=
+  let trimmed := s.trimAsciiStart.toString
+  let chars := trimmed.toList
+  let word := chars.takeWhile (fun c => !c.isWhitespace)
+  String.ofList word
+
+/-- Read all of stdin into a string. -/
+def readAllStdin : IO String := do
+  let stdin ← IO.getStdin
+  let mut result := ""
+  let mut done := false
+  while !done do
+    let line ← stdin.getLine
+    if line.isEmpty then
+      done := true
+    else
+      result := result ++ line
+  return result
+
+def main : IO UInt32 := do
+  let input ← readAllStdin
+  let keyword := (firstWord input).toUpper
+  match keyword with
+  | "FROM" =>
+    match parseFrom input with
+    | some inst =>
+      IO.println (Json.Token.toJson inst.token)
+      return 0
+    | none =>
+      IO.eprintln s!"Parse error: failed to parse FROM instruction"
+      return 1
+  | "ARG" =>
+    match parseArg input with
+    | some inst =>
+      IO.println (Json.Token.toJson inst.token)
+      return 0
+    | none =>
+      IO.eprintln s!"Parse error: failed to parse ARG instruction"
+      return 1
+  | _ =>
+    IO.eprintln s!"Unknown instruction type: {keyword}"
+    return 1

--- a/lean/lakefile.lean
+++ b/lean/lakefile.lean
@@ -12,3 +12,7 @@ lean_lib «DockerfileModel» where
 lean_exe «DockerfileModelTests» where
   root := `DockerfileModel.Tests.SlimCheck
   supportInterpreter := true
+
+lean_exe «DockerfileModelDiffTest» where
+  root := `DockerfileModel.Main
+  supportInterpreter := true

--- a/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+using System.Text;
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+/// <summary>
+/// Result of comparing C# and Lean parser outputs for a single input.
+/// </summary>
+public record DiffResult(
+    string InstructionType,
+    string Input,
+    string CSharpJson,
+    string LeanJson,
+    bool Match,
+    string? Error = null);
+
+/// <summary>
+/// Core comparison engine: parses each input with both C# and Lean parsers,
+/// serializes to canonical JSON, and compares for byte-identical output.
+/// </summary>
+public class DiffTestRunner
+{
+    private readonly string _leanCliPath;
+    private readonly string? _leanLibDir;
+    private readonly TimeSpan _timeout;
+
+    public DiffTestRunner(string leanCliPath, TimeSpan? timeout = null)
+    {
+        _leanCliPath = Path.GetFullPath(leanCliPath);
+        _timeout = timeout ?? TimeSpan.FromSeconds(30);
+
+        // Determine the Lean shared library directory.
+        // The binary is at <lake-build>/bin/DockerfileModelDiffTest(.exe).
+        // Lean shared libraries (libInit_shared.so/.dll) are in the elan toolchain bin dir.
+        // We find the toolchain by looking for elan-managed lean in PATH or common locations.
+        _leanLibDir = FindLeanLibDir();
+    }
+
+    /// <summary>
+    /// Parse an instruction with the C# parser and serialize to canonical JSON.
+    /// </summary>
+    public static string ParseCSharp(string instructionType, string input)
+    {
+        Token token = instructionType.ToUpperInvariant() switch
+        {
+            "FROM" => FromInstruction.Parse(input),
+            "ARG" => ArgInstruction.Parse(input),
+            _ => throw new ArgumentException($"Unsupported instruction type: {instructionType}")
+        };
+        return TokenJsonSerializer.Serialize(token);
+    }
+
+    /// <summary>
+    /// Parse an instruction with the Lean CLI and capture JSON from stdout.
+    /// </summary>
+    public async Task<string> ParseLeanAsync(string input)
+    {
+        using Process process = new();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = _leanCliPath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        // Ensure Lean shared libraries are findable
+        if (_leanLibDir != null)
+        {
+            string currentPath = process.StartInfo.EnvironmentVariables["PATH"] ?? "";
+            process.StartInfo.EnvironmentVariables["PATH"] = _leanLibDir + Path.PathSeparator + currentPath;
+
+            // On Linux, also set LD_LIBRARY_PATH
+            if (!OperatingSystem.IsWindows())
+            {
+                string currentLdPath = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH") ?? "";
+                process.StartInfo.EnvironmentVariables["LD_LIBRARY_PATH"] =
+                    _leanLibDir + Path.PathSeparator + currentLdPath;
+            }
+        }
+
+        process.Start();
+
+        // Write input to stdin and close
+        await process.StandardInput.WriteAsync(input);
+        process.StandardInput.Close();
+
+        // Read stdout and stderr
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+        bool exited = process.WaitForExit((int)_timeout.TotalMilliseconds);
+        if (!exited)
+        {
+            process.Kill();
+            throw new TimeoutException($"Lean CLI timed out after {_timeout.TotalSeconds}s");
+        }
+
+        string stdout = await stdoutTask;
+        string stderr = await stderrTask;
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Lean CLI exited with code {process.ExitCode}: {stderr.Trim()}");
+        }
+
+        return stdout.TrimEnd('\n', '\r');
+    }
+
+    /// <summary>
+    /// Run both parsers on a single input and compare JSON output.
+    /// </summary>
+    public async Task<DiffResult> RunSingleAsync(string instructionType, string input)
+    {
+        string csharpJson;
+        try
+        {
+            csharpJson = ParseCSharp(instructionType, input);
+        }
+        catch (Exception ex)
+        {
+            return new DiffResult(instructionType, input, "", "", false,
+                $"C# parse error: {ex.Message}");
+        }
+
+        string leanJson;
+        try
+        {
+            leanJson = await ParseLeanAsync(input);
+        }
+        catch (Exception ex)
+        {
+            return new DiffResult(instructionType, input, csharpJson, "", false,
+                $"Lean parse error: {ex.Message}");
+        }
+
+        bool match = string.Equals(csharpJson, leanJson, StringComparison.Ordinal);
+        return new DiffResult(instructionType, input, csharpJson, leanJson, match);
+    }
+
+    /// <summary>
+    /// Run both parsers on a batch of inputs, reporting progress.
+    /// </summary>
+    public async Task<List<DiffResult>> RunBatchAsync(
+        List<(string InstructionType, string Text)> inputs,
+        Action<int, int, DiffResult>? onProgress = null)
+    {
+        List<DiffResult> results = new();
+        int total = inputs.Count;
+
+        for (int i = 0; i < total; i++)
+        {
+            (string type, string text) = inputs[i];
+            DiffResult result = await RunSingleAsync(type, text);
+            results.Add(result);
+            onProgress?.Invoke(i + 1, total, result);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Find the directory containing Lean shared libraries (libInit_shared.so/.dll).
+    /// Searches common elan toolchain locations and the lean CLI's own directory tree.
+    /// </summary>
+    private static string? FindLeanLibDir()
+    {
+        // Check elan's default location
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string elandir = Path.Combine(home, ".elan", "toolchains");
+
+        if (Directory.Exists(elandir))
+        {
+            // Find the active toolchain's bin directory
+            foreach (string toolchain in Directory.GetDirectories(elandir))
+            {
+                string binDir = Path.Combine(toolchain, "bin");
+                if (Directory.Exists(binDir))
+                {
+                    string libSharedPattern = OperatingSystem.IsWindows()
+                        ? "libInit_shared.dll"
+                        : "libInit_shared.so";
+
+                    if (File.Exists(Path.Combine(binDir, libSharedPattern)))
+                    {
+                        return binDir;
+                    }
+
+                    // On some Linux setups, shared libs are in lib/lean/
+                    string libDir = Path.Combine(toolchain, "lib", "lean");
+                    if (File.Exists(Path.Combine(libDir, libSharedPattern)))
+                    {
+                        return libDir;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
@@ -1,0 +1,50 @@
+using FsCheck;
+using FsCheck.Fluent;
+using Valleysoft.DockerfileModel.Tests.Generators;
+
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+/// <summary>
+/// Wraps the linked FsCheck generators (DockerfileArbitraries) to produce
+/// random test inputs for differential testing. Returns a list of
+/// (InstructionType, Text) tuples split evenly between FROM and ARG,
+/// shuffled with a fixed seed for reproducibility.
+/// </summary>
+public static class InputGenerator
+{
+    private const int SampleSize = 50;
+
+    public static List<(string InstructionType, string Text)> Generate(int count, int seed = 42)
+    {
+        int fromCount = count / 2;
+        int argCount = count - fromCount;
+
+        List<(string InstructionType, string Text)> inputs = new();
+
+        // Generate FROM instructions using FsCheck 3.x Sample(size, count) extension
+        Gen<string> fromGen = DockerfileArbitraries.FromInstruction();
+        IReadOnlyList<string> fromInputs = fromGen.Sample(SampleSize, fromCount);
+        foreach (string text in fromInputs)
+        {
+            inputs.Add(("FROM", text));
+        }
+
+        // Generate ARG instructions
+        Gen<string> argGen = DockerfileArbitraries.ArgInstruction();
+        IReadOnlyList<string> argInputs = argGen.Sample(SampleSize, argCount);
+        foreach (string text in argInputs)
+        {
+            inputs.Add(("ARG", text));
+        }
+
+        // Shuffle with fixed seed for reproducibility
+        Random rng = new(seed);
+        for (int i = inputs.Count - 1; i > 0; i--)
+        {
+            int j = rng.Next(i + 1);
+            (inputs[i], inputs[j]) = (inputs[j], inputs[i]);
+        }
+
+        return inputs;
+    }
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/Program.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/Program.cs
@@ -1,0 +1,155 @@
+using Valleysoft.DockerfileModel.DiffTest;
+
+// Parse command-line arguments
+string mode = "";
+string leanCliPath = "";
+int count = 1000;
+int seed = 42;
+
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--parse":
+            mode = "parse";
+            break;
+        case "--compare":
+            mode = "compare";
+            break;
+        case "--generate":
+            mode = "generate";
+            break;
+        case "--lean-cli":
+            if (i + 1 < args.Length) leanCliPath = args[++i];
+            break;
+        case "--count":
+            if (i + 1 < args.Length) count = int.Parse(args[++i]);
+            break;
+        case "--seed":
+            if (i + 1 < args.Length) seed = int.Parse(args[++i]);
+            break;
+    }
+}
+
+switch (mode)
+{
+    case "parse":
+        return await RunParse();
+    case "compare":
+        return await RunCompare();
+    case "generate":
+        return RunGenerate();
+    default:
+        Console.Error.WriteLine("Usage:");
+        Console.Error.WriteLine("  --parse                          Read stdin, output JSON (symmetric with Lean CLI)");
+        Console.Error.WriteLine("  --compare --lean-cli <path> --count N  Compare both parsers on N random inputs");
+        Console.Error.WriteLine("  --generate --count N             Output test inputs as TYPE\\tBASE64 lines");
+        return 1;
+}
+
+/// <summary>
+/// Parse mode: read stdin, detect instruction type, output canonical JSON.
+/// Symmetric with the Lean CLI for manual smoke testing.
+/// </summary>
+async Task<int> RunParse()
+{
+    string input = await Console.In.ReadToEndAsync();
+    string trimmed = input.TrimStart();
+    int spaceIdx = trimmed.IndexOfAny(new[] { ' ', '\t', '\n', '\r' });
+    string keyword = spaceIdx > 0 ? trimmed[..spaceIdx].ToUpperInvariant() : trimmed.ToUpperInvariant();
+
+    try
+    {
+        string json = DiffTestRunner.ParseCSharp(keyword, input);
+        Console.WriteLine(json);
+        return 0;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Parse error: {ex.Message}");
+        return 1;
+    }
+}
+
+/// <summary>
+/// Compare mode: generate random inputs, run both parsers, report mismatches.
+/// </summary>
+async Task<int> RunCompare()
+{
+    if (string.IsNullOrEmpty(leanCliPath))
+    {
+        Console.Error.WriteLine("Error: --lean-cli <path> is required for --compare mode");
+        return 1;
+    }
+
+    Console.WriteLine($"Generating {count} random inputs (seed={seed})...");
+    List<(string InstructionType, string Text)> inputs = InputGenerator.Generate(count, seed);
+
+    Console.WriteLine($"Running differential test against Lean CLI: {leanCliPath}");
+    Console.WriteLine();
+
+    DiffTestRunner runner = new(leanCliPath);
+    int mismatches = 0;
+    int errors = 0;
+
+    List<DiffResult> results = await runner.RunBatchAsync(inputs, (current, total, result) =>
+    {
+        if (!result.Match)
+        {
+            if (result.Error != null)
+            {
+                errors++;
+                Console.Error.WriteLine($"[{current}/{total}] ERROR: {result.Error}");
+                Console.Error.WriteLine($"  Input: {Escape(result.Input)}");
+            }
+            else
+            {
+                mismatches++;
+                Console.Error.WriteLine($"[{current}/{total}] MISMATCH ({result.InstructionType}):");
+                Console.Error.WriteLine($"  Input:  {Escape(result.Input)}");
+                Console.Error.WriteLine($"  C#:     {result.CSharpJson}");
+                Console.Error.WriteLine($"  Lean:   {result.LeanJson}");
+            }
+            Console.Error.WriteLine();
+        }
+
+        // Progress indicator every 1000 inputs
+        if (current % 1000 == 0 || current == total)
+        {
+            Console.Write($"\r  Progress: {current}/{total}");
+            if (current == total) Console.WriteLine();
+        }
+    });
+
+    Console.WriteLine();
+    Console.WriteLine($"Results: {count} inputs, {mismatches} mismatches, {errors} errors");
+
+    if (mismatches > 0 || errors > 0)
+    {
+        Console.WriteLine("FAIL");
+        return 1;
+    }
+
+    Console.WriteLine("PASS");
+    return 0;
+}
+
+/// <summary>
+/// Generate mode: output test inputs as TYPE\tBASE64 lines for external use.
+/// </summary>
+int RunGenerate()
+{
+    List<(string InstructionType, string Text)> inputs = InputGenerator.Generate(count, seed);
+    foreach ((string type, string text) in inputs)
+    {
+        string b64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(text));
+        Console.WriteLine($"{type}\t{b64}");
+    }
+    return 0;
+}
+
+/// <summary>
+/// Escape control characters for display.
+/// </summary>
+static string Escape(string s) =>
+    s.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");

--- a/src/Valleysoft.DockerfileModel.DiffTest/TokenJsonSerializer.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/TokenJsonSerializer.cs
@@ -1,0 +1,225 @@
+using System.Text;
+using Valleysoft.DockerfileModel;
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+/// <summary>
+/// Hand-written recursive JSON serializer for the C# Token hierarchy.
+/// Produces compact, deterministic JSON matching the canonical format
+/// used by the Lean differential test harness.
+///
+/// Type-checking order is critical due to inheritance:
+///   - NewLineToken before WhitespaceToken (NewLineToken : WhitespaceToken)
+///   - Instruction before DockerfileConstruct (Instruction : DockerfileConstruct)
+///   - Concrete types before abstract base types
+/// </summary>
+public static class TokenJsonSerializer
+{
+    public static string Serialize(Token token)
+    {
+        StringBuilder sb = new();
+        SerializeToken(sb, token);
+        return sb.ToString();
+    }
+
+    private static void SerializeToken(StringBuilder sb, Token token)
+    {
+        // Primitives — check most-specific first
+        // NewLineToken : WhitespaceToken : PrimitiveToken
+        if (token is NewLineToken newLine)
+        {
+            SerializePrimitive(sb, "newLine", newLine.Value);
+            return;
+        }
+
+        if (token is WhitespaceToken ws)
+        {
+            SerializePrimitive(sb, "whitespace", ws.Value);
+            return;
+        }
+
+        if (token is SymbolToken sym)
+        {
+            SerializePrimitive(sb, "symbol", sym.Value);
+            return;
+        }
+
+        if (token is StringToken str)
+        {
+            SerializePrimitive(sb, "string", str.Value);
+            return;
+        }
+
+        // Aggregates — check most-specific first
+        // Instruction : DockerfileConstruct : AggregateToken
+        if (token is Instruction)
+        {
+            SerializeAggregate(sb, "instruction", token);
+            return;
+        }
+
+        if (token is DockerfileConstruct)
+        {
+            SerializeAggregate(sb, "construct", token);
+            return;
+        }
+
+        if (token is KeywordToken)
+        {
+            SerializeAggregate(sb, "keyword", token);
+            return;
+        }
+
+        if (token is VariableRefToken)
+        {
+            SerializeAggregate(sb, "variableRef", token);
+            return;
+        }
+
+        if (token is LiteralToken)
+        {
+            SerializeAggregate(sb, "literal", token);
+            return;
+        }
+
+        if (token is CommentToken)
+        {
+            SerializeAggregate(sb, "comment", token);
+            return;
+        }
+
+        if (token is LineContinuationToken)
+        {
+            SerializeAggregate(sb, "lineContinuation", token);
+            return;
+        }
+
+        // IdentifierToken is abstract — StageName, Variable extend it
+        if (token is IdentifierToken)
+        {
+            SerializeAggregate(sb, "identifier", token);
+            return;
+        }
+
+        // KeyValueToken<,> is generic — check via base-type walk
+        if (IsKeyValueToken(token))
+        {
+            SerializeAggregate(sb, "keyValue", token);
+            return;
+        }
+
+        // Fallback for any other AggregateToken subtype (e.g., ArgDeclaration)
+        if (token is AggregateToken)
+        {
+            // ArgDeclaration implements IKeyValuePair and extends AggregateToken
+            // It functions as a key-value pair in the token tree
+            if (token is IKeyValuePair)
+            {
+                SerializeAggregate(sb, "keyValue", token);
+                return;
+            }
+
+            // Unknown aggregate — shouldn't happen in well-formed trees
+            SerializeAggregate(sb, "construct", token);
+            return;
+        }
+
+        // Fallback for unknown primitive types
+        if (token is PrimitiveToken prim)
+        {
+            SerializePrimitive(sb, "string", prim.Value);
+            return;
+        }
+
+        throw new InvalidOperationException($"Unknown token type: {token.GetType().FullName}");
+    }
+
+    private static void SerializePrimitive(StringBuilder sb, string kind, string value)
+    {
+        sb.Append("{\"type\":\"primitive\",\"kind\":\"");
+        sb.Append(kind);
+        sb.Append("\",\"value\":\"");
+        JsonEscapeString(sb, value);
+        sb.Append("\"}");
+    }
+
+    private static void SerializeAggregate(StringBuilder sb, string kind, Token token)
+    {
+        sb.Append("{\"type\":\"aggregate\",\"kind\":\"");
+        sb.Append(kind);
+        sb.Append("\",\"quoteChar\":");
+
+        // Check for IQuotableToken — LiteralToken and IdentifierToken implement it
+        if (token is IQuotableToken quotable && quotable.QuoteChar.HasValue)
+        {
+            sb.Append('"');
+            JsonEscapeString(sb, quotable.QuoteChar.Value.ToString());
+            sb.Append('"');
+        }
+        else
+        {
+            sb.Append("null");
+        }
+
+        sb.Append(",\"children\":[");
+
+        AggregateToken aggregate = (AggregateToken)token;
+        bool first = true;
+        foreach (Token child in aggregate.Tokens)
+        {
+            if (!first) sb.Append(',');
+            SerializeToken(sb, child);
+            first = false;
+        }
+
+        sb.Append("]}");
+    }
+
+    /// <summary>
+    /// Check if a token is a KeyValueToken&lt;,&gt; by walking the base types
+    /// looking for a generic type definition match.
+    /// </summary>
+    private static bool IsKeyValueToken(Token token)
+    {
+        Type? type = token.GetType();
+        while (type != null)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValueToken<,>))
+            {
+                return true;
+            }
+            type = type.BaseType;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// JSON-standard string escaping: \\ \" \n \r \t and control chars &lt; 0x20 as \uXXXX.
+    /// </summary>
+    private static void JsonEscapeString(StringBuilder sb, string s)
+    {
+        foreach (char c in s)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                default:
+                    if (c < 0x20)
+                    {
+                        sb.Append("\\u");
+                        sb.Append(((int)c).ToString("x4"));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/Valleysoft.DockerfileModel.DiffTest.csproj
+++ b/src/Valleysoft.DockerfileModel.DiffTest/Valleysoft.DockerfileModel.DiffTest.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsCheck" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Valleysoft.DockerfileModel\Valleysoft.DockerfileModel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Valleysoft.DockerfileModel.Tests\Generators\DockerfileArbitraries.cs"
+             Link="Generators\DockerfileArbitraries.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Valleysoft.DockerfileModel.sln
+++ b/src/Valleysoft.DockerfileModel.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valleysoft.DockerfileModel"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valleysoft.DockerfileModel.Tests", "Valleysoft.DockerfileModel.Tests\Valleysoft.DockerfileModel.Tests.csproj", "{E1E9A7D5-55A8-4ADD-BDD5-C881DE5199F4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valleysoft.DockerfileModel.DiffTest", "Valleysoft.DockerfileModel.DiffTest\Valleysoft.DockerfileModel.DiffTest.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{E1E9A7D5-55A8-4ADD-BDD5-C881DE5199F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1E9A7D5-55A8-4ADD-BDD5-C881DE5199F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1E9A7D5-55A8-4ADD-BDD5-C881DE5199F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- Adds a differential testing harness that runs both the C# and Lean 4 parsers on thousands of random inputs and compares their canonical JSON output, transferring trust from the proved Lean spec to the production C# code
- Implements Lean JSON serializer (`Json.lean`) and CLI entry point (`Main.lean`) for piping inputs and emitting canonical JSON
- Implements C# JSON serializer (`TokenJsonSerializer.cs`) with correct type-check ordering for the inheritance hierarchy (e.g. `NewLineToken` before `WhitespaceToken`)
- Adds .NET `DiffTest` console app with three modes: `--parse` (symmetric with Lean CLI), `--compare` (run both parsers, report mismatches), `--generate` (emit test inputs)
- Reuses FsCheck generators from the test project via linked `DockerfileArbitraries.cs` to produce random FROM and ARG instructions
- CI runs 10,000 random inputs per PR; locally verified with 1,000 inputs (0 mismatches)

## Test plan
- [x] `lake build DockerfileModelDiffTest` succeeds
- [x] `dotnet build Valleysoft.DockerfileModel.DiffTest -c Release` succeeds
- [x] Lean CLI smoke test: `printf "FROM alpine" | lean CLI` produces valid JSON
- [x] C# CLI smoke test: `printf "FROM alpine" | dotnet run --parse` produces identical JSON
- [x] `--compare --count 1000` passes with 0 mismatches, 0 errors
- [x] All 650 existing C# tests still pass
- [x] Full Lean build (proofs + property tests) still passes
- [ ] CI `diff-test` job passes with 10,000 inputs