### PR TITLE
Fix variable default values with leading slashes parsed as symbols

### DIFF
--- a/src/Valleysoft.DockerfileModel.DiffTest/TokenJsonSerializer.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/TokenJsonSerializer.cs
@@ -36,10 +36,6 @@ namespace Valleysoft.DockerfileModel.DiffTest;
 ///     optionally =, literal["value"]] when the literal starts with "--".
 ///   - #259 (COPY/ADD empty exec-form arrays): C# produces a literal with value "[]" instead
 ///     of two symbol tokens. Workaround splits literal["[]"] into symbol["["] + symbol["]"].
-///   - #262 (slash in variable default values): For ":-/opt" and ":+/opt" style modifiers,
-///     C# emits symbol("/") as a sibling before the modifier value LiteralToken, but Lean
-///     merges it into the literal. Workaround merges symbol("/") + literal["opt"] into
-///     literal["/opt"]. Not applied for POSIX "/" and "//" modifiers where C# and Lean agree.
 ///   - #263 (mount value trailing whitespace): mount.ToString() absorbs trailing whitespace
 ///     into the mount value string. Workaround trims and emits a separate whitespace token.
 ///   - #264 (trailing whitespace on instructions): C# preserves trailing whitespace as a
@@ -150,12 +146,9 @@ public static class TokenJsonSerializer
             return;
         }
 
-        if (token is VariableRefToken varRef)
+        if (token is VariableRefToken)
         {
-            // Workaround for #262: slash in variable default values.
-            // For ":-/opt" and ":+/opt" modifiers, C# emits symbol("/") as a separate sibling
-            // of the modifier value LiteralToken, but Lean merges it into the literal.
-            SerializeVariableRef(sb, varRef);
+            SerializeAggregate(sb, "variableRef", token);
             return;
         }
 
@@ -337,128 +330,6 @@ public static class TokenJsonSerializer
             SerializeToken(sb, child);
             first = false;
         }
