### PR TITLE
Replace Validation dependency with internal guard helpers

### DIFF
--- a/src/Valleysoft.DockerfileModel.Tests/ArgumentValidationTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ArgumentValidationTests.cs
@@ -1,0 +1,206 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class ArgumentValidationTests
+{
+    [Fact]
+    public void NullOnlyGuards()
+    {
+        Assert.Throws<ArgumentNullException>("text", () => Dockerfile.Parse(null!));
+        Assert.Throws<ArgumentNullException>("items", () => new Dockerfile(null!));
+        Assert.Throws<ArgumentNullException>("dockerfile", () => new DockerfileBuilder(null!));
+        Assert.Throws<ArgumentNullException>("values", () => StringHelper.FormatAsJson(null!));
+        Assert.Throws<ArgumentNullException>("defaultArgs", () => new HealthCheckInstruction((IEnumerable<string>)null!));
+
+        Assert.Empty(Dockerfile.Parse("").Items);
+        Assert.Empty(new Dockerfile(Array.Empty<DockerfileConstruct>()).Items);
+        Assert.Equal("[]", StringHelper.FormatAsJson(Array.Empty<string>()));
+        Assert.Equal("", new StringToken("").Value);
+        Assert.Equal(" ", new StringToken(" ").Value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("\0")]
+    [InlineData("\0name")]
+    public void StringGuards(string? value)
+    {
+        Type exceptionType = value is null ? typeof(ArgumentNullException) : typeof(ArgumentException);
+        AssertArgument(exceptionType, "imageName", () => new FromInstruction(value!));
+        AssertArgument(exceptionType, "commandWithArgs", () => new HealthCheckInstruction(value!));
+        AssertArgument(exceptionType, "variableName", () => new VariableRefToken(value!));
+        AssertArgument(exceptionType, "repository", () => new ImageName(value!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t\r\n")]
+    [InlineData("\u00a0")]
+    [InlineData("\0repo")]
+    public void RepositoryRejectsEmptyWhitespaceAndLeadingNull(string repository)
+    {
+        Assert.Throws<ArgumentException>("repository", () => ImageName.FormatImageName(repository, null, null, null));
+    }
+
+    [Fact]
+    public void NullOrEmptyDoesNotRejectWhitespaceOrEmbeddedNull()
+    {
+        Assert.Equal(" ", new WhitespaceToken(" ").Value);
+        Assert.Equal("repo\0", ImageName.FormatImageName("repo\0", null, null, null));
+    }
+
+    [Theory]
+    [InlineData("ARG", "args")]
+    [InlineData("ENV", "variables")]
+    [InlineData("LABEL", "variables")]
+    public void DictionaryGuards(string instruction, string parameterName)
+    {
+        void Create(IDictionary<string, string?>? values)
+        {
+            _ = instruction switch
+            {
+                "ARG" => (Instruction)new ArgInstruction(values!),
+                "ENV" => new EnvInstruction(values!),
+                "LABEL" => new LabelInstruction(values!),
+                _ => throw new InvalidOperationException()
+            };
+        }
+
+        Assert.Throws<ArgumentNullException>(parameterName, () => Create(null));
+        Assert.Throws<ArgumentException>(parameterName, () => Create(new Dictionary<string, string?>()));
+        Create(new Dictionary<string, string?> { ["KEY"] = "value" });
+    }
+
+    public static TheoryData<string, string, int, bool> CollectionCases()
+    {
+        TheoryData<string, string, int, bool> cases = new();
+        foreach ((string instruction, string parameterName) in new[]
+        {
+            ("VOLUME", "paths"), ("EXPOSE", "portSpecs"), ("COPY", "sources"), ("ADD", "sources")
+        })
+        {
+            for (int input = 0; input < 5; input++)
+            {
+                cases.Add(instruction, parameterName, input, false);
+                cases.Add(instruction, parameterName, input, true);
+            }
+        }
+
+        return cases;
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionCases))]
+    public void CollectionGuards(string instruction, string parameterName, int input, bool lazy)
+    {
+        string[]? values = input switch
+        {
+            0 => null,
+            1 => [],
+            2 => [null!],
+            3 => ["80", null!],
+            4 => ["80", "443"],
+            _ => throw new InvalidOperationException()
+        };
+        IEnumerable<string>? sequence = lazy && values is not null ? Enumerate(values) : values;
+        void Create()
+        {
+            _ = instruction switch
+            {
+                "VOLUME" => (Instruction)new VolumeInstruction(sequence!),
+                "EXPOSE" => new ExposeInstruction(sequence!),
+                "COPY" => new CopyInstruction(sequence!, "/destination"),
+                "ADD" => new AddInstruction(sequence!, "/destination"),
+                _ => throw new InvalidOperationException()
+            };
+        }
+
+        if (input == 4)
+        {
+            Create();
+        }
+        else
+        {
+            AssertArgument(input == 0 ? typeof(ArgumentNullException) : typeof(ArgumentException), parameterName, Create);
+        }
+    }
+
+    [Fact]
+    public void NullElementValidationIsDistinctFromStringValidation()
+    {
+        Assert.Equal("VOLUME [\"\"]", new VolumeInstruction(new[] { "" }).ToString());
+        Assert.Throws<Sprache.ParseException>(() => new VolumeInstruction(new[] { " " }));
+        Assert.Throws<ArgumentException>("values", () => StringHelper.FormatAsJson(new[] { "valid", null! }));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("\0new")]
+    public void FailedSettersPreserveState(string? value)
+    {
+        Type exceptionType = value is null ? typeof(ArgumentNullException) : typeof(ArgumentException);
+        FromInstruction from = new("scratch");
+        CopyInstruction copy = new(new[] { "source" }, "/destination");
+        ExposeInstruction expose = new("80");
+
+        AssertArgument(exceptionType, "value", () => from.ImageName = value!);
+        AssertArgument(exceptionType, "value", () => copy.Destination = value);
+        AssertArgument(exceptionType, "value", () => expose.Ports[0] = value!);
+
+        Assert.Equal("FROM scratch", from.ToString());
+        Assert.Equal("COPY source /destination", copy.ToString());
+        Assert.Equal("EXPOSE 80", expose.ToString());
+    }
+
+    [Fact]
+    public void ExplicitParameterNameAndTokenSetters()
+    {
+        ArgInstruction arg = new("KEY", "value");
+        FromInstruction from = new("scratch");
+        Assert.Throws<ArgumentNullException>("value", () => arg.Args[0] = null!);
+        Assert.Throws<ArgumentNullException>("value", () => from.ImageNameToken = null!);
+        Assert.Equal("ARG KEY=value", arg.ToString());
+        Assert.Equal("FROM scratch", from.ToString());
+    }
+
+    [Fact]
+    public void ValidationOrder()
+    {
+        Assert.Throws<ArgumentNullException>("sources", () => new CopyInstruction((IEnumerable<string>)null!, null!));
+        Assert.Throws<ArgumentException>("sources", () => new CopyInstruction(Array.Empty<string>(), null!));
+        Assert.Throws<ArgumentNullException>("command", () => new HealthCheckInstruction(null!, (IEnumerable<string>)null!));
+        Assert.Throws<ArgumentNullException>("repository", () => ImageName.FormatImageName(null!, null, "tag", "sha256:digest"));
+    }
+
+    [Fact]
+    public void InvalidOperationsPreserveState()
+    {
+        ImageName tagged = new("repo", tag: "tag");
+        ImageName digested = new("repo", digest: "sha256:digest");
+        Assert.Throws<InvalidOperationException>(() => tagged.Digest = "sha256:digest");
+        Assert.Throws<InvalidOperationException>(() => digested.Tag = "tag");
+        Assert.Equal("repo:tag", tagged.ToString());
+        Assert.Equal("repo@sha256:digest", digested.ToString());
+        Assert.Throws<InvalidOperationException>(() => ImageName.FormatImageName("repo", null, "tag", "sha256:digest"));
+        Assert.Throws<InvalidOperationException>(() => new WhitespaceToken("text"));
+        Assert.Throws<InvalidOperationException>(() => new VariableRefToken("name", "invalid", "value"));
+    }
+
+    private static void AssertArgument(Type exceptionType, string parameterName, Action action)
+    {
+        ArgumentException exception = Assert.IsAssignableFrom<ArgumentException>(Assert.Throws(exceptionType, action));
+        Assert.Equal(parameterName, exception.ParamName);
+    }
+
+    private static IEnumerable<string> Enumerate(IEnumerable<string> values)
+    {
+        foreach (string value in values)
+        {
+            yield return value;
+        }
+    }
+}

--- a/src/Valleysoft.DockerfileModel.Tests/GuardTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/GuardTests.cs
@@ -1,0 +1,185 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class GuardTests
+{
+    [Fact]
+    public void NotNull()
+    {
+        Assert.Throws<ArgumentNullException>("input", () => Guard.NotNull<object>(null, "input"));
+        Guard.NotNull(new object(), "input");
+        Guard.NotNull("", "input");
+        Guard.NotNull(Array.Empty<string>(), "input");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("\0")]
+    [InlineData("\0value")]
+    public void StringGuardsRejectNullEmptyAndLeadingNull(string? value)
+    {
+        Type expectedType = value is null ? typeof(ArgumentNullException) : typeof(ArgumentException);
+        AssertArgument(expectedType, () => Guard.NotNullOrEmpty(value, "input"));
+        AssertArgument(expectedType, () => Guard.NotNullOrWhiteSpace(value, "input"));
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("\t\r\n")]
+    [InlineData("\u00a0")]
+    [InlineData("\u2003")]
+    public void StringGuardsDistinguishWhitespace(string value)
+    {
+        Guard.NotNullOrEmpty(value, "input");
+        Assert.Throws<ArgumentException>("input", () => Guard.NotNullOrWhiteSpace(value, "input"));
+    }
+
+    [Theory]
+    [InlineData("value")]
+    [InlineData(" value ")]
+    [InlineData("value\0")]
+    public void StringGuardsAcceptNonEmptyValues(string value)
+    {
+        Guard.NotNullOrEmpty(value, "input");
+        Guard.NotNullOrWhiteSpace(value, "input");
+    }
+
+    [Fact]
+    public void EnumerableGuards()
+    {
+        Assert.Throws<ArgumentNullException>("input", () => Guard.NotNullOrEmpty<string>(null, "input"));
+        Assert.Throws<ArgumentNullException>("input", () => Guard.NotNullEmptyOrNullElements<string>(null, "input"));
+
+        foreach (IEnumerable<string> values in new IEnumerable<string>[] { Array.Empty<string>(), new List<string>() })
+        {
+            Assert.Throws<ArgumentException>("input", () => Guard.NotNullOrEmpty(values, "input"));
+            Assert.Throws<ArgumentException>("input", () => Guard.NotNullEmptyOrNullElements(values, "input"));
+        }
+
+        Guard.NotNullOrEmpty(new Dictionary<string, string?> { ["KEY"] = null }, "input");
+        Guard.NotNullOrEmpty(new string?[] { null }, "input");
+        Guard.NotNullEmptyOrNullElements(new[] { "", " ", "\0", "value" }, "input");
+        Guard.NotNullEmptyOrNullElements(new Token[] { new StringToken("value") }, "input");
+        Assert.Throws<ArgumentException>("input", () => Guard.NotNullEmptyOrNullElements(new Token?[] { null }, "input"));
+    }
+
+    [Theory]
+    [InlineData(false, 0)]
+    [InlineData(false, 1)]
+    [InlineData(false, 2)]
+    [InlineData(true, 0)]
+    [InlineData(true, 1)]
+    [InlineData(true, 2)]
+    public void EnumerableGuardsDisposeIterators(bool validateElements, int input)
+    {
+        bool disposed = false;
+        IEnumerable<string?> Values()
+        {
+            try
+            {
+                if (input > 0)
+                {
+                    yield return "value";
+                }
+                if (input == 2)
+                {
+                    yield return null;
+                }
+            }
+            finally
+            {
+                disposed = true;
+            }
+        }
+
+        void Validate()
+        {
+            if (validateElements)
+            {
+                Guard.NotNullEmptyOrNullElements(Values(), "input");
+            }
+            else
+            {
+                Guard.NotNullOrEmpty(Values(), "input");
+            }
+        }
+
+        if (input == 0 || (validateElements && input == 2))
+        {
+            Assert.Throws<ArgumentException>("input", Validate);
+        }
+        else
+        {
+            Validate();
+        }
+
+        Assert.True(disposed);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EnumerableGuardsPropagateIteratorExceptions(bool validateElements)
+    {
+        bool disposed = false;
+        InvalidOperationException failure = new("Iterator failed.");
+        IEnumerable<string> Values()
+        {
+            try
+            {
+                if (validateElements)
+                {
+                    yield return "value";
+                }
+                throw failure;
+            }
+            finally
+            {
+                disposed = true;
+            }
+        }
+
+        InvalidOperationException actual = Assert.Throws<InvalidOperationException>(() =>
+        {
+            if (validateElements)
+            {
+                Guard.NotNullEmptyOrNullElements(Values(), "input");
+            }
+            else
+            {
+                Guard.NotNullOrEmpty(Values(), "input");
+            }
+        });
+
+        Assert.Same(failure, actual);
+        Assert.True(disposed);
+    }
+
+    [Fact]
+    public void NullElementGuardStopsAtFirstInvalidElement()
+    {
+        IEnumerable<string?> Values()
+        {
+            yield return null;
+            throw new InvalidOperationException("Enumeration continued after a null element.");
+        }
+
+        Assert.Throws<ArgumentException>("input", () => Guard.NotNullEmptyOrNullElements(Values(), "input"));
+    }
+
+    [Fact]
+    public void Operation()
+    {
+        Guard.Operation(true, "message");
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => Guard.Operation(false, "message"));
+        Assert.Equal("message", exception.Message);
+    }
+
+    private static void AssertArgument(Type expectedType, Action action)
+    {
+        ArgumentException exception = Assert.IsAssignableFrom<ArgumentException>(Assert.Throws(expectedType, action));
+        Assert.Equal("input", exception.ParamName);
+    }
+}

--- a/src/Valleysoft.DockerfileModel/ArgDeclaration.cs
+++ b/src/Valleysoft.DockerfileModel/ArgDeclaration.cs
@@ -25,7 +25,7 @@ public class ArgDeclaration : AggregateToken, IKeyValuePair
         get => NameToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             NameToken.Value = value;
         }
     }
