### PR TITLE
Delay Renovate updates for 10 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
     "config:best-practices"
   ],
   "dependencyDashboard": false,
+  "minimumReleaseAge": "10 days",
   "mode": "full",
   "ignorePaths": [
     "src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs"


### PR DESCRIPTION
Renovate should avoid proposing dependency releases immediately, allowing time for newly published versions to stabilize. Configure a 10-day minimum release age before updates are considered.