-    }
-
-    // ===================================================================
-    // Workaround: #262 — slash in variable default values
-    // For ":-/opt" and ":+/opt" style modifiers, C# emits symbol("/") as a
-    // separate sibling of the modifier value LiteralToken, but Lean merges
-    // the "/" into the literal's content.
-    //
-    // C# structure: variableRef[{, "VAR", :, -, symbol("/"), literal["opt"], }]
-    // Lean structure: variableRef[{, "VAR", :, -, literal["/opt"], }]
-    //
-    // POSIX slash modifiers ("/", "//") do NOT need this workaround — for those,
-    // both C# and Lean emit the slash symbol(s) as separate modifier tokens:
-    //   /modifier:  C# = {, "VAR", symbol("/"), literal["value"], }
-    //               Lean = {, "VAR", symbol("/"), literal["value"], }
-    //   //modifier: C# = {, "VAR", symbol("/"), symbol("/"), literal["value"], }
-    //               Lean = {, "VAR", symbol("/"), symbol("/"), literal["value"], }
-    // ===================================================================
-
-    /// <summary>
-    /// Serialize a VariableRefToken, applying the #262 workaround for ":-/opt"-style defaults.
-    /// When the modifier is NOT a POSIX slash modifier ("/" or "//"), a symbol("/") that
-    /// immediately precedes the modifier value LiteralToken is merged into the literal,
-    /// matching Lean's output. For POSIX slash modifiers, the structure is emitted as-is
-    /// since C# and Lean already agree.
-    ///
-    /// C# raw:  variableRef[{, "VAR", :, -, symbol("/"), literal["opt"], }]
-    /// C# out:  variableRef[{, "VAR", :, -, literal["/opt"], }]
-    /// Lean:    variableRef[{, "VAR", :, -, literal["/opt"], }]
-    /// </summary>
-    private static void SerializeVariableRef(StringBuilder sb, VariableRefToken varRef)
-    {
-        sb.Append("{\"type\":\"aggregate\",\"kind\":\"variableRef\",\"quoteChar\":null,\"children\":[");
-
-        List<Token> children = varRef.Tokens.ToList();
-        bool first = true;
-        LiteralToken? modifierValue = varRef.ModifierValueToken;
-
-        // For POSIX "/" and "//" modifiers, C# and Lean already agree — no transformation needed.
-        // Only apply the symbol("/") merge for other modifiers (e.g., ":-", ":+", "-", "+").
-        string? modifier = varRef.Modifier;
-        bool isPosixSlashModifier = modifier == "/" || modifier == "//";
-
-        for (int i = 0; i < children.Count; i++)
-        {
-            Token child = children[i];
-
-            // Workaround for #262: merge symbol("/") + modifierValue into literal["/..."]
-            // Only applies when the modifier is NOT "/" or "//" (i.e., the slash is not the
-            // modifier itself but a leading "/" in the default value like ":-/opt").
-            if (!isPosixSlashModifier
-                && child is SymbolToken slashSym && slashSym.Value == "/"
-                && modifierValue != null
-                && i + 1 < children.Count && children[i + 1] == modifierValue)
-            {
-                if (!first) sb.Append(',');
-                first = false;
-                // Prepend "/" to the modifier value literal's first string token
-                SerializeModifierValueLiteralWithSlashPrefix(sb, modifierValue, "/");
-                i++; // skip the literal (consumed)
-                continue;
-            }
-
-            if (!first) sb.Append(',');
-            SerializeToken(sb, child);
-            first = false;
-        }
-
-        sb.Append("]}");
-    }
-
-    /// <summary>
-    /// Serialize a modifier value LiteralToken with a "/" prefix prepended to its content.
-    /// Merges: prefix="/" + literal[string("opt")] → literal[string("/opt")]
-    /// </summary>
-    private static void SerializeModifierValueLiteralWithSlashPrefix(
-        StringBuilder sb, LiteralToken literal, string prefix)
-    {
-        sb.Append("{\"type\":\"aggregate\",\"kind\":\"literal\",\"quoteChar\":");
-        if (literal.QuoteChar.HasValue)
-        {
-            sb.Append('"');
-            JsonEscapeString(sb, literal.QuoteChar.Value.ToString());
-            sb.Append('"');
-        }
-        else
-        {
-            sb.Append("null");
-        }
-        sb.Append(",\"children\":[");
-
-        List<Token> innerChildren = literal.Tokens.ToList();
-        bool prefixApplied = false;
-        bool first = true;
-
-        for (int j = 0; j < innerChildren.Count; j++)
-        {
-            Token innerChild = innerChildren[j];
-
-            // Apply prefix to the first string token
-            if (!prefixApplied && innerChild is StringToken firstStr)
-            {
-                if (!first) sb.Append(',');
-                SerializePrimitive(sb, "string", prefix + firstStr.Value);
-                first = false;
-                prefixApplied = true;
-                continue;
-            }
-
-            if (!first) sb.Append(',');
-            SerializeToken(sb, innerChild);
-            first = false;
-        }
-
-        // If prefix was never applied (empty literal), emit prefix as its own string
-        if (!prefixApplied)
-        {
-            if (!first) sb.Append(',');
-            SerializePrimitive(sb, "string", prefix);
-        }
-
-        sb.Append("]}");
     }
 
     // ===================================================================

--- a/src/Valleysoft.DockerfileModel.Tests/EnvInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/EnvInstructionTests.cs
@@ -485,6 +485,41 @@ public class EnvInstructionTests
                             token => ValidateWhitespace(token, "  "),
                             token => ValidateString(token, "bar")))
                 }