@@ -41,7 +41,7 @@ public class ArgDeclaration : AggregateToken, IKeyValuePair
         get => Tokens.OfType<Variable>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(NameToken, value);
         }
     }
@@ -114,7 +114,7 @@ public class ArgDeclaration : AggregateToken, IKeyValuePair
 
     private static IEnumerable<Token> GetTokens(string name, string? value, char escapeChar)
     {
-        Requires.NotNullOrEmpty(name, nameof(name));
+        Guard.NotNullOrEmpty(name, nameof(name));
 
         StringBuilder builder = new(name);
         if (value != null)

--- a/src/Valleysoft.DockerfileModel/ArgInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/ArgInstruction.cs
@@ -30,7 +30,7 @@ public class ArgInstruction : Instruction
             token => token,
             (token, keyValuePair) =>
             {
-                Requires.NotNull(keyValuePair, "value");
+                Guard.NotNull(keyValuePair, "value");
                 token.Name = keyValuePair.Key;
                 token.Value = keyValuePair.Value;
             });
@@ -49,7 +49,7 @@ public class ArgInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(IDictionary<string, string?> args, char escapeChar)
     {
-        Requires.NotNullOrEmpty(args, nameof(args));
+        Guard.NotNullOrEmpty(args, nameof(args));
 
         string[] keyValueAssignments = args
             .Select(kvp => kvp.Value is not null

--- a/src/Valleysoft.DockerfileModel/CmdInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/CmdInstruction.cs
@@ -36,21 +36,21 @@ public class CmdInstruction : CommandInstruction
 
     private static IEnumerable<Token> GetTokens(string commandWithArgs, char escapeChar)
     {
-        Requires.NotNullOrEmpty(commandWithArgs, nameof(commandWithArgs));
+        Guard.NotNullOrEmpty(commandWithArgs, nameof(commandWithArgs));
         return GetTokens($"CMD {commandWithArgs}", GetInnerParser(escapeChar));
     }
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> defaultArgs, char escapeChar)
     {
-        Requires.NotNull(defaultArgs, nameof(defaultArgs));
+        Guard.NotNull(defaultArgs, nameof(defaultArgs));
 
         return GetTokens($"CMD {StringHelper.FormatAsJson(defaultArgs)}", GetInnerParser(escapeChar));
     }
 
     private static IEnumerable<Token> GetTokens(string command, IEnumerable<string> args, char escapeChar)
     {
-        Requires.NotNullOrEmpty(command, nameof(command));
-        Requires.NotNull(args, nameof(args));
+        Guard.NotNullOrEmpty(command, nameof(command));
+        Guard.NotNull(args, nameof(args));
         return GetTokens($"CMD {StringHelper.FormatAsJson(new string[] { command }.Concat(args))}", GetInnerParser(escapeChar));
     }
 }

