### PR TITLE
Fix Lean COPY/ADD flag parsers for line continuations between flags

### DIFF
--- a/lean/DockerfileModel/Parser/Instructions/Add.lean
+++ b/lean/DockerfileModel/Parser/Instructions/Add.lean
@@ -62,7 +62,7 @@ private def addFlagParser (escapeChar : Char) : Parser (List Token) :=
                (or' (flagParser "checksum" escapeChar)
                (or' (booleanFlagParser "unpack" escapeChar)
                     (flagParser "exclude" escapeChar))))))
-    Parser.pure [flag]) escapeChar (excludeTrailingWhitespace := true)
+    Parser.pure [flag]) escapeChar
 
 -- ============================================================
 -- File transfer args (same pattern as COPY)

--- a/lean/DockerfileModel/Parser/Instructions/Copy.lean
+++ b/lean/DockerfileModel/Parser/Instructions/Copy.lean
@@ -59,7 +59,7 @@ private def copyFlagParser (escapeChar : Char) : Parser (List Token) :=
                (or' (booleanFlagParser "link" escapeChar)
                (or' (booleanFlagParser "parents" escapeChar)
                     (flagParser "exclude" escapeChar)))))
-    Parser.pure [flag]) escapeChar (excludeTrailingWhitespace := true)
+    Parser.pure [flag]) escapeChar
 
 -- ============================================================
 -- File transfer args (shared pattern for COPY and ADD)

--- a/src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs
@@ -724,12 +724,12 @@ public static class DockerfileArbitraries
             // from src in PathSegment()
             // from dst in PathSegment()
             // select $"COPY --chown={user}:{grp} {src} {dst}",
-            // Disabled: Lean parser crashes on line continuation between COPY flags (issue #210)
-            // from stage in StageName()
-            // from owner in Identifier()
-            // from src in PathSegment()
-            // from dst in PathSegment()
-            // select $"COPY --from={stage} \\\n  --chown={owner} {src} {dst}",
+            // Line continuation between COPY flags
+            from stage in StageName()
+            from owner in Identifier()
+            from src in PathSegment()
+            from dst in PathSegment()
+            select $"COPY --from={stage} \\\n  --chown={owner} {src} {dst}",
             // \r\n line continuation
             from src in PathSegment()
             from dst in PathSegment()
@@ -823,11 +823,11 @@ public static class DockerfileArbitraries
             from src in PathSegment()
             from dst in PathSegment()
             select $"ADD {src} \\\r\n  /{dst}/",
-            // Disabled: Lean parser crashes on line continuation between ADD flags (issue #210)
-            // from owner in Identifier()
-            // from src in PathSegment()
-            // from dst in PathSegment()
-            // select $"ADD --chown={owner} \\\n  --link {src} {dst}"
+            // Line continuation between ADD flags
+            from owner in Identifier()
+            from src in PathSegment()
+            from dst in PathSegment()
+            select $"ADD --chown={owner} \\\n  --link {src} {dst}",
             Gen.Constant("ADD src.txt /dst/"));
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Removed `excludeTrailingWhitespace := true` from Lean COPY and ADD flag parsers (`Copy.lean`, `Add.lean`)
- Allows `argTokens` to consume trailing whitespace and line continuations between flags
- Re-enabled 2 FsCheck generators for line continuation between COPY/ADD flags

## Test plan
- [x] All existing tests pass (649)
- [x] `COPY --from=stage \\n  --chown=user src dst` parses correctly

Fixes #210