### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:best-practices"
   ],
+  "dependencyDashboard": false,
   "mode": "full",
   "ignorePaths": [
     "src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs"


### PR DESCRIPTION
Disable Renovate's Dependency Dashboard so dependency updates are managed directly through Renovate pull requests without maintaining a dashboard issue.

This explicitly sets `dependencyDashboard` to `false` while retaining the existing best-practices preset.