--- a/src/Valleysoft.DockerfileModel/CommandInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/CommandInstruction.cs
@@ -19,7 +19,7 @@ public abstract class CommandInstruction : Instruction
         get => this.Tokens.OfType<Command>().FirstOrDefault();
         set
         {
-            Requires.NotNull(value!, nameof(value));
+            Guard.NotNull(value!, nameof(value));
             Command? current = Command;
             if (current is null)
             {

--- a/src/Valleysoft.DockerfileModel/Comment.cs
+++ b/src/Valleysoft.DockerfileModel/Comment.cs
@@ -25,7 +25,7 @@ public class Comment : DockerfileConstruct
         get => Tokens.OfType<CommentToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(ValueToken, value);
         }
     }
@@ -34,19 +34,19 @@ public class Comment : DockerfileConstruct
 
     public static Comment Parse(string text)
     {
-        Requires.NotNullOrEmpty(text, nameof(text));
+        Guard.NotNullOrEmpty(text, nameof(text));
         return new Comment(GetTokens(text, ParseHelper.CommentText()));
     }
 
     private static IEnumerable<Token> GetTokens(string comment)
     {
-        Requires.NotNullOrEmpty(comment, nameof(comment));
+        Guard.NotNullOrEmpty(comment, nameof(comment));
         return GetTokens($"#{comment}", ParseHelper.CommentText());
     }
 
     public static bool IsComment(string text)
     {
-        Requires.NotNullOrEmpty(text, nameof(text));
+        Guard.NotNullOrEmpty(text, nameof(text));
         return ParseHelper.CommentText().TryParse(text).WasSuccessful;
     }
 }

--- a/src/Valleysoft.DockerfileModel/Dockerfile.cs
+++ b/src/Valleysoft.DockerfileModel/Dockerfile.cs
@@ -12,7 +12,7 @@ public class Dockerfile : IConstructContainer
 
     public Dockerfile(IEnumerable<DockerfileConstruct> items)
     {
-        Requires.NotNull(items, nameof(items));
+        Guard.NotNull(items, nameof(items));
         this.Items = items.ToList();
     }
 
@@ -28,7 +28,7 @@ public class Dockerfile : IConstructContainer
 
     public static Dockerfile Parse(string text)
     {
-        Requires.NotNull(text, nameof(text));
+        Guard.NotNull(text, nameof(text));
         return DockerfileParser.ParseContent(text);
     }
 