+            },
+            // Variable reference default value with path — leading slash must stay in the literal
+            new ParseTestScenario<EnvInstruction>
+            {
+                Text = "ENV PATH=${BASE:-/usr/local}/bin",
+                TokenValidators = new Action<Token>[]
+                {
+                    token => ValidateKeyword(token, "ENV"),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateAggregate<KeyValueToken<Variable, LiteralToken>>(token, "PATH=${BASE:-/usr/local}/bin",
+                        token => ValidateIdentifier<Variable>(token, "PATH"),
+                        token => ValidateSymbol(token, '='),
+                        token => ValidateAggregate<LiteralToken>(token, "${BASE:-/usr/local}/bin",
+                            token => ValidateAggregate<VariableRefToken>(token, "${BASE:-/usr/local}",
+                                token => ValidateSymbol(token, '{'),
+                                token => ValidateString(token, "BASE"),
+                                token => ValidateSymbol(token, ':'),
+                                token => ValidateSymbol(token, '-'),
+                                token => ValidateLiteral(token, "/usr/local"),
+                                token => ValidateSymbol(token, '}')),
+                            token => ValidateString(token, "/bin")))
+                },
+                Validate = result =>
+                {
+                    Assert.Equal("ENV", result.InstructionName);
+                    Assert.Collection(result.Variables, new Action<IKeyValuePair>[]
+                    {
+                        pair =>
+                        {
+                            Assert.Equal("PATH", pair.Key);
+                            Assert.Equal("${BASE:-/usr/local}/bin", pair.Value);
+                        }
+                    });
+                    Assert.Equal("ENV PATH=${BASE:-/usr/local}/bin", result.ToString());
+                }
             }
         };
 

--- a/src/Valleysoft.DockerfileModel.Tests/VariableRefTokenTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/VariableRefTokenTests.cs
@@ -292,6 +292,66 @@ public class VariableRefTokenTests
                     Assert.Equal("//", result.Modifier);
                     Assert.Equal("old/new", result.ModifierValue);
                 }
+            },
+            // Default value with leading slash — slash must not be split into a separate symbol token
+            new ParseTestScenario<VariableRefToken>
+            {
+                Text = "${BASE:-/opt}",
+                TokenValidators = new Action<Token>[]
+                {
+                    token => ValidateSymbol(token, '{'),
+                    token => ValidateString(token, "BASE"),
+                    token => ValidateSymbol(token, ':'),
+                    token => ValidateSymbol(token, '-'),
+                    token => ValidateLiteral(token, "/opt"),
+                    token => ValidateSymbol(token, '}')
+                },
+                Validate = result =>
+                {
+                    Assert.Equal("BASE", result.VariableName);
+                    Assert.Equal(":-", result.Modifier);
+                    Assert.Equal("/opt", result.ModifierValue);
+                }
+            },
+            // Default value with longer path — entire path stays as one literal
+            new ParseTestScenario<VariableRefToken>
+            {
+                Text = "${BASE:-/usr/local}",
+                TokenValidators = new Action<Token>[]
+                {
+                    token => ValidateSymbol(token, '{'),
+                    token => ValidateString(token, "BASE"),
+                    token => ValidateSymbol(token, ':'),
+                    token => ValidateSymbol(token, '-'),
+                    token => ValidateLiteral(token, "/usr/local"),
+                    token => ValidateSymbol(token, '}')
+                },
+                Validate = result =>
+                {
+                    Assert.Equal("BASE", result.VariableName);
+                    Assert.Equal(":-", result.Modifier);
+                    Assert.Equal("/usr/local", result.ModifierValue);
+                }
+            },
+            // Alternate-value modifier with leading slash
+            new ParseTestScenario<VariableRefToken>
+            {
+                Text = "${APP:+/run}",
+                TokenValidators = new Action<Token>[]
+                {
+                    token => ValidateSymbol(token, '{'),
+                    token => ValidateString(token, "APP"),
+                    token => ValidateSymbol(token, ':'),
+                    token => ValidateSymbol(token, '+'),
+                    token => ValidateLiteral(token, "/run"),
+                    token => ValidateSymbol(token, '}')
+                },
+                Validate = result =>
+                {
+                    Assert.Equal("APP", result.VariableName);
+                    Assert.Equal(":+", result.Modifier);
+                    Assert.Equal("/run", result.ModifierValue);
+                }
             }
         };
 

