### PR TITLE
Use global.json for .NET setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
+          global-json-file: global.json
 
       - name: Install dependencies
         run: dotnet restore
@@ -71,8 +70,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
-          dotnet-quality: 'ga'
+          global-json-file: global.json
 
       - name: Install elan
         run: |


### PR DESCRIPTION
CI should install the same .NET SDK version used by local builds and release automation. Update both CI jobs that use `actions/setup-dotnet` to read the SDK version and roll-forward policy from `global.json` instead of independently selecting `10.0.x`.