@@ -38,7 +38,7 @@ public class Dockerfile : IConstructContainer
         ResolutionOptions? options = null)
         where TInstruction : Instruction
     {
-        Requires.NotNull(instruction, nameof(instruction));
+        Guard.NotNull(instruction, nameof(instruction));
 
         bool foundInstruction = false;
 

--- a/src/Valleysoft.DockerfileModel/DockerfileBuilder.cs
+++ b/src/Valleysoft.DockerfileModel/DockerfileBuilder.cs
@@ -11,7 +11,7 @@ public class DockerfileBuilder
 
     public DockerfileBuilder(Dockerfile dockerfile)
     {
-        Requires.NotNull(dockerfile, nameof(dockerfile));
+        Guard.NotNull(dockerfile, nameof(dockerfile));
         Dockerfile = dockerfile;
         EscapeChar = dockerfile.EscapeChar;
     }

--- a/src/Valleysoft.DockerfileModel/EntrypointInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/EntrypointInstruction.cs
@@ -33,21 +33,21 @@ public class EntrypointInstruction : CommandInstruction
 
     private static IEnumerable<Token> GetTokens(string commandWithArgs, char escapeChar)
     {
-        Requires.NotNullOrEmpty(commandWithArgs, nameof(commandWithArgs));
+        Guard.NotNullOrEmpty(commandWithArgs, nameof(commandWithArgs));
         return GetTokens($"ENTRYPOINT {commandWithArgs}", GetInnerParser(escapeChar));
     }
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> execArgs, char escapeChar)
     {
-        Requires.NotNull(execArgs, nameof(execArgs));
+        Guard.NotNull(execArgs, nameof(execArgs));
 
         return GetTokens($"ENTRYPOINT {StringHelper.FormatAsJson(execArgs)}", GetInnerParser(escapeChar));
     }
 
     private static IEnumerable<Token> GetTokens(string command, IEnumerable<string> args, char escapeChar)
     {
-        Requires.NotNullOrEmpty(command, nameof(command));
-        Requires.NotNull(args, nameof(args));
+        Guard.NotNullOrEmpty(command, nameof(command));
+        Guard.NotNull(args, nameof(args));
         return GetTokens($"ENTRYPOINT {StringHelper.FormatAsJson(new string[] { command }.Concat(args))}", GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/EnvInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/EnvInstruction.cs
@@ -18,7 +18,7 @@ public class EnvInstruction : Instruction
             token => token,
             (token, keyValuePair) =>
             {
-                Requires.NotNull(keyValuePair, "value");
+                Guard.NotNull(keyValuePair, "value");
                 token.Key = keyValuePair.Key;
                 token.Value = keyValuePair.Value!;
             });
@@ -37,7 +37,7 @@ public class EnvInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(IDictionary<string, string> variables, char escapeChar)
     {
-        Requires.NotNullOrEmpty(variables, nameof(variables));
+        Guard.NotNullOrEmpty(variables, nameof(variables));
 
         string[] keyValueAssignments = variables
             .Select(kvp => StringHelper.FormatKeyValueAssignment(kvp.Key, kvp.Value))

--- a/src/Valleysoft.DockerfileModel/ExecFormCommand.cs
+++ b/src/Valleysoft.DockerfileModel/ExecFormCommand.cs
@@ -21,7 +21,7 @@ public class ExecFormCommand : Command
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> values, char escapeChar)
     {
-        Requires.NotNull(values, nameof(values));
+        Guard.NotNull(values, nameof(values));
 
         return GetTokens(StringHelper.FormatAsJson(values), GetInnerParser(escapeChar));
     }

--- a/src/Valleysoft.DockerfileModel/ExposeInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/ExposeInstruction.cs
@@ -23,7 +23,7 @@ public class ExposeInstruction : Instruction
             token => token.Value,
             (token, value) =>
             {
-                Requires.NotNullOrEmpty(value, nameof(value));
+                Guard.NotNullOrEmpty(value, nameof(value));
                 token.Value = value;
             });
     }
@@ -41,13 +41,13 @@ public class ExposeInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(string portSpecs, char escapeChar)
     {
-        Requires.NotNullOrEmpty(portSpecs, nameof(portSpecs));
+        Guard.NotNullOrEmpty(portSpecs, nameof(portSpecs));
         return GetTokens($"EXPOSE {portSpecs}", GetInnerParser(escapeChar));
     }
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> portSpecs, char escapeChar)
     {
-        Requires.NotNullEmptyOrNullElements(portSpecs, nameof(portSpecs));
+        Guard.NotNullEmptyOrNullElements(portSpecs, nameof(portSpecs));
         return GetTokens(string.Join(" ", portSpecs), escapeChar);
     }
 

