### PR TITLE
Fix Lean shell form line continuation with trailing whitespace

### DIFF
--- a/lean/DockerfileModel/Parser/DockerfileParsers.lean
+++ b/lean/DockerfileModel/Parser/DockerfileParsers.lean
@@ -690,8 +690,12 @@ partial def shellFormCommand (escapeChar : Char) : Parser (List Token) := do
   -- Parse shell form as opaque text: $ is treated as a regular character.
   -- Each iteration produces either:
   --   a) a non-escape, non-newline character → StringToken, or
-  --   b) an escaped char (escape + non-newline) → StringToken, or
-  --   c) a line continuation (escape + newline) → LineContinuationToken.
+  --   b) a line continuation (escape + optional whitespace + newline) → LineContinuationToken, or
+  --   c) an escaped char (escape + non-newline char, not a line continuation) → StringToken.
+  --
+  -- Line continuation must be tried before escaped char so that
+  -- `\<spaces><newline>` is recognized as a continuation rather than
+  -- `escapedChar` consuming `\<space>` and terminating the instruction.
   let parts ← many1 (
     or' (do
       -- Any non-escape, non-newline character (including $, spaces, tabs)
@@ -699,10 +703,12 @@ partial def shellFormCommand (escapeChar : Char) : Parser (List Token) := do
                        "shell form character"
       Parser.pure (Token.mkString (String.ofList [c])))
     (or'
-      -- Line continuation (escape + newline)
+      -- Line continuation (escape + optional whitespace + newline) — must be
+      -- tried first so `\<trailing-spaces><newline>` is not consumed by escapedChar
       (lineContinuationParser escapeChar)
-      -- Escaped character (escape + non-newline char)
-      (escapedChar escapeChar)))
+      -- Escaped character, guarded: only match when the escape char is NOT
+      -- followed by optional whitespace + newline (which would be a continuation)
+      (except (escapedChar escapeChar) (lineContinuationParser escapeChar))))
   -- Group adjacent chars into string/whitespace runs
   let tokens := splitStringWhitespace parts
   if tokens.isEmpty then

--- a/src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs
@@ -517,8 +517,8 @@ public static class DockerfileArbitraries
             from c2 in Gen.Elements("apt-get install -y curl")
             from c3 in Gen.Elements("apt-get clean")
             select $"RUN {c1} \\\n  && {c2} \\\n  && {c3}",
-            // Disabled: Lean parser doesn't treat \<spaces><newline> as continuation (issue #211)
-            // Gen.Constant("RUN echo hello \\   \n  && echo world"),
+            // Shell form with backslash + trailing whitespace + newline as line continuation
+            Gen.Constant("RUN echo hello \\   \n  && echo world"),
             // Disabled: C# parser crashes on exec form with empty string element (issue #203)
             // from arg in Gen.Elements("hello", "-c", "test")
             // select $"RUN [\"\", \"{arg}\"]",


### PR DESCRIPTION
## Summary
- Added `except` guard on `escapedChar` in Lean `shellFormCommand` parser
- Ensures `lineContinuationParser` wins over `escapedChar` when `\<spaces><newline>` is present
- Re-enabled FsCheck generator for backslash + trailing whitespace + newline pattern

## Test plan
- [x] All existing tests pass (649)
- [x] `RUN echo hello \   \n  && echo world` treated as line continuation

Fixes #211