### PR TITLE
Use LiteralToken for COPY --from flag value

### DIFF
--- a/src/Valleysoft.DockerfileModel.Tests/CopyInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/CopyInstructionTests.cs
@@ -441,7 +441,7 @@ public class CopyInstructionTests : FileTransferInstructionTests<CopyInstruction
             token => ValidateSymbol(token, '-'),
             token => ValidateKeyword(token, key),
             token => ValidateSymbol(token, '='),
-            token => ValidateIdentifier<StageName>(token, value));
+            token => ValidateLiteral(token, value));
     }
 
 }

--- a/src/Valleysoft.DockerfileModel.Tests/TokenBuilderTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/TokenBuilderTests.cs
@@ -54,7 +54,7 @@ public class TokenBuilderTests
                 token => ValidateSymbol(token, '-'),
                 token => ValidateKeyword(token, "from"),
                 token => ValidateSymbol(token, '='),
-                token => ValidateIdentifier<StageName>(token, "stage")),
+                token => ValidateLiteral(token, "stage")),
             token => ValidateAggregate<ImageName>(token, "repo",
                 token => {
                     Assert.Equal("repo", ((LiteralToken)token).Value);

--- a/src/Valleysoft.DockerfileModel/CopyInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/CopyInstruction.cs
@@ -22,10 +22,10 @@ public class CopyInstruction : FileTransferInstruction
     {
         get => FromStageNameToken?.Value;
         set => SetOptionalTokenValue(
-            FromStageNameToken, value, val => new StageName(val, EscapeChar), token => FromStageNameToken = token);
+            FromStageNameToken, value, val => new LiteralToken(val, canContainVariables: true, EscapeChar), token => FromStageNameToken = token);
     }
 
-    public StageName? FromStageNameToken
+    public LiteralToken? FromStageNameToken
     {
         get => FromFlag?.ValueToken;
         set => SetOptionalKeyValueTokenValue(

--- a/src/Valleysoft.DockerfileModel/FromFlag.cs
+++ b/src/Valleysoft.DockerfileModel/FromFlag.cs
@@ -1,11 +1,12 @@
 ﻿using Valleysoft.DockerfileModel.Tokens;
+using static Valleysoft.DockerfileModel.ParseHelper;
 
 namespace Valleysoft.DockerfileModel;
 
-public class FromFlag : KeyValueToken<KeywordToken, StageName>
+public class FromFlag : KeyValueToken<KeywordToken, LiteralToken>
 {
     public FromFlag(string stageName, char escapeChar = Dockerfile.DefaultEscapeChar)
-        : base(new KeywordToken("from", escapeChar), new StageName(stageName, escapeChar), isFlag: true)
+        : base(new KeywordToken("from", escapeChar), new LiteralToken(stageName, canContainVariables: true, escapeChar), isFlag: true)
     {
     }
 
@@ -17,14 +18,14 @@ public class FromFlag : KeyValueToken<KeywordToken, StageName>
     public static FromFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
         Parse(text,
             KeywordToken.GetParser("from", escapeChar),
-            StageName.GetParser(escapeChar),
+            LiteralWithVariables(escapeChar),
             tokens => new FromFlag(tokens),
             escapeChar: escapeChar);
 
     public static Parser<FromFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
         GetParser(
             KeywordToken.GetParser("from", escapeChar),
-            StageName.GetParser(escapeChar),
+            LiteralWithVariables(escapeChar),
             tokens => new FromFlag(tokens),
             escapeChar: escapeChar);
 }


### PR DESCRIPTION
## Summary
- Changed `FromFlag` from `KeyValueToken<KeywordToken, StageName>` to `KeyValueToken<KeywordToken, LiteralToken>`
- Parser now uses `LiteralWithVariables()` instead of `StageName.GetParser()`
- `--from` can reference stage names, image names, numeric indices, or variable refs

## Breaking Changes

### `FromFlag` base type changed
- **Before:** `public class FromFlag : KeyValueToken<KeywordToken, StageName>`
- **After:** `public class FromFlag : KeyValueToken<KeywordToken, LiteralToken>`
- **Migration:** Code that accesses `FromFlag.ValueToken` will now receive a `LiteralToken` instead of `StageName`. Since `StageName` extended `IdentifierToken`, any code that checks `is StageName` or `is IdentifierToken` on the flag value must change to `is LiteralToken`.

### `CopyInstruction.FromStageNameToken` type changed
- **Before:** `public StageName? FromStageNameToken { get; set; }`
- **After:** `public LiteralToken? FromStageNameToken { get; set; }`
- **Migration:** Replace `StageName` type references with `LiteralToken`. The `.Value` property works the same way on both types.

## Test plan
- [x] All existing tests pass (503)
- [x] COPY --from value type matches Lean spec

Fixes #194