--- a/src/Valleysoft.DockerfileModel/FileTransferInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/FileTransferInstruction.cs
@@ -42,7 +42,7 @@ public abstract class FileTransferInstruction : Instruction
         }
         set
         {
-            Requires.NotNullOrEmpty(value!, nameof(value));
+            Guard.NotNullOrEmpty(value!, nameof(value));
             LiteralToken? destToken = DestinationToken;
             if (destToken is null)
             {
@@ -62,7 +62,7 @@ public abstract class FileTransferInstruction : Instruction
         get => Tokens.OfType<LiteralToken>().LastOrDefault();
         set
         {
-            Requires.NotNull(value!, nameof(value));
+            Guard.NotNull(value!, nameof(value));
             LiteralToken? current = DestinationToken;
             if (current is null)
             {
@@ -160,8 +160,8 @@ public abstract class FileTransferInstruction : Instruction
         string? changeOwner, string? permissions, char escapeChar, string instructionName, string? optionalFlag,
         string? trailingOptionalFlag = null)
     {
-        Requires.NotNullEmptyOrNullElements(sources, nameof(sources));
-        Requires.NotNullOrEmpty(destination, nameof(destination));
+        Guard.NotNullEmptyOrNullElements(sources, nameof(sources));
+        Guard.NotNullOrEmpty(destination, nameof(destination));
 
         IEnumerable<string> locations = sources.Append(destination);
 

--- a/src/Valleysoft.DockerfileModel/FromInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/FromInstruction.cs
@@ -36,7 +36,7 @@ public class FromInstruction : Instruction
         get => this.imageName.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             this.imageName.Value = value;
         }
     }
@@ -46,7 +46,7 @@ public class FromInstruction : Instruction
         get => this.imageName;
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(ImageNameToken, value);
             this.imageName = value;
         }
@@ -111,7 +111,7 @@ public class FromInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(string imageName, string? stageName, string? platform, char escapeChar)
     {
-        Requires.NotNullOrEmpty(imageName, nameof(imageName));
+        Guard.NotNullOrEmpty(imageName, nameof(imageName));
 
         StringBuilder builder = new("FROM ");
         if (platform is not null)

--- a/src/Valleysoft.DockerfileModel/GenericInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/GenericInstruction.cs
@@ -27,8 +27,8 @@ public class GenericInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(string instruction, string args, char escapeChar)
     {
-        Requires.NotNullOrEmpty(instruction, nameof(instruction));
-        Requires.NotNullOrEmpty(args, nameof(args));
+        Guard.NotNullOrEmpty(instruction, nameof(instruction));
+        Guard.NotNullOrEmpty(args, nameof(args));
         return GetTokens($"{instruction} {args}", GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/Guard.cs
+++ b/src/Valleysoft.DockerfileModel/Guard.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Valleysoft.DockerfileModel;
+
+internal static class Guard
+{
+    public static void NotNull<T>([NotNull] T? value, string paramName) where T : class
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+    }
+
+    public static void NotNullOrEmpty([NotNull] string? value, string paramName)
+    {
+        NotNull(value, paramName);
+        if (value.Length == 0 || value[0] == '\0')
+        {
+            throw new ArgumentException("Value cannot be empty or start with a null character.", paramName);
+        }
+    }
+
+    public static void NotNullOrWhiteSpace([NotNull] string? value, string paramName)
+    {
+        NotNullOrEmpty(value, paramName);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value cannot consist only of whitespace.", paramName);
+        }
+    }
+
+    public static void NotNullOrEmpty<T>([NotNull] IEnumerable<T>? values, string paramName)
+    {
+        NotNull(values, paramName);
+        using IEnumerator<T> enumerator = values.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            throw new ArgumentException("Collection cannot be empty.", paramName);
+        }
+    }
+
+    public static void NotNullEmptyOrNullElements<T>([NotNull] IEnumerable<T?>? values, string paramName) where T : class
+    {
+        NotNull(values, paramName);
+        using IEnumerator<T?> enumerator = values.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            throw new ArgumentException("Collection cannot be empty.", paramName);
+        }
+
+        do
+        {
+            if (enumerator.Current is null)
+            {
+                throw new ArgumentException("Collection cannot contain null elements.", paramName);
+            }
+        }
+        while (enumerator.MoveNext());
+    }
+
+    public static void Operation(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+}

--- a/src/Valleysoft.DockerfileModel/HealthCheckInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/HealthCheckInstruction.cs
@@ -219,7 +219,7 @@ public class HealthCheckInstruction : Instruction
     private static IEnumerable<Token> GetTokens(string commandBody, string? interval, string? timeout,
         string? startPeriod, string? startInterval, string? retries, char escapeChar)
     {
-        Requires.NotNullOrEmpty(commandBody, nameof(commandBody));
+        Guard.NotNullOrEmpty(commandBody, nameof(commandBody));
         return GetTokens(
             $"HEALTHCHECK {GetOptionArgs(interval, timeout, startPeriod, startInterval, retries, escapeChar)}CMD {commandBody}", GetInnerParser(escapeChar));
     }
@@ -281,20 +281,20 @@ public class HealthCheckInstruction : Instruction
 
     private static string ValidateNotNullOrEmpty(string value, string paramName)
     {
-        Requires.NotNullOrEmpty(value, paramName);
+        Guard.NotNullOrEmpty(value, paramName);
         return value;
     }
 
     private static string ValidateAndFormatAsJson(IEnumerable<string> defaultArgs, string paramName)
     {
-        Requires.NotNull(defaultArgs, paramName);
+        Guard.NotNull(defaultArgs, paramName);
         return StringHelper.FormatAsJson(defaultArgs);
     }
 
     private static string ValidateAndFormatAsJson(string command, IEnumerable<string> args)
     {
-        Requires.NotNullOrEmpty(command, nameof(command));
-        Requires.NotNull(args, nameof(args));
+        Guard.NotNullOrEmpty(command, nameof(command));
+        Guard.NotNull(args, nameof(args));
         return StringHelper.FormatAsJson(new string[] { command }.Concat(args));
     }
 }

--- a/src/Valleysoft.DockerfileModel/ImageName.cs
+++ b/src/Valleysoft.DockerfileModel/ImageName.cs
@@ -74,7 +74,7 @@ public class ImageName : AggregateToken
         get => RepositoryToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             RepositoryToken.Value = value;
         }
     }
@@ -84,7 +84,7 @@ public class ImageName : AggregateToken
         get => repositoryToken;
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(RepositoryToken, value);
             repositoryToken = value;
         }
