### PR TITLE
Add Release Drafter and release labeling policy

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,65 @@
+name-template: "Dockerfile Model $RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+tag-prefix: "v"
+commitish: refs/heads/main
+include-pre-releases: true
+
+categories:
+  - type: pre-exclude
+    when:
+      label: skip-changelog
+
+  - title: "Features"
+    exclusive: true
+    when:
+      labels:
+        - enhancement
+        - type:feature
+
+  - title: "Bug Fixes"
+    exclusive: true
+    when:
+      labels:
+        - bug
+        - type:bug
+
+  - title: "Documentation"
+    exclusive: true
+    when:
+      labels:
+        - documentation
+        - type:docs
+
+  - title: "Dependencies"
+    exclusive: true
+    collapse-after: 5
+    when:
+      label: dependencies
+
+  - title: "Maintenance"
+
+  - type: version-resolver
+    semver-increment: major
+    when:
+      label: semver:major
+
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      label: semver:minor
+
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      label: semver:patch
+
+  - type: version-resolver
+    semver-increment: patch
+
+change-template: "- $TITLE (#$NUMBER) by $AUTHORS"
+change-title-escapes: '\<*_&'
+template: |
+  ## What's Changed
+
+  $CHANGES
+no-changes-template: "* No user-facing changes"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,33 @@
   "dependencyDashboard": false,
   "minimumReleaseAge": "10 days",
   "mode": "full",
+  "addLabels": [
+    "dependencies",
+    "semver:patch"
+  ],
+  "packageRules": [
+    {
+      "description": "Exclude internal dependency updates from release notes",
+      "matchFileNames": [
+        ".github/workflows/**",
+        "global.json",
+        "src/Valleysoft.DockerfileModel.DiffTest/**",
+        "src/Valleysoft.DockerfileModel.Tests/**"
+      ],
+      "addLabels": [
+        "skip-changelog"
+      ]
+    },
+    {
+      "description": "Exclude build-only tooling from release notes",
+      "matchPackageNames": [
+        "MinVer"
+      ],
+      "addLabels": [
+        "skip-changelog"
+      ]
+    }
+  ],
   "ignorePaths": [
     "src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs"
   ]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-drafter-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update release draft
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,8 +10,8 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: release-drafter-${{ github.ref }}
-  cancel-in-progress: true
+  group: release-drafter
+  cancel-in-progress: false
 
 jobs:
   update_release_draft:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,42 @@ The Lean spec includes both machine-checked proofs (`Proofs/`) and SlimCheck pro
 - `lean/` — Lean 4 formal specification (token model, parser combinators, proofs, differential test CLI)
 - `global.json` — pins .NET SDK version
 - `src/Directory.Build.props` — shared MSBuild properties (license, authors, repo URL)
+
+## Pull request labels
+
+Every pull request must have exactly one semantic-version label, selected by the
+highest-impact public change:
+
+- `semver:major` for breaking public API or behavior
+- `semver:minor` for backward-compatible public functionality
+- `semver:patch` for fixes, documentation, dependencies, tests, build changes,
+  or maintenance
+
+Apply at most one canonical visible category:
+
+- `enhancement` for features
+- `bug` for fixes
+- `documentation` for documentation-only changes
+- `dependencies` for dependency updates
+- No category for maintenance, refactoring, tests, or infrastructure
+
+The existing `type:feature`, `type:bug`, and `type:docs` labels are accepted as
+aliases for `enhancement`, `bug`, and `documentation`. Apply only the canonical
+label to new pull requests.
+
+For mixed pull requests, classify by the highest-impact public change. A
+test-heavy pull request that fixes a product bug is `bug`; a dependency pull
+request spanning production and tooling dependencies remains `dependencies`.
+
+Apply `skip-changelog` to internal-only test dependency updates, CI action
+updates, build or tooling changes, and repository administration that are not
+useful to package users. Do not apply it to production dependency updates,
+user-facing fixes, features, documentation, or significant release behavior
+that users or maintainers should know about.
+
+Renovate automatically applies `dependencies` and `semver:patch`, plus
+`skip-changelog` for internal dependency and build-tool updates. Replace its
+semantic-version label when an update has a higher public impact.
+
+After creating a pull request, apply the labels on GitHub and verify them before
+considering pull request creation complete.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,46 @@
 # Maintainer guide
 
