### PR TITLE
Restore warning-free build and untangle test support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
         ".github/workflows/**",
         "global.json",
         "src/Valleysoft.DockerfileModel.DiffTest/**",
+        "src/Valleysoft.DockerfileModel.TestSupport/**",
         "src/Valleysoft.DockerfileModel.Tests/**"
       ],
       "addLabels": [
@@ -34,6 +35,6 @@
     }
   ],
   "ignorePaths": [
-    "src/Valleysoft.DockerfileModel.Tests/Generators/DockerfileArbitraries.cs"
+    "src/Valleysoft.DockerfileModel.TestSupport/Generators/DockerfileArbitraries.cs"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,16 @@ Key components:
 
 The `src/Valleysoft.DockerfileModel.DiffTest/` project bridges C# and Lean:
 
-- **`InputGenerator.cs`** — generates random Dockerfile instruction strings using FsCheck generators from `DockerfileArbitraries.cs` across all 18 instruction types.
+- **`InputGenerator.cs`** — generates random Dockerfile instruction strings using the shared FsCheck generators across all 18 instruction types.
 - **`DiffTestRunner.cs`** — parses each input with both C# and Lean, compares canonical JSON output for byte-identical match.
-- **`TokenJsonSerializer.cs`** — hand-written recursive JSON serializer that transforms C# token trees into the canonical format. Includes workarounds for known C# tokenization differences (each tagged with the GitHub issue tracking the underlying fix).
 - **`Program.cs`** — CLI with `--compare`, `--parse`, and `--generate` modes.
+
+The `src/Valleysoft.DockerfileModel.TestSupport/` project provides shared,
+non-production infrastructure to Tests and DiffTest:
+
+- **`Generators/DockerfileArbitraries.cs`** — FsCheck generators used by property and differential tests.
+- **`InstructionSerializer.cs`** — parses C# instructions for canonical comparison.
+- **`TokenJsonSerializer.cs`** — transforms C# token trees into canonical JSON and contains tracked workarounds for known tokenization differences.
 
 ### Source of Truth
 
@@ -104,7 +110,7 @@ Tests use **xUnit** with `[Theory]`/`[InlineData]` for data-driven tests and `[F
 
 ### Property-Based Tests (FsCheck)
 
-`PropertyTests.cs` contains property-based tests using FsCheck generators from `Generators/DockerfileArbitraries.cs`:
+`PropertyTests.cs` contains property-based tests using FsCheck generators from the TestSupport project:
 - **Round-trip fidelity** — `Parse(text).ToString() == text` for all 18 instruction types + full Dockerfiles
 - **Token tree consistency** — at every `AggregateToken` node, `ToString() == concat(children.ToString())`
 - **Variable resolution non-mutation** — `ResolveVariables()` without `UpdateInline` doesn't change the model
@@ -118,7 +124,8 @@ The Lean spec includes both machine-checked proofs (`Proofs/`) and SlimCheck pro
 ## Project Layout
 
 - `src/Valleysoft.DockerfileModel/` — library targeting `netstandard2.0` and `net10.0` (C# 13, nullable enabled)
-- `src/Valleysoft.DockerfileModel.Tests/` — test project targeting `net10.0` (unit tests, property tests, FsCheck generators)
+- `src/Valleysoft.DockerfileModel.Tests/` — test project targeting `net10.0` (unit and property tests)
+- `src/Valleysoft.DockerfileModel.TestSupport/` — shared non-production generators and canonical serialization support targeting `net8.0`
 - `src/Valleysoft.DockerfileModel.DiffTest/` — differential test CLI targeting `net8.0` (compares C# vs Lean parser output)
 - `lean/` — Lean 4 formal specification (token model, parser combinators, proofs, differential test CLI)
 - `global.json` — pins .NET SDK version

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,5 +4,7 @@
     <RepositoryUrl>https://github.com/mthalman/DockerfileModel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Authors>Matt Thalman and Contributors</Authors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1900</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.Text;
-using Valleysoft.DockerfileModel.Tokens;
+using Valleysoft.DockerfileModel.TestSupport;
 
 namespace Valleysoft.DockerfileModel.DiffTest;
 
@@ -41,31 +41,7 @@ public class DiffTestRunner
     /// Parse an instruction with the C# parser and serialize to canonical JSON.
     /// </summary>
     public static string ParseCSharp(string instructionType, string input, char escapeChar = '\\')
-    {
-        Token token = instructionType.ToUpperInvariant() switch
-        {
-            "FROM" => FromInstruction.Parse(input, escapeChar),
-            "ARG" => ArgInstruction.Parse(input, escapeChar),
-            "RUN" => RunInstruction.Parse(input, escapeChar),
-            "CMD" => CmdInstruction.Parse(input, escapeChar),
-            "ENTRYPOINT" => EntrypointInstruction.Parse(input, escapeChar),
-            "COPY" => CopyInstruction.Parse(input, escapeChar),
-            "ADD" => AddInstruction.Parse(input, escapeChar),
-            "ENV" => EnvInstruction.Parse(input, escapeChar),
-            "EXPOSE" => ExposeInstruction.Parse(input, escapeChar),
-            "VOLUME" => VolumeInstruction.Parse(input, escapeChar),
-            "USER" => UserInstruction.Parse(input, escapeChar),
-            "WORKDIR" => WorkdirInstruction.Parse(input, escapeChar),
-            "LABEL" => LabelInstruction.Parse(input, escapeChar),
-            "STOPSIGNAL" => StopSignalInstruction.Parse(input, escapeChar),
-            "HEALTHCHECK" => HealthCheckInstruction.Parse(input, escapeChar),
-            "SHELL" => ShellInstruction.Parse(input, escapeChar),
-            "MAINTAINER" => MaintainerInstruction.Parse(input, escapeChar),
-            "ONBUILD" => OnBuildInstruction.Parse(input, escapeChar),
-            _ => throw new ArgumentException($"Unsupported instruction type: {instructionType}")
-        };
-        return TokenJsonSerializer.Serialize(token);
-    }
+        => InstructionSerializer.ParseCSharp(instructionType, input, escapeChar);
 
     /// <summary>
     /// Parse an instruction with the Lean CLI and capture JSON from stdout.

--- a/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
@@ -1,11 +1,11 @@
 using FsCheck;
 using FsCheck.Fluent;
-using Valleysoft.DockerfileModel.Tests.Generators;
+using Valleysoft.DockerfileModel.TestSupport.Generators;
 
 namespace Valleysoft.DockerfileModel.DiffTest;
 
 /// <summary>
-/// Wraps the linked FsCheck generators (DockerfileArbitraries) to produce
+/// Wraps the shared FsCheck generators (DockerfileArbitraries) to produce
 /// random test inputs for differential testing. Returns a list of
 /// (InstructionType, Text, EscapeChar) tuples distributed evenly across all 18
 /// Dockerfile instruction types, shuffled with a fixed seed for reproducibility.

--- a/src/Valleysoft.DockerfileModel.TestSupport/Generators/DockerfileArbitraries.cs
+++ b/src/Valleysoft.DockerfileModel.TestSupport/Generators/DockerfileArbitraries.cs
@@ -1,7 +1,7 @@
 using FsCheck;
 using FsCheck.Fluent;
 
-namespace Valleysoft.DockerfileModel.Tests.Generators;
+namespace Valleysoft.DockerfileModel.TestSupport.Generators;
 
 /// <summary>
 /// FsCheck 3.x generators that produce valid Dockerfile instruction strings.

--- a/src/Valleysoft.DockerfileModel.TestSupport/InstructionSerializer.cs
+++ b/src/Valleysoft.DockerfileModel.TestSupport/InstructionSerializer.cs
@@ -1,0 +1,34 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel.TestSupport;
+
+public static class InstructionSerializer
+{
+    public static string ParseCSharp(string instructionType, string input, char escapeChar = '\\')
+    {
+        Token token = instructionType.ToUpperInvariant() switch
+        {
+            "FROM" => FromInstruction.Parse(input, escapeChar),
+            "ARG" => ArgInstruction.Parse(input, escapeChar),
+            "RUN" => RunInstruction.Parse(input, escapeChar),
+            "CMD" => CmdInstruction.Parse(input, escapeChar),
+            "ENTRYPOINT" => EntrypointInstruction.Parse(input, escapeChar),
+            "COPY" => CopyInstruction.Parse(input, escapeChar),
+            "ADD" => AddInstruction.Parse(input, escapeChar),
+            "ENV" => EnvInstruction.Parse(input, escapeChar),
+            "EXPOSE" => ExposeInstruction.Parse(input, escapeChar),
+            "VOLUME" => VolumeInstruction.Parse(input, escapeChar),
+            "USER" => UserInstruction.Parse(input, escapeChar),
+            "WORKDIR" => WorkdirInstruction.Parse(input, escapeChar),
+            "LABEL" => LabelInstruction.Parse(input, escapeChar),
+            "STOPSIGNAL" => StopSignalInstruction.Parse(input, escapeChar),
+            "HEALTHCHECK" => HealthCheckInstruction.Parse(input, escapeChar),
+            "SHELL" => ShellInstruction.Parse(input, escapeChar),
+            "MAINTAINER" => MaintainerInstruction.Parse(input, escapeChar),
+            "ONBUILD" => OnBuildInstruction.Parse(input, escapeChar),
+            _ => throw new ArgumentException($"Unsupported instruction type: {instructionType}")
+        };
+
+        return TokenJsonSerializer.Serialize(token);
+    }
+}

--- a/src/Valleysoft.DockerfileModel.TestSupport/InstructionSerializer.cs
+++ b/src/Valleysoft.DockerfileModel.TestSupport/InstructionSerializer.cs
@@ -1,3 +1,4 @@
+using Valleysoft.DockerfileModel;
 using Valleysoft.DockerfileModel.Tokens;
 
 namespace Valleysoft.DockerfileModel.TestSupport;

--- a/src/Valleysoft.DockerfileModel.TestSupport/TokenJsonSerializer.cs
+++ b/src/Valleysoft.DockerfileModel.TestSupport/TokenJsonSerializer.cs
@@ -2,7 +2,7 @@ using System.Text;
 using Valleysoft.DockerfileModel;
 using Valleysoft.DockerfileModel.Tokens;
 
-namespace Valleysoft.DockerfileModel.DiffTest;
+namespace Valleysoft.DockerfileModel.TestSupport;
 
 /// <summary>
 /// Hand-written recursive JSON serializer for the C# Token hierarchy.

--- a/src/Valleysoft.DockerfileModel.TestSupport/Valleysoft.DockerfileModel.TestSupport.csproj
+++ b/src/Valleysoft.DockerfileModel.TestSupport/Valleysoft.DockerfileModel.TestSupport.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Valleysoft.DockerfileModel\Valleysoft.DockerfileModel.csproj" />
-    <ProjectReference Include="..\Valleysoft.DockerfileModel.TestSupport\Valleysoft.DockerfileModel.TestSupport.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Valleysoft.DockerfileModel.Tests/AddInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/AddInstructionTests.cs
@@ -1416,15 +1416,15 @@ public class AddInstructionTests : FileTransferInstructionTests<AddInstruction>
 
     public class AddInstructionCreateTestScenario : TestScenario<AddInstruction>
     {
-        public IEnumerable<string> Sources { get; set; }
-        public string Destination { get; set; }
-        public string ChangeOwner { get; set; }
-        public string Permissions { get; set; }
-        public string Checksum { get; set; }
+        public required IEnumerable<string> Sources { get; set; }
+        public required string Destination { get; set; }
+        public string? ChangeOwner { get; set; }
+        public string? Permissions { get; set; }
+        public string? Checksum { get; set; }
         public bool KeepGitDir { get; set; }
         public bool Link { get; set; }
         public bool Unpack { get; set; }
-        public IEnumerable<string> Excludes { get; set; }
+        public IEnumerable<string>? Excludes { get; set; }
         public char EscapeChar { get; set; } = Dockerfile.DefaultEscapeChar;
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/AggregateTokenTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/AggregateTokenTests.cs
@@ -52,10 +52,10 @@ public class AggregateTokenTests
     [InlineData("repo:${TAG:-${TAG2}}", '\\', "TAG", "test", "TAG2", "foo", "repo:test")]
     [InlineData("repo:${TAG:-${TAG2:-a${TAG3}b}}", '\\', "TAG3", "foo", null, null, "repo:afoob")]
     public void Resolve(
-        string text, char escapeChar, string arg1Name, string arg1Value, string arg2Name, string arg2Value, string expected,
-        bool removeEscapeCharacters = false, string expectedError = null)
+        string text, char escapeChar, string? arg1Name, string? arg1Value, string? arg2Name, string? arg2Value, string? expected,
+        bool removeEscapeCharacters = false, string? expectedError = null)
     {
-        Dictionary<string, string> args = new();
+        Dictionary<string, string?> args = new();
         if (arg1Name != null)
         {
             args.Add(arg1Name, arg1Value);
@@ -75,7 +75,7 @@ public class AggregateTokenTests
 
         if (expectedError is null)
         {
-            string actual = inst.ResolveVariables(escapeChar, args, options);
+            string? actual = inst.ResolveVariables(escapeChar, args, options);
             Assert.Equal($"FROM {expected}", actual);
         }
         else

--- a/src/Valleysoft.DockerfileModel.Tests/ArgDeclarationTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ArgDeclarationTests.cs
@@ -34,9 +34,9 @@ public class ArgDeclarationTests
         Assert.Equal("test3", arg.Name);
         Assert.Equal("test3", arg.NameToken.Value);
 
-        Assert.Throws<ArgumentNullException>(() => arg.Name = null);
+        Assert.Throws<ArgumentNullException>(() => arg.Name = null!);
         Assert.Throws<ArgumentException>(() => arg.Name = "");
-        Assert.Throws<ArgumentNullException>(() => arg.NameToken = null);
+        Assert.Throws<ArgumentNullException>(() => arg.NameToken = null!);
     }
 
     [Fact]
@@ -49,7 +49,7 @@ public class ArgDeclarationTests
 
         arg.Value = "foo";
         Assert.Equal("foo", arg.Value);
-        Assert.Equal("foo", arg.ValueToken.Value);
+        Assert.Equal("foo", Assert.IsType<LiteralToken>(arg.ValueToken).Value);
         Assert.True(arg.HasAssignmentOperator);
 
         arg.Value = "";
@@ -243,7 +243,7 @@ public class ArgDeclarationTests
                 Validate = result =>
                 {
                     Assert.Equal("MY_ARG", result.Name);
-                    Assert.Empty(result.Value);
+                    Assert.Equal(string.Empty, result.Value);
                 }
             },
             // Line continuation after = with indented default value (issue #288)
@@ -412,7 +412,7 @@ public class ArgDeclarationTests
 
     public class CreateTestScenario : TestScenario<ArgDeclaration>
     {
-        public string Name { get; set; }
-        public string Value { get; set; }
+        public required string Name { get; set; }
+        public string? Value { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/ArgInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ArgInstructionTests.cs
@@ -44,7 +44,7 @@ public class ArgInstructionTests
         }
 
         ArgInstruction result = new(
-            new Dictionary<string, string>
+            new Dictionary<string, string?>
             {
                 { "VAR1", "test" }
             });
@@ -397,7 +397,7 @@ public class ArgInstructionTests
         {
             new CreateTestScenario
             {
-                Args = new Dictionary<string, string>
+                Args = new Dictionary<string, string?>
                 {
                     { "TEST1", null }
                 },
@@ -411,7 +411,7 @@ public class ArgInstructionTests
             },
             new CreateTestScenario
             {
-                Args = new Dictionary<string, string>
+                Args = new Dictionary<string, string?>
                 {
                     { "TEST1", null },
                     { "TEST2", null }
@@ -429,7 +429,7 @@ public class ArgInstructionTests
             },
             new CreateTestScenario
             {
-                Args = new Dictionary<string, string>
+                Args = new Dictionary<string, string?>
                 {
                     { "TEST1", "b" }
                 },
@@ -445,7 +445,7 @@ public class ArgInstructionTests
             },
             new CreateTestScenario
             {
-                Args = new Dictionary<string, string>
+                Args = new Dictionary<string, string?>
                 {
                     { "TEST1", "b" },
                     { "TEST2", "c" }
@@ -467,7 +467,7 @@ public class ArgInstructionTests
             },
             new CreateTestScenario
             {
-                Args = new Dictionary<string, string>
+                Args = new Dictionary<string, string?>
                 {
                     { "TEST1", "" }
                 },
@@ -482,7 +482,7 @@ public class ArgInstructionTests
             },
             new CreateTestScenario
             {
-                Args = new Dictionary<string, string>
+                Args = new Dictionary<string, string?>
                 {
                     { "TEST1", "" },
                     { "TEST2", "" }
@@ -507,7 +507,7 @@ public class ArgInstructionTests
 
     public class CreateTestScenario : TestScenario<ArgInstruction>
     {
-        public Dictionary<string, string> Args { get; set; }
+        public required Dictionary<string, string?> Args { get; set; }
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/ChecksumFlagTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ChecksumFlagTests.cs
@@ -168,6 +168,6 @@ public class ChecksumFlagTests
 
     public class CreateTestScenario : TestScenario<ChecksumFlag>
     {
-        public string Checksum { get; set; }
+        public required string Checksum { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/CmdInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/CmdInstructionTests.cs
@@ -22,6 +22,7 @@ public class CmdInstructionTests
         }
         else
         {
+            Assert.NotNull(scenario.Commands);
             result = new CmdInstruction(scenario.Commands);
         }
 
@@ -47,8 +48,8 @@ public class CmdInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("CMD", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo hello", cmd.Value);
@@ -101,8 +102,8 @@ public class CmdInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("CMD", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo #not-a-comment", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo #not-a-comment");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo #not-a-comment", cmd.Value);
@@ -122,8 +123,8 @@ public class CmdInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("CMD", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("#FF0000", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "#FF0000");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("#FF0000", cmd.Value);
@@ -154,8 +155,8 @@ public class CmdInstructionTests
                     Assert.Single(result.Comments);
                     Assert.Equal("test comment", result.Comments.First());
                     Assert.Equal("CMD", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo `\n#test comment\nhello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo `\n#test comment\nhello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo hello", cmd.Value);
@@ -176,8 +177,8 @@ public class CmdInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("CMD", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -200,7 +201,7 @@ public class CmdInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("CMD", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -228,8 +229,8 @@ public class CmdInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("CMD", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[\"/bin/bash\", \"-c\", \"echo hello\"]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[\"/bin/bash\", \"-c\", \"echo hello\"]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Equal(
@@ -275,7 +276,7 @@ public class CmdInstructionTests
                 },
                 Validate = result =>
                 {
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -312,7 +313,7 @@ public class CmdInstructionTests
 
     public class CreateTestScenario : TestScenario<CmdInstruction>
     {
-        public string Command { get; set; }
-        public IEnumerable<string> Commands { get; set; }
+        public string? Command { get; set; }
+        public IEnumerable<string>? Commands { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/CommentTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/CommentTests.cs
@@ -15,7 +15,7 @@ public class CommentTests
             Comment result = Comment.Parse(scenario.Text);
             Assert.Equal(scenario.Text, result.ToString());
             Assert.Collection(result.Tokens, scenario.TokenValidators);
-            scenario.Validate(result);
+            scenario.Validate?.Invoke(result);
         }
         else
         {
@@ -32,7 +32,7 @@ public class CommentTests
     {
         Comment result = new(scenario.Comment);
         Assert.Collection(result.Tokens, scenario.TokenValidators);
-        scenario.Validate(result);
+        scenario.Validate?.Invoke(result);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class CommentTests
         Assert.Null(comment.Value);
         Assert.Null(comment.ValueToken.Text);
 
-        Assert.Throws<ArgumentNullException>(() => comment.ValueToken = null);
+        Assert.Throws<ArgumentNullException>(() => comment.ValueToken = null!);
     }
 
     public static IEnumerable<object[]> ParseTestInput()
@@ -174,6 +174,6 @@ public class CommentTests
 
     public class CreateTestScenario : TestScenario<Comment>
     {
-        public string Comment { get; set; }
+        public required string Comment { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/CommentTokenTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/CommentTokenTests.cs
@@ -30,7 +30,7 @@ public class CommentTokenTests
         CommentToken comment = new("test");
 
         Assert.Equal("test", comment.Text);
-        Assert.Equal("test", comment.TextToken.Value);
+        Assert.Equal("test", Assert.IsType<StringToken>(comment.TextToken).Value);
 
         comment.Text = "foo";
         Assert.Equal("foo", comment.Text);

--- a/src/Valleysoft.DockerfileModel.Tests/CopyInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/CopyInstructionTests.cs
@@ -32,7 +32,7 @@ public class CopyInstructionTests : FileTransferInstructionTests<CopyInstruction
         static void Validate(CopyInstruction instruction, string stage)
         {
             Assert.Equal(stage, instruction.FromStageName);
-            Assert.Equal(stage, instruction.FromStageNameToken.Value);
+            Assert.Equal(stage, Assert.IsType<LiteralToken>(instruction.FromStageNameToken).Value);
             Assert.Equal($"COPY --from={stage} src dst", instruction.ToString());
         }
 
@@ -70,8 +70,7 @@ public class CopyInstructionTests : FileTransferInstructionTests<CopyInstruction
         FromFlag fromFlag = instruction.Tokens.OfType<FromFlag>().Single();
 
         // The flag value should be a LiteralToken
-        LiteralToken valueToken = fromFlag.ValueToken;
-        Assert.NotNull(valueToken);
+        LiteralToken valueToken = Assert.IsType<LiteralToken>(fromFlag.ValueToken);
         Assert.Equal(expectedFlagValue, valueToken.Value);
 
         // The literal should contain NO VariableRefToken children — $VAR is plain string text

--- a/src/Valleysoft.DockerfileModel.Tests/DockerfileTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DockerfileTests.cs
@@ -72,7 +72,7 @@ public class DockerfileTests
 
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
 
-        Dictionary<string, string> argValues = new()
+        Dictionary<string, string?> argValues = new()
         {
             { "test", "b" }
         };
@@ -134,7 +134,7 @@ public class DockerfileTests
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
         StagesView stagesView = new(dockerfile);
 
-        Dictionary<string, string> argValues = new()
+        Dictionary<string, string?> argValues = new()
         {
             { "test", "z" }
         };
@@ -205,7 +205,7 @@ public class DockerfileTests
 
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
 
-        Dictionary<string, string> argValues = new()
+        Dictionary<string, string?> argValues = new()
         {
             { "test1", "a1" },
             { "test2", "b1" },
@@ -299,7 +299,7 @@ public class DockerfileTests
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
         StagesView stagesView = new(dockerfile);
 
-        Dictionary<string, string> argValues = new()
+        Dictionary<string, string?> argValues = new()
         {
             { "test1", "a1" },
             { "test2", "b1" },
@@ -343,7 +343,7 @@ public class DockerfileTests
 
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
 
-        Dictionary<string, string> argValues = new();
+        Dictionary<string, string?> argValues = new();
 
         string originalDockerfileString = dockerfile.ToString();
 
@@ -425,7 +425,7 @@ public class DockerfileTests
 
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
 
-        Dictionary<string, string> argValues = new()
+        Dictionary<string, string?> argValues = new()
         {
             { "test1", "foo" }
         };
@@ -448,7 +448,7 @@ public class DockerfileTests
 
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
 
-        Dictionary<string, string> argValues = new()
+        Dictionary<string, string?> argValues = new()
         {
             { "test", "foo" }
         };
@@ -477,7 +477,7 @@ public class DockerfileTests
 
         Dockerfile dockerfile = Dockerfile.Parse(String.Join("\n", lines.ToArray()));
 
-        Dictionary<string, string> argValues = new()
+        Dictionary<string, string?> argValues = new()
         {
             { "test", null }
         };

--- a/src/Valleysoft.DockerfileModel.Tests/DurationTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DurationTests.cs
@@ -10,7 +10,7 @@ public class DurationTests
     [InlineData("1.5h", "01:30:00", "1h30m")]
     [InlineData("61s", "00:01:01", "1m1s")]
     [InlineData("34h", "1.10:00:00")]
-    public void Parse(string text, string expectedTimeSpanString, string expected = null)
+    public void Parse(string text, string expectedTimeSpanString, string? expected = null)
     {
         TimeSpan expectedTimeSpan = TimeSpan.Parse(expectedTimeSpanString);
 

--- a/src/Valleysoft.DockerfileModel.Tests/EntrypointInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/EntrypointInstructionTests.cs
@@ -22,10 +22,12 @@ public class EntrypointInstructionTests
         }
         else if (scenario.Args is null)
         {
+            Assert.NotNull(scenario.Command);
             result = new EntrypointInstruction(scenario.Command);
         }
         else
         {
+            Assert.NotNull(scenario.Command);
             result = new EntrypointInstruction(scenario.Command, scenario.Args);
         }
 
@@ -51,8 +53,8 @@ public class EntrypointInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("ENTRYPOINT", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo hello", cmd.Value);
@@ -105,8 +107,8 @@ public class EntrypointInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("ENTRYPOINT", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo #not-a-comment", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo #not-a-comment");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo #not-a-comment", cmd.Value);
@@ -126,8 +128,8 @@ public class EntrypointInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("ENTRYPOINT", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("#FF0000", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "#FF0000");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("#FF0000", cmd.Value);
@@ -158,8 +160,8 @@ public class EntrypointInstructionTests
                     Assert.Single(result.Comments);
                     Assert.Equal("test comment", result.Comments.First());
                     Assert.Equal("ENTRYPOINT", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo `\n#test comment\nhello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo `\n#test comment\nhello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo hello", cmd.Value);
@@ -180,8 +182,8 @@ public class EntrypointInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("ENTRYPOINT", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -204,7 +206,7 @@ public class EntrypointInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("ENTRYPOINT", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -232,8 +234,8 @@ public class EntrypointInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("ENTRYPOINT", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[\"/bin/bash\", \"-c\", \"echo hello\"]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[\"/bin/bash\", \"-c\", \"echo hello\"]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Equal(
@@ -279,7 +281,7 @@ public class EntrypointInstructionTests
                 },
                 Validate = result =>
                 {
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -316,8 +318,8 @@ public class EntrypointInstructionTests
 
     public class CreateTestScenario : TestScenario<EntrypointInstruction>
     {
-        public string Command { get; set; }
-        public IEnumerable<string> ExecArgs { get; set; }
-        public IEnumerable<string> Args { get; set; }
+        public string? Command { get; set; }
+        public IEnumerable<string>? ExecArgs { get; set; }
+        public IEnumerable<string>? Args { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/EnvInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/EnvInstructionTests.cs
@@ -162,7 +162,7 @@ public class EnvInstructionTests
                 { "VAR1", "$var" }
             });
         TestHelper.TestVariablesWithLiteral(
-            () => result.VariableTokens[0].ValueToken, "var", canContainVariables: true);
+            () => Assert.IsType<LiteralToken>(result.VariableTokens[0].ValueToken), "var", canContainVariables: true);
     }
 
     public static IEnumerable<object[]> ParseTestInput()
@@ -611,7 +611,7 @@ public class EnvInstructionTests
 
     public class CreateTestScenario : TestScenario<EnvInstruction>
     {
-        public Dictionary<string, string> Variables { get; set; }
+        public required Dictionary<string, string> Variables { get; set; }
     }
 
     /// <summary>

--- a/src/Valleysoft.DockerfileModel.Tests/ExecFormCommandTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ExecFormCommandTests.cs
@@ -294,6 +294,6 @@ public class ExecFormCommandTests
 
     public class CreateTestScenario : TestScenario<ExecFormCommand>
     {
-        public IEnumerable<string> Commands { get; set; }
+        public required IEnumerable<string> Commands { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/ExposeInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ExposeInstructionTests.cs
@@ -455,7 +455,7 @@ public class ExposeInstructionTests
 
     public class CreateTestScenario : TestScenario<ExposeInstruction>
     {
-        public string PortSpec { get; set; }
+        public required string PortSpec { get; set; }
     }
 
     [Fact]
@@ -464,8 +464,7 @@ public class ExposeInstructionTests
         string text = "EXPOSE 80\n";
         ExposeInstruction inst = ExposeInstruction.Parse(text);
         Assert.Equal(text, inst.ToString());
-        Assert.Equal(1, inst.Ports.Count);
-        Assert.Equal("80", inst.Ports[0]);
+        Assert.Equal("80", Assert.Single(inst.Ports));
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/FileTransferInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/FileTransferInstructionTests.cs
@@ -9,12 +9,12 @@ public abstract class FileTransferInstructionTests<TInstruction>
 {
     private readonly string instructionName;
     private readonly Func<string, char, TInstruction> parse;
-    private readonly Func<IEnumerable<string>, string, string, string, char, TInstruction> create;
+    private readonly Func<IEnumerable<string>, string, string?, string?, char, TInstruction> create;
 
     public FileTransferInstructionTests(
         string instructionName,
         Func<string, char, TInstruction> parse,
-        Func<IEnumerable<string>, string, string, string, char, TInstruction> create)
+        Func<IEnumerable<string>, string, string?, string?, char, TInstruction> create)
     {
         this.instructionName = instructionName;
         this.parse = parse;
@@ -53,7 +53,7 @@ public abstract class FileTransferInstructionTests<TInstruction>
     {
         TInstruction instruction = this.create(new string[] { "src1", "src2" }, "dst", null, null, Dockerfile.DefaultEscapeChar);
         Assert.Equal("dst", instruction.Destination);
-        Assert.Equal("dst", instruction.DestinationToken.Value);
+        Assert.Equal("dst", Assert.IsType<LiteralToken>(instruction.DestinationToken).Value);
 
         instruction.Destination = "test";
         Assert.Equal("test", instruction.Destination);
@@ -67,16 +67,17 @@ public abstract class FileTransferInstructionTests<TInstruction>
         Assert.Equal("bar", instruction.Destination);
         Assert.Equal("bar", instruction.DestinationToken.Value);
 
-        Assert.Throws<ArgumentNullException>(() => instruction.Destination = null);
+        Assert.Throws<ArgumentNullException>(() => instruction.Destination = null!);
         Assert.Throws<ArgumentException>(() => instruction.Destination = "");
-        Assert.Throws<ArgumentNullException>(() => instruction.DestinationToken = null);
+        Assert.Throws<ArgumentNullException>(() => instruction.DestinationToken = null!);
     }
 
     [Fact]
     public void DestinationWithVariables()
     {
         TInstruction instruction = this.create(new string[] { "src1", "src2" }, "$var", null, null, Dockerfile.DefaultEscapeChar);
-        TestHelper.TestVariablesWithLiteral(() => instruction.DestinationToken, "var", canContainVariables: true);
+        TestHelper.TestVariablesWithLiteral(
+            () => Assert.IsType<LiteralToken>(instruction.DestinationToken), "var", canContainVariables: true);
     }
 
     [Fact]
@@ -180,7 +181,7 @@ public abstract class FileTransferInstructionTests<TInstruction>
             token => ValidateLiteral(token, "dst")
         });
 
-        string result = instruction.ResolveVariables(Dockerfile.DefaultEscapeChar, new Dictionary<string, string>
+        string? result = instruction.ResolveVariables(Dockerfile.DefaultEscapeChar, new Dictionary<string, string?>
         {
             { "var", "user" }
         },
@@ -211,7 +212,7 @@ public abstract class FileTransferInstructionTests<TInstruction>
         void Validate(TInstruction instruction, string permissions)
         {
             Assert.Equal(permissions, instruction.Permissions);
-            Assert.Equal(permissions, instruction.PermissionsToken.Value);
+            Assert.Equal(permissions, Assert.IsType<LiteralToken>(instruction.PermissionsToken).Value);
             Assert.Equal($"{instructionName} --chmod={permissions} src dst", instruction.ToString());
         }
 
@@ -829,10 +830,10 @@ public abstract class FileTransferInstructionTests<TInstruction>
 
     public class CreateTestScenario : TestScenario<TInstruction>
     {
-        public string Destination { get; set; }
-        public IEnumerable<string> Sources { get; set; }
-        public string ChangeOwner { get; set; }
-        public string Permissions { get; set; }
+        public required string Destination { get; set; }
+        public required IEnumerable<string> Sources { get; set; }
+        public string? ChangeOwner { get; set; }
+        public string? Permissions { get; set; }
         public char EscapeChar { get; set; } = Dockerfile.DefaultEscapeChar;
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/FromInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/FromInstructionTests.cs
@@ -50,9 +50,9 @@ public class FromInstructionTests
         Assert.Equal("test4", instruction.ImageName);
         Assert.Equal("test4", instruction.ImageNameToken.Value);
 
-        Assert.Throws<ArgumentNullException>(() => instruction.ImageName = null);
+        Assert.Throws<ArgumentNullException>(() => instruction.ImageName = null!);
         Assert.Throws<ArgumentException>(() => instruction.ImageName = "");
-        Assert.Throws<ArgumentNullException>(() => instruction.ImageNameToken = null);
+        Assert.Throws<ArgumentNullException>(() => instruction.ImageNameToken = null!);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class FromInstructionTests
 
         instruction.Platform = "foo";
         Assert.Equal("foo", instruction.Platform);
-        Assert.Equal("foo", instruction.PlatformToken.Value);
+        Assert.Equal("foo", Assert.IsType<LiteralToken>(instruction.PlatformToken).Value);
 
         instruction.PlatformToken.Value = "foo2";
         Assert.Equal("foo2", instruction.Platform);
@@ -119,7 +119,7 @@ public class FromInstructionTests
 
         instruction.StageName = "foo";
         Assert.Equal("foo", instruction.StageName);
-        Assert.Equal("foo", instruction.StageNameToken.Value);
+        Assert.Equal("foo", Assert.IsType<StageName>(instruction.StageNameToken).Value);
 
         instruction.StageNameToken.Value = "foo2";
         Assert.Equal("foo2", instruction.StageName);
@@ -597,9 +597,9 @@ public class FromInstructionTests
 
     public class CreateTestScenario : TestScenario<FromInstruction>
     {
-        public string Platform { get; set; }
-        public string ImageName { get; set; }
-        public string Stage { get; set; }
+        public string? Platform { get; set; }
+        public required string ImageName { get; set; }
+        public string? Stage { get; set; }
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/GenericInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/GenericInstructionTests.cs
@@ -31,7 +31,7 @@ public class GenericInstructionTests
     {
         GenericInstruction result = new(scenario.InstructionName, scenario.Args);
         Assert.Collection(result.Tokens, scenario.TokenValidators);
-        scenario.Validate(result);
+        scenario.Validate?.Invoke(result);
     }
 
     public static IEnumerable<object[]> ParseTestInput()
@@ -215,7 +215,7 @@ public class GenericInstructionTests
 
     public class CreateTestScenario : TestScenario<GenericInstruction>
     {
-        public string InstructionName { get; set; }
-        public string Args { get; set; }
+        public required string InstructionName { get; set; }
+        public required string Args { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/HealthCheckInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/HealthCheckInstructionTests.cs
@@ -42,7 +42,7 @@ public class HealthCheckInstructionTests
     {
         HealthCheckInstruction instruction = new("command", interval: "10s");
         Assert.Equal("10s", instruction.Interval);
-        Assert.Equal("10s", instruction.IntervalToken.Value);
+        Assert.Equal("10s", Assert.IsType<LiteralToken>(instruction.IntervalToken).Value);
         Assert.Equal("HEALTHCHECK --interval=10s CMD command", instruction.ToString());
 
         instruction.Interval = "20s";
@@ -84,7 +84,7 @@ public class HealthCheckInstructionTests
     {
         HealthCheckInstruction instruction = new("command", timeout: "10s");
         Assert.Equal("10s", instruction.Timeout);
-        Assert.Equal("10s", instruction.TimeoutToken.Value);
+        Assert.Equal("10s", Assert.IsType<LiteralToken>(instruction.TimeoutToken).Value);
         Assert.Equal("HEALTHCHECK --timeout=10s CMD command", instruction.ToString());
 
         instruction.Timeout = "20s";
@@ -126,7 +126,7 @@ public class HealthCheckInstructionTests
     {
         HealthCheckInstruction instruction = new("command", startPeriod: "10s");
         Assert.Equal("10s", instruction.StartPeriod);
-        Assert.Equal("10s", instruction.StartPeriodToken.Value);
+        Assert.Equal("10s", Assert.IsType<LiteralToken>(instruction.StartPeriodToken).Value);
         Assert.Equal("HEALTHCHECK --start-period=10s CMD command", instruction.ToString());
 
         instruction.StartPeriod = "20s";
@@ -168,7 +168,7 @@ public class HealthCheckInstructionTests
     {
         HealthCheckInstruction instruction = new("command", startInterval: "10s");
         Assert.Equal("10s", instruction.StartInterval);
-        Assert.Equal("10s", instruction.StartIntervalToken.Value);
+        Assert.Equal("10s", Assert.IsType<LiteralToken>(instruction.StartIntervalToken).Value);
         Assert.Equal("HEALTHCHECK --start-interval=10s CMD command", instruction.ToString());
 
         instruction.StartInterval = "20s";
@@ -210,7 +210,7 @@ public class HealthCheckInstructionTests
     {
         HealthCheckInstruction instruction = new("command", retries: "10s");
         Assert.Equal("10s", instruction.Retries);
-        Assert.Equal("10s", instruction.RetriesToken.Value);
+        Assert.Equal("10s", Assert.IsType<LiteralToken>(instruction.RetriesToken).Value);
         Assert.Equal("HEALTHCHECK --retries=10s CMD command", instruction.ToString());
 
         instruction.Retries = "20s";
@@ -707,12 +707,12 @@ public class HealthCheckInstructionTests
 
     public class CreateTestScenario : TestScenario<HealthCheckInstruction>
     {
-        public string Command { get; set; }
-        public IEnumerable<string> Args { get; set; }
-        public string Interval { get; set; }
-        public string Timeout { get; set; }
-        public string StartPeriod { get; set; }
-        public string StartInterval { get; set; }
-        public string Retries { get; set; }
+        public string? Command { get; set; }
+        public IEnumerable<string>? Args { get; set; }
+        public string? Interval { get; set; }
+        public string? Timeout { get; set; }
+        public string? StartPeriod { get; set; }
+        public string? StartInterval { get; set; }
+        public string? Retries { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/ImageNameTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ImageNameTests.cs
@@ -19,7 +19,7 @@ public class ImageNameTests
     [InlineData("localhost", null, "localhost", null, null)]
     [InlineData("Localhost/myimage:latest", "Localhost", "myimage", "latest", null)]
     [InlineData("LOCALHOST/myimage:latest", "LOCALHOST", "myimage", "latest", null)]
-    public void Parse(string input, string expectedRegistry, string expectedRepository, string expectedTag, string expectedDigest)
+    public void Parse(string input, string? expectedRegistry, string expectedRepository, string? expectedTag, string? expectedDigest)
     {
         ImageName result = ImageName.Parse(input);
         Assert.Equal(expectedRegistry, result.Registry);
@@ -38,7 +38,7 @@ public class ImageNameTests
     [InlineData(null, "repo1", "tag1", null, "repo1:tag1")]
     [InlineData(null, "repo1", null, TestSha, "repo1@" + TestSha)]
     [InlineData("docker.io", "library/image", null, TestSha, "docker.io/library/image@" + TestSha)]
-    public void Create(string registry, string repository, string tag, string digest, string expectedOutput)
+    public void Create(string? registry, string repository, string? tag, string? digest, string expectedOutput)
     {
         ImageName result = new(repository, registry, tag, digest);
         Assert.Equal(expectedOutput, result.ToString());
@@ -130,7 +130,7 @@ public class ImageNameTests
         imageName.Repository = "test2";
         Assert.Equal("test2", imageName.Repository);
 
-        Assert.Throws<ArgumentNullException>(() => imageName.Repository = null);
+        Assert.Throws<ArgumentNullException>(() => imageName.Repository = null!);
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/KeyValueTokenTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/KeyValueTokenTests.cs
@@ -12,6 +12,7 @@ public class KeyValueTokenTests
     {
         if (scenario.ParseExceptionPosition is null)
         {
+            Assert.NotNull(scenario.Key);
             KeyValueToken<KeywordToken, LiteralToken> result = KeyValueToken<KeywordToken, LiteralToken>.Parse(
                 scenario.Text,
                 KeywordToken.GetParser(scenario.Key, scenario.EscapeChar),
@@ -214,12 +215,12 @@ public class KeyValueTokenTests
 
     public class KeyValueTokenParseTestScenario : ParseTestScenario<KeyValueToken<KeywordToken, LiteralToken>>
     {
-        public string Key { get; set; }
+        public string? Key { get; set; }
     }
 
     public class CreateTestScenario : TestScenario<KeyValueToken<KeywordToken, LiteralToken>>
     {
-        public string Key { get; set; }
-        public string Value { get; set; }
+        public required string Key { get; set; }
+        public required string Value { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/LabelInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/LabelInstructionTests.cs
@@ -566,7 +566,7 @@ public class LabelInstructionTests
 
     public class CreateTestScenario : TestScenario<LabelInstruction>
     {
-        public Dictionary<string, string> Variables { get; set; }
+        public required Dictionary<string, string> Variables { get; set; }
     }
 
     /// <summary>

--- a/src/Valleysoft.DockerfileModel.Tests/LiteralTokenTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/LiteralTokenTests.cs
@@ -33,7 +33,7 @@ public class LiteralTokenTests
         {
             Value = "$REPO:tag"
         };
-        token.ResolveVariables(Dockerfile.DefaultEscapeChar, new Dictionary<string, string>
+        token.ResolveVariables(Dockerfile.DefaultEscapeChar, new Dictionary<string, string?>
         {
             { "REPO", "test" }
         }, options: new ResolutionOptions { UpdateInline = true});

--- a/src/Valleysoft.DockerfileModel.Tests/MaintainerInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/MaintainerInstructionTests.cs
@@ -196,7 +196,7 @@ public class MaintainerInstructionTests
 
     public class CreateTestScenario : TestScenario<MaintainerInstruction>
     {
-        public string Maintainer { get; set; }
+        public required string Maintainer { get; set; }
     }
 
     /// <summary>

--- a/src/Valleysoft.DockerfileModel.Tests/NetworkFlagTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/NetworkFlagTests.cs
@@ -164,6 +164,6 @@ public class NetworkFlagTests
 
     public class CreateTestScenario : TestScenario<NetworkFlag>
     {
-        public string Network { get; set; }
+        public required string Network { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/OnBuildInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/OnBuildInstructionTests.cs
@@ -32,7 +32,7 @@ public class OnBuildInstructionTests
         Assert.Equal("RUN test2", result.Instruction.ToString());
         Assert.Equal("ONBUILD RUN test2", result.ToString());
 
-        Assert.Throws<ArgumentNullException>(() => result.Instruction = null);
+        Assert.Throws<ArgumentNullException>(() => result.Instruction = null!);
     }
 
     [Theory]
@@ -153,7 +153,7 @@ public class OnBuildInstructionTests
                     Assert.Equal("test comment", result.Comments.First());
                     Assert.Equal("ONBUILD", result.InstructionName);
                     RunInstruction instruction = Assert.IsType<RunInstruction>(result.Instruction);
-                    Assert.Equal(CommandType.ShellForm, instruction.Command.CommandType);
+                    TestHelper.AssertCommandType(instruction.Command, CommandType.ShellForm);
                     ShellFormCommand command = Assert.IsType<ShellFormCommand>(instruction.Command);
                     Assert.Equal("echo hello \\\n# test comment\nworld", command.ToString());
                     Assert.Equal("echo hello world", command.Value);
@@ -278,7 +278,7 @@ public class OnBuildInstructionTests
 
     public class CreateTestScenario : TestScenario<OnBuildInstruction>
     {
-        public Instruction Instruction { get; set; }
+        public required Instruction Instruction { get; set; }
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/ParserDirectiveTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ParserDirectiveTests.cs
@@ -15,7 +15,7 @@ public class ParserDirectiveTests
             ParserDirective result = ParserDirective.Parse(scenario.Text);
             Assert.Equal(scenario.Text, result.ToString());
             Assert.Collection(result.Tokens, scenario.TokenValidators);
-            scenario.Validate(result);
+            scenario.Validate?.Invoke(result);
         }
         else
         {
@@ -32,7 +32,7 @@ public class ParserDirectiveTests
     {
         ParserDirective result = new(scenario.Directive, scenario.Value);
         Assert.Collection(result.Tokens, scenario.TokenValidators);
-        scenario.Validate(result);
+        scenario.Validate?.Invoke(result);
     }
 
     public static IEnumerable<object[]> ParseTestInput()
@@ -147,19 +147,19 @@ public class ParserDirectiveTests
 
     public abstract class TestScenario
     {
-        public Action<ParserDirective> Validate { get; set; }
-        public Action<Token>[] TokenValidators { get; set; }
+        public Action<ParserDirective>? Validate { get; set; }
+        public Action<Token>[] TokenValidators { get; set; } = [];
     }
 
     public class ParseTestScenario : TestScenario
     {
-        public string Text { get; set; }
-        public Position ParseExceptionPosition { get; set; }
+        public required string Text { get; set; }
+        public Position? ParseExceptionPosition { get; set; }
     }
 
     public class CreateTestScenario : TestScenario
     {
-        public string Directive { get; set; }
-        public string Value { get; set; }
+        public required string Directive { get; set; }
+        public required string Value { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/PropertyTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/PropertyTests.cs
@@ -1,6 +1,6 @@
 using FsCheck;
 using FsCheck.Fluent;
-using Valleysoft.DockerfileModel.Tests.Generators;
+using Valleysoft.DockerfileModel.TestSupport.Generators;
 using Valleysoft.DockerfileModel.Tokens;
 
 namespace Valleysoft.DockerfileModel.Tests;
@@ -415,7 +415,7 @@ public class PropertyTests
             string beforeResolve = parsed.ToString();
 
             // Resolve with overrides but still UpdateInline = false
-            var overrides = new Dictionary<string, string> { { "anyvar", "anyval" } };
+            var overrides = new Dictionary<string, string?> { { "anyvar", "anyval" } };
             parsed.ResolveVariables(overrides);
 
             string afterResolve = parsed.ToString();
@@ -455,7 +455,7 @@ public class PropertyTests
     /// If false, the variable is never declared (truly "unset").</param>
     private static string ResolveModifierDockerfile(
         string varName, string modifier, string modValue,
-        Dictionary<string, string> argOverrides = null,
+        Dictionary<string, string?>? argOverrides = null,
         bool declareArg = true)
     {
         string argLine = declareArg ? $"ARG {varName}\n" : "";
@@ -486,7 +486,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "" } };
+            var overrides = new Dictionary<string, string?> { { varName, "" } };
             string result = ResolveModifierDockerfile(varName, ":-", modValue, overrides);
             Assert.Equal($"LABEL key={modValue}", result);
         }
@@ -499,7 +499,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "realval" } };
+            var overrides = new Dictionary<string, string?> { { varName, "realval" } };
             string result = ResolveModifierDockerfile(varName, ":-", modValue, overrides);
             Assert.Equal("LABEL key=realval", result);
         }
@@ -526,7 +526,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "" } };
+            var overrides = new Dictionary<string, string?> { { varName, "" } };
             string result = ResolveModifierDockerfile(varName, "-", modValue, overrides);
             Assert.Equal("LABEL key=", result);
         }
@@ -539,7 +539,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "something" } };
+            var overrides = new Dictionary<string, string?> { { varName, "something" } };
             string result = ResolveModifierDockerfile(varName, ":+", modValue, overrides);
             Assert.Equal($"LABEL key={modValue}", result);
         }
@@ -564,7 +564,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "" } };
+            var overrides = new Dictionary<string, string?> { { varName, "" } };
             string result = ResolveModifierDockerfile(varName, ":+", modValue, overrides);
             Assert.Equal("LABEL key=", result);
         }
@@ -577,7 +577,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "" } };
+            var overrides = new Dictionary<string, string?> { { varName, "" } };
             string result = ResolveModifierDockerfile(varName, "+", modValue, overrides);
             Assert.Equal($"LABEL key={modValue}", result);
         }
@@ -615,7 +615,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "" } };
+            var overrides = new Dictionary<string, string?> { { varName, "" } };
             Assert.Throws<VariableSubstitutionException>(() =>
                 ResolveModifierDockerfile(varName, ":?", modValue, overrides));
         }
@@ -628,7 +628,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "realval" } };
+            var overrides = new Dictionary<string, string?> { { varName, "realval" } };
             string result = ResolveModifierDockerfile(varName, ":?", modValue, overrides);
             Assert.Equal("LABEL key=realval", result);
         }
@@ -654,7 +654,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "" } };
+            var overrides = new Dictionary<string, string?> { { varName, "" } };
             string result = ResolveModifierDockerfile(varName, "?", modValue, overrides);
             Assert.Equal("LABEL key=", result);
         }
@@ -667,7 +667,7 @@ public class PropertyTests
         var samples = DockerfileArbitraries.VariableModifierComponents().Sample(SampleSize, 50);
         foreach (var (varName, _, modValue) in samples)
         {
-            var overrides = new Dictionary<string, string> { { varName, "realval" } };
+            var overrides = new Dictionary<string, string?> { { varName, "realval" } };
             string result = ResolveModifierDockerfile(varName, "?", modValue, overrides);
             Assert.Equal("LABEL key=realval", result);
         }

--- a/src/Valleysoft.DockerfileModel.Tests/RunInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/RunInstructionTests.cs
@@ -196,8 +196,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     Assert.Empty(result.Mounts);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
@@ -263,8 +263,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("#FF0000", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "#FF0000");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("#FF0000", cmd.Value);
@@ -309,8 +309,8 @@ public class RunInstructionTests
                     Assert.Single(result.Comments);
                     Assert.Equal("test comment", result.Comments.First());
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo `\n#test comment\nhello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo `\n#test comment\nhello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo hello", cmd.Value);
@@ -338,8 +338,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[\"/bin/bash\", \"-c\", \"echo hello\"]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[\"/bin/bash\", \"-c\", \"echo hello\"]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Equal(
@@ -389,8 +389,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[ \"/bi`\nn/bash\", `\n \"-c\" , \"echo he`\"llo\"]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[ \"/bi`\nn/bash\", `\n \"-c\" , \"echo he`\"llo\"]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Equal(
@@ -461,8 +461,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo hello", cmd.Value);
@@ -501,8 +501,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.IsType<ShellFormCommand>(result.Command);
                     ShellFormCommand cmd = (ShellFormCommand)result.Command;
                     Assert.Equal("echo hello", cmd.Value);
@@ -702,8 +702,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.Equal("host", result.Network);
                     Assert.Empty(result.Mounts);
                     Assert.Null(result.Security);
@@ -726,8 +726,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.Equal("insecure", result.Security);
                     Assert.Empty(result.Mounts);
                     Assert.Null(result.Network);
@@ -843,8 +843,8 @@ public class RunInstructionTests
                 Validate = result =>
                 {
                     Assert.Equal("host", result.Network);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    ExecFormCommand cmd = (ExecFormCommand)result.Command;
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    ExecFormCommand cmd = Assert.IsType<ExecFormCommand>(result.Command);
                     Assert.Equal(
                         new string[]
                         {
@@ -871,7 +871,7 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -895,7 +895,7 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Empty(cmd.Values);
@@ -929,8 +929,8 @@ public class RunInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("RUN", result.InstructionName);
-                    Assert.Equal(CommandType.ShellForm, result.Command.CommandType);
-                    Assert.Equal("echo hello", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ShellForm);
+                    TestHelper.AssertCommandText(result.Command, "echo hello");
                     Assert.Single(result.Mounts);
                     Assert.Equal("secret", result.Mounts.First().Type);
                     Assert.Equal("type=secret,id=mysecret,required", result.Mounts.First().ToString());
@@ -1114,11 +1114,11 @@ public class RunInstructionTests
 
     public class CreateTestScenario : TestScenario<RunInstruction>
     {
-        public string Command { get; set; }
-        public IEnumerable<string> Args { get; set; }
-        public IEnumerable<Mount> Mounts { get; set; }
-        public string Network { get; set; }
-        public string Security { get; set; }
+        public required string Command { get; set; }
+        public IEnumerable<string>? Args { get; set; }
+        public IEnumerable<Mount>? Mounts { get; set; }
+        public string? Network { get; set; }
+        public string? Security { get; set; }
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/ScenarioTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ScenarioTests.cs
@@ -95,7 +95,7 @@ public class ScenarioTests
         // arguments with their resolved values. Be aware of this if your intention is
         // write the model back to the Dockerfile on disk.
         dockerfile.ResolveVariables(
-            new Dictionary<string, string>
+            new Dictionary<string, string?>
             {
                 { "TAG", "3.12" }
             },

--- a/src/Valleysoft.DockerfileModel.Tests/SecurityFlagTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/SecurityFlagTests.cs
@@ -129,6 +129,6 @@ public class SecurityFlagTests
 
     public class CreateTestScenario : TestScenario<SecurityFlag>
     {
-        public string Security { get; set; }
+        public required string Security { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/ShellFormCommandTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ShellFormCommandTests.cs
@@ -35,7 +35,7 @@ public class ShellFormCommandTests
         Assert.Equal("echo hola", result.Value);
         Assert.Equal("echo hola", result.ValueToken.Value);
 
-        Assert.Throws<ArgumentNullException>(() => result.Value = null);
+        Assert.Throws<ArgumentNullException>(() => result.Value = null!);
         Assert.Throws<ArgumentException>(() => result.Value = "");
     }
 
@@ -199,6 +199,6 @@ public class ShellFormCommandTests
 
     public class CreateTestScenario : TestScenario<ShellFormCommand>
     {
-        public string Command { get; set; }
+        public required string Command { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/ShellInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ShellInstructionTests.cs
@@ -44,8 +44,8 @@ public class ShellInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("SHELL", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[\"echo\", \"hello\"]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[\"echo\", \"hello\"]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Collection(cmd.Values, new Action<string>[]
@@ -71,8 +71,8 @@ public class ShellInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("SHELL", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[\"echo\"]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[\"echo\"]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Collection(cmd.Values, new Action<string>[]
@@ -99,8 +99,8 @@ public class ShellInstructionTests
                 {
                     Assert.Empty(result.Comments);
                     Assert.Equal("SHELL", result.InstructionName);
-                    Assert.Equal(CommandType.ExecForm, result.Command.CommandType);
-                    Assert.Equal("[\"echo\"]", result.Command.ToString());
+                    TestHelper.AssertCommandType(result.Command, CommandType.ExecForm);
+                    TestHelper.AssertCommandText(result.Command, "[\"echo\"]");
                     Assert.IsType<ExecFormCommand>(result.Command);
                     ExecFormCommand cmd = (ExecFormCommand)result.Command;
                     Assert.Collection(cmd.Values, new Action<string>[]
@@ -162,7 +162,7 @@ public class ShellInstructionTests
 
     public class CreateTestScenario : TestScenario<ShellInstruction>
     {
-        public string Command { get; set; }
+        public required string Command { get; set; }
         public IEnumerable<string> Args { get; set; } = Enumerable.Empty<string>();
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/StopSignalTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/StopSignalTests.cs
@@ -39,9 +39,9 @@ public class StopSignalInstructionTests
         Assert.Equal("test3", result.SignalToken.Value);
         Assert.Equal("STOPSIGNAL test3", result.ToString());
 
-        Assert.Throws<ArgumentNullException>(() => result.Signal = null);
+        Assert.Throws<ArgumentNullException>(() => result.Signal = null!);
         Assert.Throws<ArgumentException>(() => result.Signal = "");
-        Assert.Throws<ArgumentNullException>(() => result.SignalToken = null);
+        Assert.Throws<ArgumentNullException>(() => result.SignalToken = null!);
     }
 
     public static IEnumerable<object[]> ParseTestInput()
@@ -200,7 +200,7 @@ public class StopSignalInstructionTests
 
     public class CreateTestScenario : TestScenario<StopSignalInstruction>
     {
-        public string Signal { get; set; }
+        public required string Signal { get; set; }
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/TestHelper.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/TestHelper.cs
@@ -6,6 +6,18 @@ namespace Valleysoft.DockerfileModel.Tests;
 
 public static class TestHelper
 {
+    public static void AssertCommandType(Command? command, CommandType expected)
+    {
+        Assert.NotNull(command);
+        Assert.Equal(expected, command.CommandType);
+    }
+
+    public static void AssertCommandText(Command? command, string expected)
+    {
+        Assert.NotNull(command);
+        Assert.Equal(expected, command.ToString());
+    }
+
     public static string ConcatLines(IEnumerable<string> lines, string lineEnding = "\n") =>
         string.Join(lineEnding, lines.ToArray());
 
@@ -31,10 +43,25 @@ public static class TestHelper
     public static void TestVariablesWithLiteral(Func<LiteralToken> getLiteral, string initialValue, bool canContainVariables) =>
         TestVariablesWithLiteral(getLiteral, initialValue, canContainVariables, null, null);
 
-    public static void TestVariablesWithNullableLiteral(Func<LiteralToken> getLiteral, Action<LiteralToken> setLiteral, Action<string> setValue, string initialValue, bool canContainVariables) =>
-        TestVariablesWithLiteral(getLiteral, initialValue, canContainVariables, setLiteral, setValue);
+    public static void TestVariablesWithNullableLiteral(
+        Func<LiteralToken?> getLiteral,
+        Action<LiteralToken?> setLiteral,
+        Action<string?> setValue,
+        string initialValue,
+        bool canContainVariables) =>
+        TestVariablesWithLiteral(
+            () => Assert.IsType<LiteralToken>(getLiteral()),
+            initialValue,
+            canContainVariables,
+            setLiteral,
+            setValue);
 
-    private static void TestVariablesWithLiteral(Func<LiteralToken> getLiteral, string initialValue, bool canContainVariables, Action<LiteralToken> setLiteral, Action<string> setValue)
+    private static void TestVariablesWithLiteral(
+        Func<LiteralToken> getLiteral,
+        string initialValue,
+        bool canContainVariables,
+        Action<LiteralToken?>? setLiteral,
+        Action<string?>? setValue)
     {
         if (canContainVariables)
         {
@@ -59,6 +86,7 @@ public static class TestHelper
 
             if (setLiteral is not null)
             {
+                Assert.NotNull(setValue);
                 setLiteral(null);
                 setValue("$var3");
                 Assert.Collection(getLiteral().Tokens, new Action<Token>[]
@@ -90,6 +118,7 @@ public static class TestHelper
 
             if (setLiteral is not null)
             {
+                Assert.NotNull(setValue);
                 setLiteral(null);
                 setValue("$var3");
                 Assert.Collection(getLiteral().Tokens, new Action<Token>[]

--- a/src/Valleysoft.DockerfileModel.Tests/TestScenario.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/TestScenario.cs
@@ -4,13 +4,13 @@ namespace Valleysoft.DockerfileModel.Tests;
 
 public abstract class TestScenario<T>
 {
-    public Action<T> Validate { get; set; }
-    public Action<Token>[] TokenValidators { get; set; }
+    public Action<T>? Validate { get; set; }
+    public Action<Token>[] TokenValidators { get; set; } = [];
 }
 
 public class ParseTestScenario<T> : TestScenario<T>
 {
-    public string Text { get; set; }
-    public Position ParseExceptionPosition { get; set; }
+    public required string Text { get; set; }
+    public Position? ParseExceptionPosition { get; set; }
     public char EscapeChar { get; set; }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/TokenJsonSerializerTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/TokenJsonSerializerTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Valleysoft.DockerfileModel.DiffTest;
+using Valleysoft.DockerfileModel.TestSupport;
 
 namespace Valleysoft.DockerfileModel.Tests;
 
@@ -26,7 +26,7 @@ public class TokenJsonSerializerTests
     {
         // "RUN echo hello \\\nworld" — backslash + newline is a line continuation
         string input = "RUN echo hello \\" + "\n" + "world";
-        string json = DiffTestRunner.ParseCSharp("RUN", input, '\\');
+        string json = InstructionSerializer.ParseCSharp("RUN", input, '\\');
 
         // The literal children should contain:
         //   string("echo hello "), lineContinuation[symbol("\\"), newLine("\n")], string("world")
@@ -56,7 +56,7 @@ public class TokenJsonSerializerTests
     public void ShellForm_CMD_WhitespaceBeforeLineContinuation()
     {
         string input = "CMD foo bar \\" + "\n" + "baz";
-        string json = DiffTestRunner.ParseCSharp("CMD", input, '\\');
+        string json = InstructionSerializer.ParseCSharp("CMD", input, '\\');
 
         // The literal children should NOT contain separate whitespace tokens
         Assert.DoesNotContain("\"kind\":\"whitespace\"", GetLiteralChildrenJson(json));
@@ -74,7 +74,7 @@ public class TokenJsonSerializerTests
     public void ShellForm_ENTRYPOINT_MultipleLineContinuations()
     {
         string input = "ENTRYPOINT a b \\" + "\n" + "c d \\" + "\n" + "e";
-        string json = DiffTestRunner.ParseCSharp("ENTRYPOINT", input, '\\');
+        string json = InstructionSerializer.ParseCSharp("ENTRYPOINT", input, '\\');
 
         // No whitespace tokens inside the literal
         Assert.DoesNotContain("\"kind\":\"whitespace\"", GetLiteralChildrenJson(json));
@@ -94,7 +94,7 @@ public class TokenJsonSerializerTests
     public void ShellForm_NoLineContinuation_WhitespaceCollapsed()
     {
         string input = "RUN echo hello world";
-        string json = DiffTestRunner.ParseCSharp("RUN", input, '\\');
+        string json = InstructionSerializer.ParseCSharp("RUN", input, '\\');
 
         // The literal should contain a single string with all text
         Assert.Contains("\"value\":\"echo hello world\"", json);
@@ -108,7 +108,7 @@ public class TokenJsonSerializerTests
     public void RUN_MountAndShellFormWithLineContinuation()
     {
         string input = "RUN --mount=type=secret,id=mysecret echo hello \\" + "\n" + "world";
-        string json = DiffTestRunner.ParseCSharp("RUN", input, '\\');
+        string json = InstructionSerializer.ParseCSharp("RUN", input, '\\');
 
         // Mount flag should be serialized as keyValue
         Assert.Contains("\"kind\":\"keyValue\"", json);

--- a/src/Valleysoft.DockerfileModel.Tests/UserInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/UserInstructionTests.cs
@@ -32,7 +32,7 @@ public class UserInstructionTests
         Assert.Equal("root:root", result.User);
         Assert.Equal("USER root:root", result.ToString());
 
-        Assert.Throws<ArgumentNullException>(() => result.User = null);
+        Assert.Throws<ArgumentNullException>(() => result.User = null!);
         Assert.Throws<ArgumentException>(() => result.User = "");
     }
 
@@ -47,7 +47,7 @@ public class UserInstructionTests
         Assert.Equal("bob", result.User);
         Assert.Equal("USER bob", result.ToString());
 
-        Assert.Throws<ArgumentNullException>(() => result.UserToken = null);
+        Assert.Throws<ArgumentNullException>(() => result.UserToken = null!);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class UserInstructionTests
 
     public class CreateTestScenario : TestScenario<UserInstruction>
     {
-        public string User { get; set; }
+        public required string User { get; set; }
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/Valleysoft.DockerfileModel.Tests.csproj
+++ b/src/Valleysoft.DockerfileModel.Tests/Valleysoft.DockerfileModel.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>13.0</LangVersion>
+    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
@@ -24,7 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Valleysoft.DockerfileModel\Valleysoft.DockerfileModel.csproj" />
-    <ProjectReference Include="..\Valleysoft.DockerfileModel.DiffTest\Valleysoft.DockerfileModel.DiffTest.csproj" />
+    <ProjectReference Include="..\Valleysoft.DockerfileModel.TestSupport\Valleysoft.DockerfileModel.TestSupport.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Valleysoft.DockerfileModel.Tests/VariableRefTokenTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/VariableRefTokenTests.cs
@@ -21,6 +21,7 @@ public class VariableRefTokenTests
         }
         else
         {
+            Assert.NotNull(scenario.ModifierValue);
             result = new VariableRefToken(scenario.VariableName, scenario.Modifier, scenario.ModifierValue);
         }
 
@@ -47,9 +48,9 @@ public class VariableRefTokenTests
         Assert.Equal("test3", token.VariableName);
         Assert.Equal("test3", token.VariableNameToken.Value);
 
-        Assert.Throws<ArgumentNullException>(() => token.VariableName = null);
+        Assert.Throws<ArgumentNullException>(() => token.VariableName = null!);
         Assert.Throws<ArgumentException>(() => token.VariableName = "");
-        Assert.Throws<ArgumentNullException>(() => token.VariableNameToken = null);
+        Assert.Throws<ArgumentNullException>(() => token.VariableNameToken = null!);
     }
 
     [Fact]
@@ -81,7 +82,7 @@ public class VariableRefTokenTests
     {
         VariableRefToken token = new("foo", "-", "bar");
         Assert.Equal("bar", token.ModifierValue);
-        Assert.Equal("bar", token.ModifierValueToken.Value);
+        Assert.Equal("bar", Assert.IsType<LiteralToken>(token.ModifierValueToken).Value);
         Assert.NotEmpty(token.ModifierTokens);
         Assert.Equal("${foo-bar}", token.ToString());
 
@@ -473,11 +474,11 @@ public class VariableRefTokenTests
                 },
                 Validate = token =>
                 {
-                    Dictionary<string, string> variables = new() {
+                    Dictionary<string, string?> variables = new() {
 
                     };
 
-                    string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
+                    string? result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                     Assert.Equal("test", result);
 
                     variables["foo"] = null;
@@ -506,10 +507,10 @@ public class VariableRefTokenTests
                 },
                 Validate = token =>
                 {
-                    Dictionary<string, string> variables = new() {
+                    Dictionary<string, string?> variables = new() {
                     };
 
-                    string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
+                    string? result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                     Assert.Equal("test", result);
 
                     variables["foo"] = null;
@@ -537,10 +538,10 @@ public class VariableRefTokenTests
                 },
                 Validate = token =>
                 {
-                    Dictionary<string, string> variables = new() {
+                    Dictionary<string, string?> variables = new() {
                     };
 
-                    string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
+                    string? result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                     Assert.Equal("", result);
 
                     variables["foo"] = null;
@@ -569,10 +570,10 @@ public class VariableRefTokenTests
                 },
                 Validate = token =>
                 {
-                    Dictionary<string, string> variables = new() {
+                    Dictionary<string, string?> variables = new() {
                     };
 
-                    string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
+                    string? result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                     Assert.Equal("", result);
 
                     variables["foo"] = null;
@@ -600,13 +601,13 @@ public class VariableRefTokenTests
                 },
                 Validate = token =>
                 {
-                    Dictionary<string, string> variables = new() {
+                    Dictionary<string, string?> variables = new() {
                     };
 
                     Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables));
 
                     variables["foo"] = null;
-                    string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
+                    string? result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                     Assert.Equal("", result);
 
                     variables["foo"] = "test2";
@@ -631,7 +632,7 @@ public class VariableRefTokenTests
                 },
                 Validate = token =>
                 {
-                    Dictionary<string, string> variables = new() {
+                    Dictionary<string, string?> variables = new() {
                     };
 
                     Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables));
@@ -640,7 +641,7 @@ public class VariableRefTokenTests
                     Assert.Throws<VariableSubstitutionException>(() => token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables));
 
                     variables["foo"] = "test2";
-                    string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
+                    string? result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                     Assert.Equal("test2", result);
                 }
             },
@@ -666,11 +667,11 @@ public class VariableRefTokenTests
                 },
                 Validate = token =>
                 {
-                    Dictionary<string, string> variables = new() {
+                    Dictionary<string, string?> variables = new() {
                         { "bar", "test2" }
                     };
 
-                    string result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
+                    string? result = token.ResolveVariables(Dockerfile.DefaultEscapeChar, variables);
                     Assert.Equal("atest2x", result);
 
                 }
@@ -836,9 +837,9 @@ public class VariableRefTokenTests
 
     public class CreateTestScenario : TestScenario<VariableRefToken>
     {
-        public string VariableName { get; set; }
-        public string Modifier { get; set; }
-        public string ModifierValue { get; set; }
+        public required string VariableName { get; set; }
+        public string? Modifier { get; set; }
+        public string? ModifierValue { get; set; }
     }
 
     /// <summary>

--- a/src/Valleysoft.DockerfileModel.Tests/VolumeInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/VolumeInstructionTests.cs
@@ -365,6 +365,6 @@ public class VolumeInstructionTests
 
     public class CreateTestScenario : TestScenario<VolumeInstruction>
     {
-        public IEnumerable<string> Paths { get; set; }
+        public required IEnumerable<string> Paths { get; set; }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/WhitespaceTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/WhitespaceTests.cs
@@ -31,7 +31,7 @@ public class WhitespaceTests
     {
         Whitespace whitespace = new(" ");
         Assert.Equal(" ", whitespace.Value);
-        Assert.Equal(" ", whitespace.ValueToken.Value);
+        Assert.Equal(" ", Assert.IsType<WhitespaceToken>(whitespace.ValueToken).Value);
 
         whitespace.Value = "\t";
         Assert.Equal("\t", whitespace.Value);
@@ -63,7 +63,7 @@ public class WhitespaceTests
 
         whitespace.NewLine = "\n";
         Assert.Equal("\n", whitespace.NewLine);
-        Assert.Equal("\n", whitespace.NewLineToken.Value);
+        Assert.Equal("\n", Assert.IsType<NewLineToken>(whitespace.NewLineToken).Value);
 
         whitespace.NewLine = null;
         Assert.Null(whitespace.NewLine);

--- a/src/Valleysoft.DockerfileModel.Tests/WorkdirInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/WorkdirInstructionTests.cs
@@ -44,9 +44,9 @@ public class WorkdirInstructionTests
         Assert.Equal("/test4", result.PathToken.Value);
         Assert.Equal("WORKDIR /test4", result.ToString());
 
-        Assert.Throws<ArgumentNullException>(() => result.Path = null);
+        Assert.Throws<ArgumentNullException>(() => result.Path = null!);
         Assert.Throws<ArgumentException>(() => result.Path = "");
-        Assert.Throws<ArgumentNullException>(() => result.PathToken = null);
+        Assert.Throws<ArgumentNullException>(() => result.PathToken = null!);
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class WorkdirInstructionTests
 
     public class CreateTestScenario : TestScenario<WorkdirInstruction>
     {
-        public string Path { get; set; }
+        public required string Path { get; set; }
     }
 
     /// <summary>

--- a/src/Valleysoft.DockerfileModel.sln
+++ b/src/Valleysoft.DockerfileModel.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valleysoft.DockerfileModel.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valleysoft.DockerfileModel.DiffTest", "Valleysoft.DockerfileModel.DiffTest\Valleysoft.DockerfileModel.DiffTest.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valleysoft.DockerfileModel.TestSupport", "Valleysoft.DockerfileModel.TestSupport\Valleysoft.DockerfileModel.TestSupport.csproj", "{252445EB-5183-4DAE-A8F8-763A3174EAA1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{252445EB-5183-4DAE-A8F8-763A3174EAA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{252445EB-5183-4DAE-A8F8-763A3174EAA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{252445EB-5183-4DAE-A8F8-763A3174EAA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{252445EB-5183-4DAE-A8F8-763A3174EAA1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A noisy Release build and circular test-infrastructure ownership made new compiler, analyzer, and dependency regressions difficult to identify. This change restores a zero-warning baseline and gives shared test utilities a clear non-production home.

## Summary

- Extract shared FsCheck generators and canonical token serialization into a dedicated `Valleysoft.DockerfileModel.TestSupport` project used by Tests and DiffTest.
- Remove linked generator source and the Tests-to-DiffTest project reference.
- Enable nullable analysis in the test project and correct nullable and xUnit analyzer findings without suppressing diagnostics.
- Enforce warnings as errors through `Directory.Build.props`, while leaving transient NuGet audit transport failures (`NU1900`) visible but non-blocking.
- Update CI, Renovate rules, and repository architecture guidance for the new project layout.

## Validation

- Clean Release build: 0 warnings, 0 errors
- .NET tests: 1,353 passed
- Differential CLI parse and generation paths verified

Fixes: #351