@@ -95,7 +95,7 @@ public class ImageName : AggregateToken
         get => this.tagToken?.Value;
         set
         {
-            Verify.Operation(
+            Guard.Operation(
                 value is null || Digest is null,
                 $"{nameof(Tag)} cannot be set when {nameof(Digest)} is already set.");
 
@@ -116,7 +116,7 @@ public class ImageName : AggregateToken
         get => tagToken;
         set
         {
-            Verify.Operation(
+            Guard.Operation(
                 value is null || DigestToken is null,
                 $"{nameof(TagToken)} cannot be set when {nameof(DigestToken)} is already set.");
 
@@ -144,7 +144,7 @@ public class ImageName : AggregateToken
         get => this.digestToken?.Value;
         set
         {
-            Verify.Operation(
+            Guard.Operation(
                 value is null || Tag is null,
                 $"{nameof(Digest)} cannot be set when {nameof(Tag)} is already set.");
 
@@ -165,7 +165,7 @@ public class ImageName : AggregateToken
         get => digestToken;
         set
         {
-            Verify.Operation(
+            Guard.Operation(
                 value is null || Tag is null,
                 $"{nameof(DigestToken)} cannot be set when {nameof(TagToken)} is already set.");
 
@@ -190,8 +190,8 @@ public class ImageName : AggregateToken
 
     public static string FormatImageName(string repository, string? registry, string? tag, string? digest)
     {
-        Requires.NotNullOrWhiteSpace(repository, nameof(repository));
-        Verify.Operation(
+        Guard.NotNullOrWhiteSpace(repository, nameof(repository));
+        Guard.Operation(
             (tag is null && digest is null) || String.IsNullOrEmpty(tag) ^ String.IsNullOrEmpty(digest),
             $"Either {nameof(tag)} may be set or {nameof(digest)} may be set but not both.");
 

--- a/src/Valleysoft.DockerfileModel/Imports.cs
+++ b/src/Valleysoft.DockerfileModel/Imports.cs
@@ -1,2 +1,1 @@
 ﻿global using global::Sprache;
-global using global::Validation;

--- a/src/Valleysoft.DockerfileModel/LabelInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/LabelInstruction.cs
@@ -18,7 +18,7 @@ public class LabelInstruction : Instruction
             token => token,
             (token, keyValuePair) =>
             {
-                Requires.NotNull(keyValuePair, "value");
+                Guard.NotNull(keyValuePair, "value");
                 token.Key = keyValuePair.Key;
                 token.Value = keyValuePair.Value!;
             });
@@ -37,7 +37,7 @@ public class LabelInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(IDictionary<string, string> variables, char escapeChar)
     {
-        Requires.NotNullOrEmpty(variables, nameof(variables));
+        Guard.NotNullOrEmpty(variables, nameof(variables));
 
         string[] keyValueAssignments = variables
             .Select(kvp => StringHelper.FormatKeyValueAssignment(kvp.Key, kvp.Value))

--- a/src/Valleysoft.DockerfileModel/MaintainerInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/MaintainerInstruction.cs
@@ -19,7 +19,7 @@ public class MaintainerInstruction : Instruction
         get => MaintainerToken.Value;
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             MaintainerToken.Value = value;
         }
     }
@@ -29,7 +29,7 @@ public class MaintainerInstruction : Instruction
         get => Tokens.OfType<LiteralToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(MaintainerToken, value);
         }
     }
@@ -43,7 +43,7 @@ public class MaintainerInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(string maintainer, char escapeChar)
     {
-        Requires.NotNull(maintainer, nameof(maintainer));
+        Guard.NotNull(maintainer, nameof(maintainer));
         return GetTokens($"MAINTAINER {(String.IsNullOrEmpty(maintainer) ? "\"\"" : maintainer)}", GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/Mount.cs
+++ b/src/Valleysoft.DockerfileModel/Mount.cs
@@ -20,7 +20,7 @@ public class Mount : AggregateToken
         get => TypeToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             var valueToken = TypeToken.ValueToken
                 ?? throw new InvalidOperationException("Mount.TypeToken.ValueToken cannot be null when setting Mount.Type.");
             valueToken.Value = value;
@@ -32,7 +32,7 @@ public class Mount : AggregateToken
         get => Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(TypeToken, value);
         }
     }

--- a/src/Valleysoft.DockerfileModel/NotNullAttribute.cs
+++ b/src/Valleysoft.DockerfileModel/NotNullAttribute.cs
@@ -1,0 +1,8 @@
+#if NETSTANDARD2_0
+namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(AttributeTargets.Parameter)]
+internal sealed class NotNullAttribute : Attribute
+{
+}
+#endif

--- a/src/Valleysoft.DockerfileModel/OnBuildInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/OnBuildInstruction.cs
@@ -28,7 +28,7 @@ public class OnBuildInstruction : Instruction
         get => Tokens.OfType<Instruction>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(Instruction, value);
         }
     }
@@ -42,7 +42,7 @@ public class OnBuildInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(Instruction instruction, char escapeChar)
     {
-        Requires.NotNull(instruction, nameof(instruction));
+        Guard.NotNull(instruction, nameof(instruction));
         return GetTokens($"ONBUILD {instruction}", GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/ParseHelper.cs
+++ b/src/Valleysoft.DockerfileModel/ParseHelper.cs
@@ -589,7 +589,7 @@ internal static class ParseHelper
     private static IEnumerable<Token> CollapseLiteralTokens(IEnumerable<Token> tokens,
         bool canContainVariables, char escapeChar, char? quoteChar = null)
     {
-        Requires.NotNullEmptyOrNullElements(tokens, nameof(tokens));
+        Guard.NotNullEmptyOrNullElements(tokens, nameof(tokens));
         return new Token[]
         {
             new LiteralToken(

--- a/src/Valleysoft.DockerfileModel/ParserDirective.cs
+++ b/src/Valleysoft.DockerfileModel/ParserDirective.cs
@@ -30,7 +30,7 @@ public class ParserDirective : DockerfileConstruct
         get => DirectiveValueToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             DirectiveValueToken.Value = value;
         }
     }
@@ -40,7 +40,7 @@ public class ParserDirective : DockerfileConstruct
         get => Tokens.OfType<LiteralToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(DirectiveValueToken, value);
         }
     }
@@ -68,8 +68,8 @@ public class ParserDirective : DockerfileConstruct
 
     private static IEnumerable<Token> GetTokens(string directive, string value)
     {
-        Requires.NotNullOrEmpty(directive, nameof(directive));
-        Requires.NotNullOrEmpty(value, nameof(value));
+        Guard.NotNullOrEmpty(directive, nameof(directive));
+        Guard.NotNullOrEmpty(value, nameof(value));
         return GetTokens($"#{directive}={value}", GetParser());
     }
 

--- a/src/Valleysoft.DockerfileModel/RunInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/RunInstruction.cs
@@ -53,7 +53,7 @@ public class RunInstruction : CommandInstruction
                 throw new InvalidOperationException("Cannot set Command on a heredoc RUN instruction.");
             }
 
-            Requires.NotNull(value!, nameof(value));
+            Guard.NotNull(value!, nameof(value));
             Command? current = Command;
             if (current is null)
             {
@@ -148,8 +148,8 @@ public class RunInstruction : CommandInstruction
     private static IEnumerable<Token> GetTokens(string commandWithArgs, IEnumerable<Mount> mounts,
         string? network, string? security, char escapeChar)
     {
-        Requires.NotNullOrEmpty(commandWithArgs, nameof(commandWithArgs));
-        Requires.NotNull(mounts, nameof(mounts));
+        Guard.NotNullOrEmpty(commandWithArgs, nameof(commandWithArgs));
+        Guard.NotNull(mounts, nameof(mounts));
 
         return GetTokens($"RUN {GetFlagArgs(mounts, network, security, escapeChar)}{commandWithArgs}", GetInnerParser(escapeChar));
     }
@@ -157,9 +157,9 @@ public class RunInstruction : CommandInstruction
     private static IEnumerable<Token> GetTokens(string command, IEnumerable<string> args, IEnumerable<Mount> mounts,
         string? network, string? security, char escapeChar)
     {
-        Requires.NotNullOrEmpty(command, nameof(command));
-        Requires.NotNull(args, nameof(args));
-        Requires.NotNull(mounts, nameof(mounts));
+        Guard.NotNullOrEmpty(command, nameof(command));
+        Guard.NotNull(args, nameof(args));
+        Guard.NotNull(mounts, nameof(mounts));
 
         return GetTokens(
             $"RUN {GetFlagArgs(mounts, network, security, escapeChar)}{StringHelper.FormatAsJson(new string[] { command }.Concat(args))}", GetInnerParser(escapeChar));

--- a/src/Valleysoft.DockerfileModel/ShellFormCommand.cs
+++ b/src/Valleysoft.DockerfileModel/ShellFormCommand.cs
@@ -29,7 +29,7 @@ public class ShellFormCommand : Command
         get => ValueToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             ValueToken.Value = value;
         }
     }
@@ -39,14 +39,14 @@ public class ShellFormCommand : Command
         get => Tokens.OfType<LiteralToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(ValueToken, value);
         }
     }
 
     private static IEnumerable<Token> GetTokens(string command, char escapeChar)
     {
-        Requires.NotNullOrEmpty(command, nameof(command));
+        Guard.NotNullOrEmpty(command, nameof(command));
         return GetTokens(command, GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/ShellInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/ShellInstruction.cs
@@ -28,8 +28,8 @@ public class ShellInstruction : CommandInstruction
 
     private static IEnumerable<Token> GetTokens(string command, IEnumerable<string> args, char escapeChar)
     {
-        Requires.NotNull(command, nameof(command));
-        Requires.NotNull(args, nameof(args));
+        Guard.NotNull(command, nameof(command));
+        Guard.NotNull(args, nameof(args));
         return GetTokens($"SHELL {StringHelper.FormatAsJson(new string[] { command }.Concat(args))}", GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/StagesView.cs
+++ b/src/Valleysoft.DockerfileModel/StagesView.cs
@@ -4,7 +4,7 @@ public class StagesView
 {
     public StagesView(Dockerfile dockerfile)
     {
-        Requires.NotNull(dockerfile, nameof(dockerfile));
+        Guard.NotNull(dockerfile, nameof(dockerfile));
 
         List<DockerfileConstruct> items = dockerfile.Items.ToList();
 

--- a/src/Valleysoft.DockerfileModel/StopSignalInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/StopSignalInstruction.cs
@@ -19,7 +19,7 @@ public class StopSignalInstruction : Instruction
         get => SignalToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             SignalToken.Value = value;
         }
     }
@@ -29,7 +29,7 @@ public class StopSignalInstruction : Instruction
         get => Tokens.OfType<LiteralToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(SignalToken, value);
         }
     }
@@ -43,7 +43,7 @@ public class StopSignalInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(string signal, char escapeChar)
     {
-        Requires.NotNullOrEmpty(signal, nameof(signal));
+        Guard.NotNullOrEmpty(signal, nameof(signal));
         return GetTokens($"STOPSIGNAL {signal}", GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/StringHelper.cs
+++ b/src/Valleysoft.DockerfileModel/StringHelper.cs
@@ -7,7 +7,7 @@ internal static class StringHelper
 
     public static string FormatAsJson(IEnumerable<string> values)
     {
-        Requires.NotNull(values, nameof(values));
+        Guard.NotNull(values, nameof(values));
 
         // Materialize the sequence once to avoid double enumeration, then
         // validate that no element is null.

--- a/src/Valleysoft.DockerfileModel/Tokens/AggregateToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/AggregateToken.cs
@@ -6,15 +6,15 @@ public abstract class AggregateToken : Token
 {
     protected AggregateToken(IEnumerable<Token> tokens)
     {
-        Requires.NotNull(tokens, nameof(tokens));
+        Guard.NotNull(tokens, nameof(tokens));
 
         this.TokenList = tokens.ToList();
     }
 
     protected static IEnumerable<Token> GetTokens(string text, Parser<IEnumerable<Token?>> parser)
     {
-        Requires.NotNull(text, nameof(text));
-        Requires.NotNull(parser, nameof(parser));
+        Guard.NotNull(text, nameof(text));
+        Guard.NotNull(parser, nameof(parser));
 
         return FilterNulls(parser.Parse(text))
             .ToList();
@@ -26,7 +26,7 @@ public abstract class AggregateToken : Token
 
     protected override string GetUnderlyingValue(TokenStringOptions options)
     {
-        Requires.NotNull(options, nameof(options));
+        Guard.NotNull(options, nameof(options));
 
         return String.Concat(
             Tokens

--- a/src/Valleysoft.DockerfileModel/Tokens/HeredocDelimiterToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/HeredocDelimiterToken.cs
@@ -18,7 +18,7 @@ public class HeredocDelimiterToken : IdentifierToken
 
     private static IEnumerable<Token> GetTokens(string value)
     {
-        Requires.NotNullOrEmpty(value, nameof(value));
+        Guard.NotNullOrEmpty(value, nameof(value));
         return new Token[] { new StringToken(value) };
     }
 }

--- a/src/Valleysoft.DockerfileModel/Tokens/IdentifierToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/IdentifierToken.cs
@@ -11,7 +11,7 @@ public abstract class IdentifierToken : AggregateToken, IQuotableValueToken
         get => this.ToString(TokenStringOptions.CreateOptionsForValueString());
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             ReplaceWithTokens(GetInnerTokens(value));
         }
     }
@@ -23,7 +23,7 @@ public abstract class IdentifierToken : AggregateToken, IQuotableValueToken
     protected static (IEnumerable<Token> Tokens, char? QuoteChar) GetTokens(string value,
         Parser<(IEnumerable<Token> Token, char? QuoteChar)> parser)
     {
-        Requires.NotNull(value, nameof(value));
+        Guard.NotNull(value, nameof(value));
         return parser.Parse(value);
     }
 }

--- a/src/Valleysoft.DockerfileModel/Tokens/KeyValueToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/KeyValueToken.cs
@@ -41,7 +41,7 @@ public class KeyValueToken<TKey, TValue> : AggregateToken, IKeyValuePair
         get => KeyToken.Value;
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             KeyToken.Value = value;
         }
     }
@@ -51,7 +51,7 @@ public class KeyValueToken<TKey, TValue> : AggregateToken, IKeyValuePair
         get => Tokens.OfType<TKey>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(KeyToken, value);
         }
     }
@@ -71,7 +71,7 @@ public class KeyValueToken<TKey, TValue> : AggregateToken, IKeyValuePair
         }
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
 
             TValue? existingToken = Tokens.After(KeyToken).OfType<TValue>().FirstOrDefault();
             if (existingToken is IValueToken valueToken)