+## Label pull requests
+
+Apply exactly one semantic-version label based on the highest-impact public
+change:
+
+- `semver:major` for breaking public API or behavior
+- `semver:minor` for backward-compatible public functionality
+- `semver:patch` for fixes, documentation, dependencies, tests, build changes,
+  or maintenance
+
+Apply at most one release-note category:
+
+- `enhancement` for features
+- `bug` for fixes
+- `documentation` for documentation-only changes
+- `dependencies` for dependency updates
+- No category for maintenance, refactoring, tests, or infrastructure
+
+The existing `type:feature`, `type:bug`, and `type:docs` labels are accepted as
+aliases for `enhancement`, `bug`, and `documentation`. Apply only the canonical
+label to new pull requests.
+
+For mixed pull requests, classify by the highest-impact public change. For
+example, a test-heavy pull request that fixes a product bug is a `bug`. A
+dependency pull request that updates production and tooling dependencies remains
+a `dependencies` change.
+
+Apply `skip-changelog` to internal-only test dependency updates, CI action
+updates, build or tooling changes, and repository administration that package
+users do not need to know about. Do not apply `skip-changelog` to production
+dependency updates, user-facing fixes, features, documentation, or significant
+release behavior.
+
+Renovate automatically applies `dependencies` and `semver:patch`, plus
+`skip-changelog` for internal dependency and build-tool updates. Replace its
+semantic-version label when an update has a higher public impact.
+
 ## Versioning and releases
 
 Package and assembly versions are derived from Git tags by
-[MinVer](https://github.com/adamralph/minver). Create a tag on the commit to
-release and push it to start the release workflow:
+[MinVer](https://github.com/adamralph/minver):
 
 * Stable release: `v1.2.3`
 * Prerelease: `v1.2.3-preview.1`
@@ -16,3 +52,35 @@ Untagged commits use MinVer's deterministic development version. After a stable
 release, MinVer increments the patch version and adds an `alpha.0` prerelease
 identifier and the Git commit height, so an untagged build cannot be mistaken
 for a stable release.
+
+## Manage release notes
+
+[Release Drafter](https://github.com/release-drafter/release-drafter) collects
+pull requests merged to `main` since the latest published release in an
+unpublished GitHub Release and uses their labels to organize the release notes
+and select the next version.
+
+If no semantic-version label is present, Release Drafter proposes a patch
+release. If more than one is present, the highest version change wins. Pull
+requests without a category appear under Maintenance. Pull requests with
+`skip-changelog` are excluded from both the release notes and version
+resolution.
+
+If labels are corrected after a pull request is merged, manually run the
+Release Drafter workflow to update the draft immediately.
+
+To publish a stable release:
+
+1. Review the accumulated draft on the GitHub Releases page.
+2. Confirm that its proposed version and release notes are correct.
+3. Publish the draft. GitHub creates its proposed `v*` tag on `main`, which
+   starts the release workflow and publishes the matching NuGet package.
+
+For a prerelease, create a GitHub prerelease with a tag such as
+`v1.2.3-preview.1`. Creating the tag starts the same package release workflow.
+Publishing a prerelease starts a new draft range, so the later stable release
+notes contain only changes made after that prerelease. The prerelease remains
+the release-note record for the changes it introduced.
+
+Published GitHub Releases are the release-note system of record; this repository
+does not maintain a `CHANGELOG.md`.


### PR DESCRIPTION
Release notes currently require manual assembly, and pull requests do not consistently communicate their release-note category or semantic-version impact. This adds an accumulated draft-release workflow and a documented labeling policy so maintainers can review a complete proposed release before publishing it.

- Categorize features, fixes, documentation, dependencies, and maintenance changes while excluding internal-only work.
- Resolve the next version from `semver:*` labels, with patch as the fallback, and account for published prereleases.
- Update one draft after pushes to `main` or a manual run, with the draft target pinned to `main`, serialized execution, least-privilege permissions, and a SHA-pinned Release Drafter action.
- Configure Renovate to label dependency updates and exclude test, CI, SDK, and build-tool updates from public notes.
- Document the stable and prerelease publishing flow and establish GitHub Releases as the release-note system of record.

Publishing a prerelease starts a new draft range. Its published GitHub Release remains the release-note record for changes introduced by that prerelease, while the next draft contains subsequent changes.

Fixes: #361