--- a/src/Valleysoft.DockerfileModel.Tests/WorkdirInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/WorkdirInstructionTests.cs
@@ -98,6 +98,37 @@ public class WorkdirInstructionTests
                     token => ValidateWhitespace(token, " "),
                     token => ValidateLiteral(token, "/test")
                 }
+            },
+            // Variable reference with path default value — slash must not be split into a separate symbol token
+            new ParseTestScenario<WorkdirInstruction>
+            {
+                Text = "WORKDIR ${BASE:-/opt}/${APP:-myapp}",
+                TokenValidators = new Action<Token>[]
+                {
+                    token => ValidateKeyword(token, "WORKDIR"),
+                    token => ValidateWhitespace(token, " "),
+                    token => ValidateAggregate<LiteralToken>(token, "${BASE:-/opt}/${APP:-myapp}",
+                        token => ValidateAggregate<VariableRefToken>(token, "${BASE:-/opt}",
+                            token => ValidateSymbol(token, '{'),
+                            token => ValidateString(token, "BASE"),
+                            token => ValidateSymbol(token, ':'),
+                            token => ValidateSymbol(token, '-'),
+                            token => ValidateLiteral(token, "/opt"),
+                            token => ValidateSymbol(token, '}')),
+                        token => ValidateString(token, "/"),
+                        token => ValidateAggregate<VariableRefToken>(token, "${APP:-myapp}",
+                            token => ValidateSymbol(token, '{'),
+                            token => ValidateString(token, "APP"),
+                            token => ValidateSymbol(token, ':'),
+                            token => ValidateSymbol(token, '-'),
+                            token => ValidateLiteral(token, "myapp"),
+                            token => ValidateSymbol(token, '}')))
+                },
+                Validate = result =>
+                {
+                    Assert.Equal("${BASE:-/opt}/${APP:-myapp}", result.Path);
+                    Assert.Equal("WORKDIR ${BASE:-/opt}/${APP:-myapp}", result.ToString());
+                }
             }
         };
 

--- a/src/Valleysoft.DockerfileModel/Tokens/VariableRefToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/VariableRefToken.cs
@@ -302,7 +302,7 @@ public class VariableRefToken : AggregateToken
             from varName in VariableIdentifier()
             select new StringToken(varName)
         from modifierTokens in (
-            from modifier in OrConcat(variableSubstitutionModifiers).Once()
+            from modifier in variableSubstitutionModifiers.Aggregate((current, next) => current.Or(next)).Once()
             from modifierValueTokens in ValueOrVariableRef(escapeChar, createModifierValueToken, new char[] { '}' })
                 .AtLeastOnce()
                 .Flatten()


### PR DESCRIPTION
## Summary
- Fixed `BracedVariableReference` parser in `VariableRefToken.cs` — replaced greedy `OrConcat(...).Many()` with a single `Or` chain that matches exactly one modifier
- `/` is no longer treated as a POSIX replacement modifier inside `${}`
- Path-like defaults like `${BASE:-/opt}` now keep `/opt` as a single literal
- Removed serializer workarounds (`SerializeVariableRef`, `SerializeModifierValueLiteralWithSlashPrefix`)
- Added 5 new tests across `VariableRefTokenTests`, `WorkdirInstructionTests`, `EnvInstructionTests`

Fixes #262

## Test plan
- [x] `${BASE:-/opt}` default value is single `literal["/opt"]`
- [x] `${BASE:-/usr/local}` keeps full path as one literal
- [x] `WORKDIR ${BASE:-/opt}/${APP:-myapp}` parses correctly
- [x] Round-trip fidelity maintained
- [x] All 1044 tests pass