--- a/src/Valleysoft.DockerfileModel/Tokens/LiteralToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/LiteralToken.cs
@@ -30,7 +30,7 @@ public class LiteralToken : AggregateToken, IQuotableValueToken
         get => this.ToString(TokenStringOptions.CreateOptionsForValueString());
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             ReplaceWithTokens(GetInnerTokens(value));
         }
     }
@@ -42,7 +42,7 @@ public class LiteralToken : AggregateToken, IQuotableValueToken
 
     private static (IEnumerable<Token> Tokens, char? QuoteChar) GetTokens(string value, bool canContainVariables, char escapeChar)
     {
-        Requires.NotNull(value, nameof(value));
+        Guard.NotNull(value, nameof(value));
 
         if (value == string.Empty)
         {

--- a/src/Valleysoft.DockerfileModel/Tokens/PrimitiveToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/PrimitiveToken.cs
@@ -6,7 +6,7 @@ public abstract class PrimitiveToken : Token, IValueToken
 
     public PrimitiveToken(string value)
     {
-        Requires.NotNull(value, nameof(value));
+        Guard.NotNull(value, nameof(value));
         this.value = value;
     }
 
@@ -15,7 +15,7 @@ public abstract class PrimitiveToken : Token, IValueToken
         get => value;
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             this.value = value;
         }
     }

--- a/src/Valleysoft.DockerfileModel/Tokens/Token.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/Token.cs
@@ -9,7 +9,7 @@ public abstract class Token
 
     public string ToString(TokenStringOptions options)
     {
-        Requires.NotNull(options, nameof(options));
+        Guard.NotNull(options, nameof(options));
 
         string value = GetUnderlyingValue(options);
 

--- a/src/Valleysoft.DockerfileModel/Tokens/VariableRefToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/VariableRefToken.cs
@@ -43,7 +43,7 @@ public class VariableRefToken : AggregateToken
         get => VariableNameToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             VariableNameToken.Value = value;
         }
     }
@@ -53,7 +53,7 @@ public class VariableRefToken : AggregateToken
         get => Tokens.OfType<StringToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(VariableNameToken, value);
         }
     }
@@ -263,9 +263,9 @@ public class VariableRefToken : AggregateToken
 
     private static IEnumerable<Token> GetTokens(string variableName, string modifier, string modifierValue, char escapeChar)
     {
-        Requires.NotNullOrEmpty(variableName, nameof(variableName));
-        Requires.NotNullOrEmpty(modifier, nameof(modifier));
-        Requires.NotNull(modifierValue, nameof(modifierValue));
+        Guard.NotNullOrEmpty(variableName, nameof(variableName));
+        Guard.NotNullOrEmpty(modifier, nameof(modifier));
+        Guard.NotNull(modifierValue, nameof(modifierValue));
         ValidateModifier(modifier);
 
         return GetTokens($"${{{variableName}{modifier}{modifierValue}}}", GetInnerParser(escapeChar));
@@ -273,7 +273,7 @@ public class VariableRefToken : AggregateToken
 
     private static IEnumerable<Token> GetTokens(string variableName, bool includeBraces, char escapeChar)
     {
-        Requires.NotNullOrEmpty(variableName, nameof(variableName));
+        Guard.NotNullOrEmpty(variableName, nameof(variableName));
 
         StringBuilder builder = new("$");
         if (includeBraces)
@@ -293,7 +293,7 @@ public class VariableRefToken : AggregateToken
     {
         if (!String.IsNullOrEmpty(modifier))
         {
-            Verify.Operation(ValidModifiers.Contains(modifier),
+            Guard.Operation(ValidModifiers.Contains(modifier),
                 $"'{modifier}' is not a valid modifier. Supported modifiers: {String.Join(", ", ValidModifiers)}");
         }
     }

--- a/src/Valleysoft.DockerfileModel/Tokens/WhitespaceToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/WhitespaceToken.cs
@@ -8,8 +8,8 @@ public class WhitespaceToken : PrimitiveToken
 
     internal static string ValidateValue(string value)
     {
-        Requires.NotNullOrEmpty(value, nameof(value));
-        Verify.Operation(value.Trim().Length == 0, $"'{value}' contains non-whitespace characters.");
+        Guard.NotNullOrEmpty(value, nameof(value));
+        Guard.Operation(value.Trim().Length == 0, $"'{value}' contains non-whitespace characters.");
         return value;
     }
 }

--- a/src/Valleysoft.DockerfileModel/UserInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/UserInstruction.cs
@@ -19,7 +19,7 @@ public class UserInstruction : Instruction
         get => UserToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             UserToken.Value = value;
         }
     }
@@ -29,7 +29,7 @@ public class UserInstruction : Instruction
         get => Tokens.OfType<LiteralToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(UserToken, value);
         }
     }
@@ -43,7 +43,7 @@ public class UserInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(string user, char escapeChar)
     {
-        Requires.NotNullOrEmpty(user, nameof(user));
+        Guard.NotNullOrEmpty(user, nameof(user));
         return GetTokens($"USER {user}", GetInnerParser(escapeChar));
     }
 

--- a/src/Valleysoft.DockerfileModel/Valleysoft.DockerfileModel.csproj
+++ b/src/Valleysoft.DockerfileModel/Valleysoft.DockerfileModel.csproj
@@ -17,7 +17,6 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
     <PackageReference Include="Sprache" Version="2.3.1" />
-    <PackageReference Include="Validation" Version="2.6.68" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Valleysoft.DockerfileModel/VolumeInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/VolumeInstruction.cs
@@ -40,7 +40,7 @@ public class VolumeInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> paths, char escapeChar)
     {
-        Requires.NotNullEmptyOrNullElements(paths, nameof(paths));
+        Guard.NotNullEmptyOrNullElements(paths, nameof(paths));
         string[] pathArray = paths.ToArray();
         bool useShellForm = pathArray.Length == 1 && pathArray[0].Length > 0 && !pathArray[0].Any(char.IsWhiteSpace);
         string args = useShellForm

--- a/src/Valleysoft.DockerfileModel/WorkdirInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/WorkdirInstruction.cs
@@ -19,7 +19,7 @@ public class WorkdirInstruction : Instruction
         get => PathToken.Value;
         set
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Guard.NotNullOrEmpty(value, nameof(value));
             PathToken.Value = value;
         }
     }
@@ -29,7 +29,7 @@ public class WorkdirInstruction : Instruction
         get => Tokens.OfType<LiteralToken>().First();
         set
         {
-            Requires.NotNull(value, nameof(value));
+            Guard.NotNull(value, nameof(value));
             SetToken(PathToken, value);
         }
     }
@@ -46,7 +46,7 @@ public class WorkdirInstruction : Instruction
 
     private static IEnumerable<Token> GetTokens(string path, char escapeChar)
     {
-        Requires.NotNullOrEmpty(path, nameof(path));
+        Guard.NotNullOrEmpty(path, nameof(path));
         return GetTokens($"WORKDIR {path}", GetInnerParser(escapeChar));
     }
 


### PR DESCRIPTION
## Summary

Remove the production Validation dependency rather than introducing another package for a small set of runtime checks. Internal guards now handle the existing argument and invalid-operation checks on both `netstandard2.0` and `net10.0`, without changing public signatures.

- Preserve validation outcomes, exception types, parameter names, and check ordering across all migrated call sites.
- Retain non-obvious behavior, including rejection of strings beginning with NUL and rejection of empty or null-containing collections. Exception message wording is not a compatibility requirement.
- Add characterization and guard tests covering constructors, setters, projected collections, failed-mutation isolation, and iterator disposal/error propagation. Include a minimal internal nullable attribute shim for `netstandard2.0`.

## Validation

- Release solution build completed with zero warnings and errors.
- All 1,437 unit and property tests passed.
- Compared replacement guards against Validation before removing the package.
- Inspected both packaged framework dependency groups and assembly metadata: Validation is absent, no replacement guard package was added, and the new implementation types are internal.

Fixes: #360