### PR TITLE
Add persistent batching and minimization to differential tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
 
       - name: Run differential tests
         working-directory: src
-        run: dotnet run --project Valleysoft.DockerfileModel.DiffTest -c Release -- --compare --lean-cli ../lean/.lake/build/bin/DockerfileModelDiffTest --count 10000
+        run: dotnet run --project Valleysoft.DockerfileModel.DiffTest -c Release -- --compare --lean-cli ../lean/.lake/build/bin/DockerfileModelDiffTest --count 10000 --seed 42 --workers 4

--- a/.github/workflows/diff-test-scheduled.yml
+++ b/.github/workflows/diff-test-scheduled.yml
@@ -1,0 +1,46 @@
+name: Scheduled differential testing
+
+on:
+  schedule:
+    - cron: '23 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diff-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          global-json-file: global.json
+
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Build Lean CLI
+        working-directory: lean
+        run: lake build DockerfileModelDiffTest
+
+      - name: Build .NET DiffTest
+        working-directory: src
+        run: dotnet build Valleysoft.DockerfileModel.DiffTest -c Release
+
+      - name: Derive deterministic daily seed
+        id: seed
+        shell: bash
+        run: |
+          seed=$((10#$(date -u +%Y) * 1000 + 10#$(date -u +%j)))
+          echo "seed=$seed" >> "$GITHUB_OUTPUT"
+          echo "Differential test seed: $seed"
+
+      - name: Run differential tests
+        working-directory: src
+        run: dotnet run --project Valleysoft.DockerfileModel.DiffTest -c Release -- --compare --lean-cli ../lean/.lake/build/bin/DockerfileModelDiffTest --count 10000 --seed ${{ steps.seed.outputs.seed }} --workers 4

--- a/lean/DockerfileModel/Main.lean
+++ b/lean/DockerfileModel/Main.lean
@@ -1,8 +1,8 @@
 /-
   Main.lean — CLI entry point for differential testing.
 
-  Reads all of stdin, detects instruction type from first keyword (case-insensitive),
-  calls the appropriate parser, and outputs canonical JSON to stdout.
+  In one-shot mode, reads stdin and outputs canonical JSON. In --batch mode,
+  reads tab-delimited request frames and writes one response frame per request.
 
   Exit code 0 on success, 1 on parse failure (with error to stderr).
 
@@ -57,15 +57,39 @@ def readAllStdin : IO String := do
       result := result ++ line
   return result
 
-/-- Helper: dispatch a parse function and output JSON or error. -/
-def dispatchParse (name : String) (result : Option Instruction) : IO UInt32 :=
+/-- Convert a parser result to canonical JSON or a stable error. -/
+def dispatchResult (name : String) (result : Option Instruction) : Except String String :=
   match result with
-  | some inst => do
-    IO.println (Json.Token.toJson inst.token)
-    return 0
-  | none => do
-    IO.eprintln s!"Parse error: failed to parse {name} instruction"
-    return 1
+  | some inst => .ok (Json.Token.toJson inst.token)
+  | none => .error s!"Parse error: failed to parse {name} instruction"
+
+/-- Parse an instruction and return canonical JSON. -/
+def parseInput (input : String) (escapeChar : Char) : Except String String :=
+  let keyword := (firstWord input).toUpper
+  match keyword with
+  | "FROM"       => dispatchResult "FROM" (parseFrom input escapeChar)
+  | "ARG"        => dispatchResult "ARG" (parseArg input escapeChar)
+  | "MAINTAINER" => dispatchResult "MAINTAINER" (parseMaintainer input escapeChar)
+  | "WORKDIR"    => dispatchResult "WORKDIR" (parseWorkdir input escapeChar)
+  | "STOPSIGNAL" => dispatchResult "STOPSIGNAL" (parseStopsignal input escapeChar)
+  | "CMD"        => dispatchResult "CMD" (parseCmd input escapeChar)
+  | "ENTRYPOINT" => dispatchResult "ENTRYPOINT" (parseEntrypoint input escapeChar)
+  | "SHELL"      => dispatchResult "SHELL" (parseShell input escapeChar)
+  | "USER"       => dispatchResult "USER" (parseUser input escapeChar)
+  | "EXPOSE"     => dispatchResult "EXPOSE" (parseExpose input escapeChar)
+  | "VOLUME"     => dispatchResult "VOLUME" (parseVolume input escapeChar)
+  | "ENV"        => dispatchResult "ENV" (parseEnv input escapeChar)
+  | "LABEL"      => dispatchResult "LABEL" (parseLabel input escapeChar)
+  | "RUN"        => dispatchResult "RUN" (parseRun input escapeChar)
+  | "COPY"       => dispatchResult "COPY" (parseCopy input escapeChar)
+  | "ADD"        => dispatchResult "ADD" (parseAdd input escapeChar)
+  | "HEALTHCHECK" => dispatchResult "HEALTHCHECK" (parseHealthcheck input escapeChar)
+  | "ONBUILD"    => dispatchResult "ONBUILD" (parseOnbuild input escapeChar)
+  | _ =>
+    if keyword.isEmpty then
+      .error "Parse error: failed to detect instruction type"
+    else
+      .error s!"Unknown instruction type: {keyword}"
 
 /-- Parse --escape flag from command-line arguments. Returns the escape char (default: backslash). -/
 def parseEscapeArg (args : List String) : Char :=
@@ -77,29 +101,140 @@ def parseEscapeArg (args : List String) : Char :=
   | _ :: rest => parseEscapeArg rest
   | [] => '\\'
 
-def main (args : List String) : IO UInt32 := do
+def base64Char (value : Nat) : Char :=
+  if value < 26 then
+    Char.ofNat ('A'.toNat + value)
+  else if value < 52 then
+    Char.ofNat ('a'.toNat + value - 26)
+  else if value < 62 then
+    Char.ofNat ('0'.toNat + value - 52)
+  else if value == 62 then '+'
+  else '/'
+
+def base64Value (char : Char) : Option Nat :=
+  let value := char.toNat
+  if 'A'.toNat ≤ value && value ≤ 'Z'.toNat then
+    some (value - 'A'.toNat)
+  else if 'a'.toNat ≤ value && value ≤ 'z'.toNat then
+    some (value - 'a'.toNat + 26)
+  else if '0'.toNat ≤ value && value ≤ '9'.toNat then
+    some (value - '0'.toNat + 52)
+  else if char == '+' then some 62
+  else if char == '/' then some 63
+  else none
+
+def encodeBase64Bytes : List UInt8 → List Char
+  | first :: second :: third :: rest =>
+    let a := first.toNat
+    let b := second.toNat
+    let c := third.toNat
+    base64Char (a / 4) ::
+      base64Char ((a % 4) * 16 + b / 16) ::
+      base64Char ((b % 16) * 4 + c / 64) ::
+      base64Char (c % 64) ::
+      encodeBase64Bytes rest
+  | first :: second :: [] =>
+    let a := first.toNat
+    let b := second.toNat
+    [base64Char (a / 4),
+      base64Char ((a % 4) * 16 + b / 16),
+      base64Char ((b % 16) * 4),
+      '=']
+  | first :: [] =>
+    let a := first.toNat
+    [base64Char (a / 4), base64Char ((a % 4) * 16), '=', '=']
+  | [] => []
+
+def encodeBase64 (value : String) : String :=
+  String.ofList (encodeBase64Bytes value.toUTF8.toList)
+
+def decodeQuartet (a b c d : Char) : Option (List UInt8) := do
+  let first ← base64Value a
+  let second ← base64Value b
+  if c == '=' then
+    if d == '=' then
+      return [UInt8.ofNat (first * 4 + second / 16)]
+    else
+      none
+  else
+    let third ← base64Value c
+    let firstByte := UInt8.ofNat (first * 4 + second / 16)
+    let secondByte := UInt8.ofNat ((second % 16) * 16 + third / 4)
+    if d == '=' then
+      return [firstByte, secondByte]
+    else
+      let fourth ← base64Value d
+      return [
+        firstByte,
+        secondByte,
+        UInt8.ofNat ((third % 4) * 64 + fourth)]
+
+def decodeBase64Chars : List Char → Option (List UInt8)
+  | [] => some []
+  | a :: b :: c :: d :: rest => do
+    let bytes ← decodeQuartet a b c d
+    if (c == '=' || d == '=') && !rest.isEmpty then
+      none
+    else
+      let remaining ← decodeBase64Chars rest
+      return bytes ++ remaining
+  | _ => none
+
+def decodeBase64 (value : String) : Option String := do
+  let bytes ← decodeBase64Chars value.toList
+  String.fromUTF8? ⟨bytes.toArray⟩
+
+def writeFrame (requestId status body : String) : IO Unit := do
+  let stdout ← IO.getStdout
+  stdout.putStrLn s!"{requestId}\t{status}\t{encodeBase64 body}"
+  stdout.flush
+
+def stripFrameLineEnding (line : String) : String :=
+  let chars := line.toList
+  if line.endsWith "\r\n" then
+    String.ofList chars.dropLast.dropLast
+  else if line.endsWith "\n" || line.endsWith "\r" then
+    String.ofList chars.dropLast
+  else
+    line
+
+example : stripFrameLineEnding "5\t92\t\n" = "5\t92\t" := by native_decide
+
+def processBatchLine (line : String) : IO Unit := do
+  match (stripFrameLineEnding line).splitOn "\t" with
+  | [requestId, escapeCode, payload] =>
+    match escapeCode.toNat?, decodeBase64 payload with
+    | some code, some input =>
+      match parseInput input (Char.ofNat code) with
+      | .ok json => writeFrame requestId "ok" json
+      | .error message =>
+        let status := if message.startsWith "Parse error:" then "parse-error" else "error"
+        writeFrame requestId status message
+    | _, _ => writeFrame requestId "error" "Invalid request encoding"
+  | requestId :: _ => writeFrame requestId "error" "Malformed request frame"
+  | [] => writeFrame "?" "error" "Malformed request frame"
+
+def runBatch : IO UInt32 := do
+  let stdin ← IO.getStdin
+  let mut done := false
+  while !done do
+    let line ← stdin.getLine
+    if line.isEmpty then
+      done := true
+    else
+      processBatchLine line
+  return 0
+
+def runOneShot (args : List String) : IO UInt32 := do
   let escapeChar := parseEscapeArg args
   let input ← readAllStdin
-  let keyword := (firstWord input).toUpper
-  match keyword with
-  | "FROM"       => dispatchParse "FROM" (parseFrom input escapeChar)
-  | "ARG"        => dispatchParse "ARG" (parseArg input escapeChar)
-  | "MAINTAINER" => dispatchParse "MAINTAINER" (parseMaintainer input escapeChar)
-  | "WORKDIR"    => dispatchParse "WORKDIR" (parseWorkdir input escapeChar)
-  | "STOPSIGNAL" => dispatchParse "STOPSIGNAL" (parseStopsignal input escapeChar)
-  | "CMD"        => dispatchParse "CMD" (parseCmd input escapeChar)
-  | "ENTRYPOINT" => dispatchParse "ENTRYPOINT" (parseEntrypoint input escapeChar)
-  | "SHELL"      => dispatchParse "SHELL" (parseShell input escapeChar)
-  | "USER"       => dispatchParse "USER" (parseUser input escapeChar)
-  | "EXPOSE"     => dispatchParse "EXPOSE" (parseExpose input escapeChar)
-  | "VOLUME"     => dispatchParse "VOLUME" (parseVolume input escapeChar)
-  | "ENV"        => dispatchParse "ENV" (parseEnv input escapeChar)
-  | "LABEL"      => dispatchParse "LABEL" (parseLabel input escapeChar)
-  | "RUN"        => dispatchParse "RUN" (parseRun input escapeChar)
-  | "COPY"       => dispatchParse "COPY" (parseCopy input escapeChar)
-  | "ADD"        => dispatchParse "ADD" (parseAdd input escapeChar)
-  | "HEALTHCHECK" => dispatchParse "HEALTHCHECK" (parseHealthcheck input escapeChar)
-  | "ONBUILD"    => dispatchParse "ONBUILD" (parseOnbuild input escapeChar)
-  | _ =>
-    IO.eprintln s!"Unknown instruction type: {keyword}"
+  match parseInput input escapeChar with
+  | .ok json =>
+    IO.println json
+    return 0
+  | .error message =>
+    IO.eprintln message
     return 1
+
+def main (args : List String) : IO UInt32 :=
+  if args.contains "--batch" then runBatch else runOneShot args

--- a/lean/README.md
+++ b/lean/README.md
@@ -41,6 +41,68 @@ dotnet run --project src/Valleysoft.DockerfileModel.DiffTest/ -- \
 
 The Lean CLI (`DockerfileModelDiffTest`) reads a Dockerfile instruction from stdin and outputs the canonical JSON token tree to stdout.
 
+### Persistent workers
+
+Comparison mode starts a bounded pool of long-lived Lean processes instead of
+launching a process for every input. The default worker count is the smaller of
+the machine's processor count and 4; override it with `--workers`:
+
+```bash
+dotnet run --project src/Valleysoft.DockerfileModel.DiffTest/ -- \
+  --compare --lean-cli lean/.lake/build/bin/DockerfileModelDiffTest \
+  --count 10000 --seed 42 --workers 4
+```
+
+Each worker runs the Lean CLI with `--batch`. Requests and responses are
+tab-delimited, one per line. Request frames contain a request ID, the decimal
+escape-character code point, and base64-encoded UTF-8 input. Response frames
+contain the same request ID, `ok`, `parse-error`, or `error`, and a
+base64-encoded UTF-8 body. The `error` status is reserved for malformed
+requests and unknown instructions. This framing keeps newlines, tabs, JSON,
+and parser errors out of the protocol structure.
+
+### Replaying and minimizing failures
+
+Generated cases retain their seed, stable generator name, generator-relative
+case index, and escape character. Every failure prints those values and an
+exact replay command using the minimized input:
+
+```bash
+dotnet run --project src/Valleysoft.DockerfileModel.DiffTest -- \
+  --replay --lean-cli lean/.lake/build/bin/DockerfileModelDiffTest \
+  --instruction FROM --escape-code 92 --input-base64 RlJPTSBhbHBpbmU=
+```
+
+The minimizer tries deterministic, instruction-shaped simplifications. A
+candidate is accepted only when it preserves the original outcome category:
+JSON mismatch, one-sided parse error, or C# parser crash. Inputs both parsers
+reject are treated as agreement. Infrastructure failures such as process
+exits, malformed frames, unknown instructions, and timeouts are reported
+without being minimized.
+
+### Local regression corpus
+
+Locally authored regressions are normalized JSON fixtures in
+`src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus`. They are loaded in
+filename order and always run before generated cases. This corpus is separate
+from the pinned upstream BuildKit corpus tracked by issue #358, but both use
+the same differential execution path.
+
+Ordinary comparison and CI runs never modify the corpus. To persist minimized
+failures as idempotent, content-addressed fixtures, explicitly pass:
+
+```bash
+dotnet run --project src/Valleysoft.DockerfileModel.DiffTest/ -- \
+  --compare --lean-cli lean/.lake/build/bin/DockerfileModelDiffTest \
+  --count 10000 --seed 42 --promote-failures
+```
+
+Review and commit the resulting fixture changes together with the parser fix.
+
+Pull-request CI uses seed `42`. The scheduled workflow derives a rotating but
+reproducible daily seed as `UTC year * 1000 + UTC day-of-year` and prints it
+before running the same corpus-first comparison.
+
 ## Design Principles
 
 ### BuildKit is the Source of Truth

--- a/src/Valleysoft.DockerfileModel.DiffTest/AssemblyInfo.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Valleysoft.DockerfileModel.Tests")]

--- a/src/Valleysoft.DockerfileModel.DiffTest/DiffModels.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/DiffModels.cs
@@ -1,0 +1,131 @@
+using System.Text;
+
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+internal static class InstructionTypes
+{
+    private static readonly HashSet<string> Supported = new(
+        new[]
+        {
+            "ADD", "ARG", "CMD", "COPY", "ENTRYPOINT", "ENV", "EXPOSE",
+            "FROM", "HEALTHCHECK", "LABEL", "MAINTAINER", "ONBUILD", "RUN",
+            "SHELL", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"
+        },
+        StringComparer.OrdinalIgnoreCase);
+
+    public static bool IsSupported(string instructionType) =>
+        Supported.Contains(instructionType);
+}
+
+public enum DiffCaseSource
+{
+    Regression,
+    Generated,
+    Replay
+}
+
+public enum DiffOutcomeKind
+{
+    Match,
+    JsonMismatch,
+    CSharpParseError,
+    CSharpParserCrash,
+    LeanParseError,
+    InfrastructureError
+}
+
+public sealed record DiffCase(
+    string Id,
+    DiffCaseSource Source,
+    string InstructionType,
+    string Input,
+    char EscapeChar,
+    string? Generator = null,
+    int? Seed = null,
+    int? CaseIndex = null)
+{
+    public string InputBase64 => Convert.ToBase64String(Encoding.UTF8.GetBytes(Input));
+}
+
+public sealed record DiffResult(
+    DiffCase Case,
+    string CSharpJson,
+    string LeanJson,
+    DiffOutcomeKind Outcome,
+    string? Error = null)
+{
+    public bool Match => Outcome == DiffOutcomeKind.Match;
+}
+
+public sealed record RegressionFixture(
+    string Id,
+    string InstructionType,
+    string InputBase64,
+    string EscapeCharacter,
+    string? Generator = null,
+    int? Seed = null,
+    int? CaseIndex = null)
+{
+    public DiffCase ToCase()
+    {
+        if (string.IsNullOrWhiteSpace(Id))
+        {
+            throw new InvalidDataException("Regression fixture must have a non-empty id.");
+        }
+
+        if (string.IsNullOrWhiteSpace(InstructionType))
+        {
+            throw new InvalidDataException(
+                $"Regression fixture '{Id}' must have a non-empty instructionType.");
+        }
+
+        if (!InstructionTypes.IsSupported(InstructionType))
+        {
+            throw new InvalidDataException(
+                $"Regression fixture '{Id}' has unsupported instructionType '{InstructionType}'.");
+        }
+
+        if (InputBase64 is null)
+        {
+            throw new InvalidDataException(
+                $"Regression fixture '{Id}' must have an inputBase64 value.");
+        }
+
+        if (EscapeCharacter is null || EscapeCharacter.Length != 1)
+        {
+            throw new InvalidDataException(
+                $"Regression fixture '{Id}' must have a one-character escapeCharacter.");
+        }
+
+        string input;
+        try
+        {
+            input = Encoding.UTF8.GetString(Convert.FromBase64String(InputBase64));
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidDataException(
+                $"Regression fixture '{Id}' has invalid base64 input.", ex);
+        }
+
+        return new DiffCase(
+            Id,
+            DiffCaseSource.Regression,
+            InstructionType,
+            input,
+            EscapeCharacter[0],
+            Generator,
+            Seed,
+            CaseIndex);
+    }
+
+    public static RegressionFixture FromCase(DiffCase testCase) =>
+        new(
+            testCase.Id,
+            testCase.InstructionType,
+            testCase.InputBase64,
+            testCase.EscapeChar.ToString(),
+            testCase.Generator,
+            testCase.Seed,
+            testCase.CaseIndex);
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/DiffModels.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/DiffModels.cs
@@ -66,6 +66,9 @@ public sealed record RegressionFixture(
     int? Seed = null,
     int? CaseIndex = null)
 {
+    private static readonly Encoding StrictUtf8 =
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
     public DiffCase ToCase()
     {
         if (string.IsNullOrWhiteSpace(Id))
@@ -100,12 +103,12 @@ public sealed record RegressionFixture(
         string input;
         try
         {
-            input = Encoding.UTF8.GetString(Convert.FromBase64String(InputBase64));
+            input = StrictUtf8.GetString(Convert.FromBase64String(InputBase64));
         }
-        catch (FormatException ex)
+        catch (Exception ex) when (ex is FormatException or DecoderFallbackException)
         {
             throw new InvalidDataException(
-                $"Regression fixture '{Id}' has invalid base64 input.", ex);
+                $"Regression fixture '{Id}' has invalid base64 or UTF-8 input.", ex);
         }
 
         return new DiffCase(

--- a/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
@@ -95,7 +95,28 @@ public sealed class DiffTestRunner
 
             if (IsKnownCrash(testCase.InstructionType, testCase.Input))
             {
-                return new DiffResult(testCase, "", "", DiffOutcomeKind.Match);
+                try
+                {
+                    await parser.ParseAsync(
+                        testCase.Input,
+                        testCase.EscapeChar,
+                        cancellationToken);
+                    return new DiffResult(testCase, "", "", DiffOutcomeKind.Match);
+                }
+                catch (LeanParseException)
+                {
+                    return new DiffResult(testCase, "", "", DiffOutcomeKind.Match);
+                }
+                catch (Exception leanException)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return new DiffResult(
+                        testCase,
+                        "",
+                        "",
+                        DiffOutcomeKind.InfrastructureError,
+                        leanException.Message);
+                }
             }
 
             if (ex is not ParseException)

--- a/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/DiffTestRunner.cs
@@ -1,237 +1,196 @@
-using System.Diagnostics;
-using System.Text;
 using Valleysoft.DockerfileModel.TestSupport;
+using Sprache;
 
 namespace Valleysoft.DockerfileModel.DiffTest;
 
-/// <summary>
-/// Result of comparing C# and Lean parser outputs for a single input.
-/// </summary>
-public record DiffResult(
-    string InstructionType,
-    string Input,
-    string CSharpJson,
-    string LeanJson,
-    bool Match,
-    string? Error = null);
-
-/// <summary>
-/// Core comparison engine: parses each input with both C# and Lean parsers,
-/// serializes to canonical JSON, and compares for byte-identical output.
-/// </summary>
-public class DiffTestRunner
+public sealed class DiffTestRunner
 {
-    private readonly string _leanCliPath;
-    private readonly string? _leanLibDir;
-    private readonly TimeSpan _timeout;
+    private readonly Func<ILeanParser> _parserFactory;
 
     public DiffTestRunner(string leanCliPath, TimeSpan? timeout = null)
+        : this(() => new LeanProcessWorker(leanCliPath, timeout))
     {
-        _leanCliPath = Path.GetFullPath(leanCliPath);
-        _timeout = timeout ?? TimeSpan.FromSeconds(30);
-
-        // Determine the Lean shared library directory.
-        // The binary is at <lake-build>/bin/DockerfileModelDiffTest(.exe).
-        // Lean shared libraries (libInit_shared.so/.dll) are in the elan toolchain bin dir.
-        // We find the toolchain by looking for elan-managed lean in PATH or common locations.
-        _leanLibDir = FindLeanLibDir();
     }
 
-    /// <summary>
-    /// Parse an instruction with the C# parser and serialize to canonical JSON.
-    /// </summary>
-    public static string ParseCSharp(string instructionType, string input, char escapeChar = '\\')
-        => InstructionSerializer.ParseCSharp(instructionType, input, escapeChar);
-
-    /// <summary>
-    /// Parse an instruction with the Lean CLI and capture JSON from stdout.
-    /// </summary>
-    public async Task<string> ParseLeanAsync(string input, char escapeChar = '\\')
+    public DiffTestRunner(Func<ILeanParser> parserFactory)
     {
-        using Process process = new();
-        process.StartInfo = new ProcessStartInfo
-        {
-            FileName = _leanCliPath,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
+        _parserFactory = parserFactory;
+    }
 
-        // Pass escape char to Lean CLI when non-default
-        if (escapeChar != '\\')
+    public static string ParseCSharp(
+        string instructionType,
+        string input,
+        char escapeChar = '\\') =>
+        InstructionSerializer.ParseCSharp(instructionType, input, escapeChar);
+
+    public async Task<DiffResult> RunSingleAsync(
+        DiffCase testCase,
+        CancellationToken cancellationToken = default)
+    {
+        await using ILeanParser parser = _parserFactory();
+        return await RunSingleAsync(parser, testCase, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<DiffResult>> RunBatchAsync(
+        IReadOnlyList<DiffCase> inputs,
+        int workerCount,
+        CancellationToken cancellationToken = default)
+    {
+        if (workerCount <= 0)
         {
-            process.StartInfo.ArgumentList.Add("--escape");
-            process.StartInfo.ArgumentList.Add(escapeChar.ToString());
+            throw new ArgumentOutOfRangeException(nameof(workerCount));
         }
 
-        // Ensure Lean shared libraries are findable
-        if (_leanLibDir != null)
+        if (inputs.Count == 0)
         {
-            string currentPath = process.StartInfo.EnvironmentVariables["PATH"] ?? "";
-            process.StartInfo.EnvironmentVariables["PATH"] = _leanLibDir + Path.PathSeparator + currentPath;
+            return Array.Empty<DiffResult>();
+        }
 
-            // On Linux, also set LD_LIBRARY_PATH
-            if (!OperatingSystem.IsWindows())
+        int actualWorkerCount = Math.Min(workerCount, inputs.Count);
+        DiffResult?[] results = new DiffResult[inputs.Count];
+        int nextIndex = -1;
+
+        Task[] workers = Enumerable.Range(0, actualWorkerCount)
+            .Select(_ => RunWorkerAsync())
+            .ToArray();
+        await Task.WhenAll(workers);
+
+        return results.Select(result => result!).ToArray();
+
+        async Task RunWorkerAsync()
+        {
+            await using ILeanParser parser = _parserFactory();
+            while (true)
             {
-                string currentLdPath = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH") ?? "";
-                process.StartInfo.EnvironmentVariables["LD_LIBRARY_PATH"] =
-                    _leanLibDir + Path.PathSeparator + currentLdPath;
+                int index = Interlocked.Increment(ref nextIndex);
+                if (index >= inputs.Count)
+                {
+                    return;
+                }
+
+                results[index] = await RunSingleAsync(
+                    parser,
+                    inputs[index],
+                    cancellationToken);
             }
         }
-
-        process.Start();
-
-        // Write input to stdin and close
-        await process.StandardInput.WriteAsync(input);
-        process.StandardInput.Close();
-
-        // Read stdout and stderr
-        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
-        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-
-        bool exited = process.WaitForExit((int)_timeout.TotalMilliseconds);
-        if (!exited)
-        {
-            process.Kill();
-            throw new TimeoutException($"Lean CLI timed out after {_timeout.TotalSeconds}s");
-        }
-
-        string stdout = await stdoutTask;
-        string stderr = await stderrTask;
-
-        if (process.ExitCode != 0)
-        {
-            throw new InvalidOperationException(
-                $"Lean CLI exited with code {process.ExitCode}: {stderr.Trim()}");
-        }
-
-        return stdout.TrimEnd('\n', '\r');
     }
 
-    /// <summary>
-    /// Run both parsers on a single input and compare JSON output.
-    /// </summary>
-    public async Task<DiffResult> RunSingleAsync(string instructionType, string input, char escapeChar = '\\')
+    internal static async Task<DiffResult> RunSingleAsync(
+        ILeanParser parser,
+        DiffCase testCase,
+        CancellationToken cancellationToken)
     {
         string csharpJson;
         try
         {
-            csharpJson = ParseCSharp(instructionType, input, escapeChar);
+            csharpJson = ParseCSharp(
+                testCase.InstructionType,
+                testCase.Input,
+                testCase.EscapeChar);
         }
         catch (Exception ex)
         {
-            // Workaround for #259: VOLUME [] crashes C# parser (empty exec-form array)
-            if (IsKnownCrash(instructionType, input))
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (IsKnownCrash(testCase.InstructionType, testCase.Input))
             {
-                return new DiffResult(instructionType, input, "", "", true);
+                return new DiffResult(testCase, "", "", DiffOutcomeKind.Match);
             }
 
-            return new DiffResult(instructionType, input, "", "", false,
-                $"C# parse error: {ex.Message}");
+            if (ex is not ParseException)
+            {
+                return new DiffResult(
+                    testCase,
+                    "",
+                    "",
+                    DiffOutcomeKind.CSharpParserCrash,
+                    $"{ex.GetType().Name}: {ex.Message}");
+            }
+
+            string leanResultJson;
+            try
+            {
+                leanResultJson = await parser.ParseAsync(
+                    testCase.Input,
+                    testCase.EscapeChar,
+                    cancellationToken);
+            }
+            catch (LeanParseException)
+            {
+                return new DiffResult(testCase, "", "", DiffOutcomeKind.Match);
+            }
+            catch (Exception leanException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                return new DiffResult(
+                    testCase,
+                    "",
+                    "",
+                    DiffOutcomeKind.InfrastructureError,
+                    leanException.Message);
+            }
+
+            return new DiffResult(
+                testCase,
+                "",
+                leanResultJson,
+                DiffOutcomeKind.CSharpParseError,
+                ex.Message);
         }
 
         string leanJson;
         try
         {
-            leanJson = await ParseLeanAsync(input, escapeChar);
+            leanJson = await parser.ParseAsync(
+                testCase.Input,
+                testCase.EscapeChar,
+                cancellationToken);
+        }
+        catch (LeanParseException ex)
+        {
+            return new DiffResult(
+                testCase,
+                csharpJson,
+                "",
+                DiffOutcomeKind.LeanParseError,
+                ex.Message);
         }
         catch (Exception ex)
         {
-            return new DiffResult(instructionType, input, csharpJson, "", false,
-                $"Lean parse error: {ex.Message}");
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return new DiffResult(
+                testCase,
+                csharpJson,
+                "",
+                DiffOutcomeKind.InfrastructureError,
+                ex.Message);
         }
 
-        bool match = string.Equals(csharpJson, leanJson, StringComparison.Ordinal);
-        return new DiffResult(instructionType, input, csharpJson, leanJson, match);
+        DiffOutcomeKind outcome = string.Equals(
+            csharpJson,
+            leanJson,
+            StringComparison.Ordinal)
+            ? DiffOutcomeKind.Match
+            : DiffOutcomeKind.JsonMismatch;
+
+        return new DiffResult(testCase, csharpJson, leanJson, outcome);
     }
 
-    /// <summary>
-    /// Returns true for inputs known to crash the C# parser due to unimplemented features.
-    /// These are tracked bugs where the correct fix is in the C# parser itself, not the serializer.
-    ///
-    /// Covered cases:
-    ///   #259: VOLUME [] — C# throws on empty JSON array input.
-    /// </summary>
     private static bool IsKnownCrash(string instructionType, string input)
     {
-        string upper = instructionType.ToUpperInvariant();
-
-        // Workaround for #259: VOLUME with [] (empty exec-form array) crashes C#
-        if (upper == "VOLUME")
+        if (!string.Equals(instructionType, "VOLUME", StringComparison.OrdinalIgnoreCase))
         {
-            string trimmedArgs = input.TrimStart();
-            // Strip the keyword from the front
-            int spaceIdx = trimmedArgs.IndexOfAny(new[] { ' ', '\t' });
-            string argsOnly = spaceIdx >= 0 ? trimmedArgs.Substring(spaceIdx).TrimStart() : "";
-            if (argsOnly.TrimStart('[', ' ', '\t', ']').Length == 0 && argsOnly.Contains('['))
-            {
-                return true;
-            }
+            return false;
         }
 
-        return false;
-    }
-
-    /// <summary>
-    /// Run both parsers on a batch of inputs, reporting progress.
-    /// </summary>
-    public async Task<List<DiffResult>> RunBatchAsync(
-        List<(string InstructionType, string Text, char EscapeChar)> inputs,
-        Action<int, int, DiffResult>? onProgress = null)
-    {
-        List<DiffResult> results = new();
-        int total = inputs.Count;
-
-        for (int i = 0; i < total; i++)
-        {
-            (string type, string text, char escapeChar) = inputs[i];
-            DiffResult result = await RunSingleAsync(type, text, escapeChar);
-            results.Add(result);
-            onProgress?.Invoke(i + 1, total, result);
-        }
-
-        return results;
-    }
-
-    /// <summary>
-    /// Find the directory containing Lean shared libraries (libInit_shared.so/.dll).
-    /// Searches common elan toolchain locations and the lean CLI's own directory tree.
-    /// </summary>
-    private static string? FindLeanLibDir()
-    {
-        // Check elan's default location
-        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        string elandir = Path.Combine(home, ".elan", "toolchains");
-
-        if (Directory.Exists(elandir))
-        {
-            // Find the active toolchain's bin directory
-            foreach (string toolchain in Directory.GetDirectories(elandir))
-            {
-                string binDir = Path.Combine(toolchain, "bin");
-                if (Directory.Exists(binDir))
-                {
-                    string libSharedPattern = OperatingSystem.IsWindows()
-                        ? "libInit_shared.dll"
-                        : "libInit_shared.so";
-
-                    if (File.Exists(Path.Combine(binDir, libSharedPattern)))
-                    {
-                        return binDir;
-                    }
-
-                    // On some Linux setups, shared libs are in lib/lean/
-                    string libDir = Path.Combine(toolchain, "lib", "lean");
-                    if (File.Exists(Path.Combine(libDir, libSharedPattern)))
-                    {
-                        return libDir;
-                    }
-                }
-            }
-        }
-
-        return null;
+        string trimmed = input.TrimStart();
+        int spaceIndex = trimmed.IndexOfAny(new[] { ' ', '\t' });
+        string arguments = spaceIndex >= 0 ? trimmed[spaceIndex..].TrimStart() : "";
+        string withoutWhitespace = string.Concat(
+            arguments.Where(character => !char.IsWhiteSpace(character)));
+        return string.Equals(withoutWhitespace, "[]", StringComparison.Ordinal);
     }
 }

--- a/src/Valleysoft.DockerfileModel.DiffTest/FailureMinimizer.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/FailureMinimizer.cs
@@ -1,0 +1,320 @@
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+public sealed class FailureMinimizer
+{
+    private readonly Func<ILeanParser> _parserFactory;
+    private readonly int _maximumEvaluations;
+
+    public FailureMinimizer(
+        Func<ILeanParser> parserFactory,
+        int maximumEvaluations = 250)
+    {
+        _parserFactory = parserFactory;
+        _maximumEvaluations = maximumEvaluations;
+    }
+
+    public async Task<DiffResult> MinimizeAsync(
+        DiffResult original,
+        CancellationToken cancellationToken = default)
+    {
+        if (original.Match || original.Outcome == DiffOutcomeKind.InfrastructureError)
+        {
+            return original;
+        }
+
+        await using ILeanParser parser = _parserFactory();
+        DiffResult best = original;
+        HashSet<string> evaluated = new(StringComparer.Ordinal)
+        {
+            original.Case.Input
+        };
+        int evaluations = 0;
+
+        while (evaluations < _maximumEvaluations)
+        {
+            DiffResult? improvement = null;
+            int remainingEvaluations = _maximumEvaluations - evaluations;
+            foreach (string candidateInput in GetCandidates(
+                best.Case.Input,
+                remainingEvaluations))
+            {
+                if (!evaluated.Add(candidateInput))
+                {
+                    continue;
+                }
+
+                evaluations++;
+                DiffCase candidate = best.Case with { Input = candidateInput };
+                DiffResult result = await DiffTestRunner.RunSingleAsync(
+                    parser,
+                    candidate,
+                    cancellationToken);
+
+                if (result.Outcome == original.Outcome)
+                {
+                    improvement = result;
+                    break;
+                }
+
+                if (evaluations >= _maximumEvaluations)
+                {
+                    break;
+                }
+            }
+
+            if (improvement is null)
+            {
+                break;
+            }
+
+            best = improvement;
+        }
+
+        return best;
+    }
+
+    internal static IEnumerable<string> GetCandidates(
+        string input,
+        int maximumCandidates = 250)
+    {
+        if (maximumCandidates <= 0)
+        {
+            yield break;
+        }
+
+        int keywordEnd = input.IndexOfAny(new[] { ' ', '\t', '\r', '\n' });
+        if (keywordEnd <= 0)
+        {
+            yield break;
+        }
+
+        string keyword = input[..keywordEnd];
+        string arguments = input[keywordEnd..];
+        HashSet<string> candidates = new(StringComparer.Ordinal);
+        (bool allowsCrLf, bool allowsLf, bool allowsCr) = GetNewlineStyles(input);
+        int yielded = 0;
+
+        foreach (string candidate in new[]
+        {
+            keyword + arguments.TrimEnd(),
+            keyword + " " + arguments.Trim(),
+            keyword + " " + CollapseWhitespace(arguments.Trim())
+        })
+        {
+            if (TryAdd(candidate))
+            {
+                yield return candidate;
+                yielded++;
+            }
+
+            if (yielded >= maximumCandidates)
+            {
+                yield break;
+            }
+        }
+
+        IReadOnlyList<string> lines = SplitLinesPreservingEndings(arguments);
+        if (lines.Count > 1)
+        {
+            int lineCandidateBudget = Math.Max(1, maximumCandidates / 2);
+            foreach (int index in GetSampledOffsets(
+                lines.Count - 1,
+                lineCandidateBudget))
+            {
+                string remaining = string.Concat(lines.Where((_, i) => i != index));
+                if (remaining.Length > 0 && !char.IsWhiteSpace(remaining[0]))
+                {
+                    remaining = " " + remaining;
+                }
+
+                string candidate = keyword + remaining;
+                if (TryAdd(candidate))
+                {
+                    yield return candidate;
+                    yielded++;
+                }
+
+                if (yielded >= maximumCandidates)
+                {
+                    yield break;
+                }
+            }
+        }
+
+        string trimmedArguments = arguments.Trim();
+        List<int> chunkSizes = new();
+        for (int chunkSize = HighestPowerOfTwo(trimmedArguments.Length);
+            chunkSize > 0;
+            chunkSize /= 2)
+        {
+            chunkSizes.Add(chunkSize);
+        }
+
+        int chunkAttemptBudget = maximumCandidates * 4;
+        int attemptsPerChunkSize = chunkSizes.Count == 0
+            ? 0
+            : Math.Max(1, chunkAttemptBudget / chunkSizes.Count);
+        foreach (int chunkSize in chunkSizes)
+        {
+            int maximumStart = trimmedArguments.Length - chunkSize;
+            foreach (int start in GetSampledOffsets(
+                maximumStart,
+                attemptsPerChunkSize))
+            {
+                string simplified =
+                    trimmedArguments.Remove(start, chunkSize).Trim();
+                string candidate = keyword + " " + simplified;
+                if (TryAdd(candidate))
+                {
+                    yield return candidate;
+                    yielded++;
+                }
+
+                if (yielded >= maximumCandidates)
+                {
+                    yield break;
+                }
+            }
+        }
+
+        bool TryAdd(string candidate)
+        {
+            return candidate.Length > keyword.Length &&
+                candidate.Length < input.Length &&
+                char.IsWhiteSpace(candidate[keyword.Length]) &&
+                UsesOnlyNewlineStyles(candidate, allowsCrLf, allowsLf, allowsCr) &&
+                candidates.Add(candidate);
+        }
+    }
+
+    private static (bool CrLf, bool Lf, bool Cr) GetNewlineStyles(string value)
+    {
+        bool crLf = false;
+        bool lf = false;
+        bool cr = false;
+        for (int index = 0; index < value.Length; index++)
+        {
+            if (value[index] == '\r')
+            {
+                if (index + 1 < value.Length && value[index + 1] == '\n')
+                {
+                    crLf = true;
+                    index++;
+                }
+                else
+                {
+                    cr = true;
+                }
+            }
+            else if (value[index] == '\n')
+            {
+                lf = true;
+            }
+        }
+
+        return (crLf, lf, cr);
+    }
+
+    private static bool UsesOnlyNewlineStyles(
+        string value,
+        bool allowsCrLf,
+        bool allowsLf,
+        bool allowsCr)
+    {
+        (bool crLf, bool lf, bool cr) = GetNewlineStyles(value);
+        return (!crLf || allowsCrLf) &&
+            (!lf || allowsLf) &&
+            (!cr || allowsCr);
+    }
+
+    private static IReadOnlyList<string> SplitLinesPreservingEndings(string value)
+    {
+        List<string> lines = new();
+        int start = 0;
+        for (int index = 0; index < value.Length; index++)
+        {
+            int terminatorLength = value[index] switch
+            {
+                '\r' when index + 1 < value.Length && value[index + 1] == '\n' => 2,
+                '\r' or '\n' => 1,
+                _ => 0
+            };
+            if (terminatorLength == 0)
+            {
+                continue;
+            }
+
+            int end = index + terminatorLength;
+            lines.Add(value[start..end]);
+            start = end;
+            index = end - 1;
+        }
+
+        if (start < value.Length)
+        {
+            lines.Add(value[start..]);
+        }
+
+        return lines;
+    }
+
+    private static string CollapseWhitespace(string value)
+    {
+        Span<char> buffer = value.Length <= 512
+            ? stackalloc char[value.Length]
+            : new char[value.Length];
+        int length = 0;
+        bool inWhitespace = false;
+        foreach (char character in value)
+        {
+            if (char.IsWhiteSpace(character))
+            {
+                if (!inWhitespace)
+                {
+                    buffer[length++] = ' ';
+                    inWhitespace = true;
+                }
+            }
+            else
+            {
+                buffer[length++] = character;
+                inWhitespace = false;
+            }
+        }
+
+        return new string(buffer[..length]);
+    }
+
+    private static int HighestPowerOfTwo(int value)
+    {
+        int result = 1;
+        while (result <= value / 2)
+        {
+            result *= 2;
+        }
+
+        return value == 0 ? 0 : result;
+    }
+
+    private static IEnumerable<int> GetSampledOffsets(
+        int maximumInclusive,
+        int maximumSamples)
+    {
+        int sampleCount = Math.Min(maximumSamples, maximumInclusive + 1);
+        if (sampleCount <= 0)
+        {
+            yield break;
+        }
+
+        if (sampleCount == 1)
+        {
+            yield return maximumInclusive;
+            yield break;
+        }
+
+        for (int sample = 0; sample < sampleCount; sample++)
+        {
+            yield return (int)((long)sample * maximumInclusive / (sampleCount - 1));
+        }
+    }
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
@@ -15,104 +15,151 @@ public static class InputGenerator
 {
     private const int SampleSize = 50;
 
-    public static List<(string InstructionType, string Text, char EscapeChar)> Generate(int count, int seed = 42)
+    private sealed record GeneratorSpec(string Name, string InstructionType, Gen<string> Generator);
+
+    public static List<DiffCase> Generate(int count, int seed = 42)
     {
-        // All instruction generators with their type labels.
-        // The first 18 are the standard instruction generators; the remaining
-        // are edge-case generators targeting specific bugs found via
-        // differential testing.
-        var generators = new (string Type, Gen<string> Gen)[]
+        if (count < 0)
         {
-            ("FROM", DockerfileArbitraries.FromInstruction()),
-            ("ARG", DockerfileArbitraries.ArgInstruction()),
-            ("RUN", DockerfileArbitraries.RunInstruction()),
-            ("CMD", DockerfileArbitraries.CmdInstruction()),
-            ("ENTRYPOINT", DockerfileArbitraries.EntrypointInstruction()),
-            ("COPY", DockerfileArbitraries.CopyInstruction()),
-            ("ADD", DockerfileArbitraries.AddInstruction()),
-            ("ENV", DockerfileArbitraries.EnvInstruction()),
-            ("EXPOSE", DockerfileArbitraries.ExposeInstruction()),
-            ("VOLUME", DockerfileArbitraries.VolumeInstruction()),
-            ("USER", DockerfileArbitraries.UserInstruction()),
-            ("WORKDIR", DockerfileArbitraries.WorkdirInstruction()),
-            ("LABEL", DockerfileArbitraries.LabelInstruction()),
-            ("STOPSIGNAL", DockerfileArbitraries.StopSignalInstruction()),
-            ("HEALTHCHECK", DockerfileArbitraries.HealthCheckInstruction()),
-            ("SHELL", DockerfileArbitraries.ShellInstruction()),
-            ("MAINTAINER", DockerfileArbitraries.MaintainerInstruction()),
-            ("ONBUILD", DockerfileArbitraries.OnBuildInstruction()),
-            // Edge-case generators targeting specific differential test bugs
-            ("RUN", DockerfileArbitraries.RunHeredocInstruction()),        // Bugs 7-11: heredoc
-            ("COPY", DockerfileArbitraries.CopyHeredocInstruction()),      // Bugs 7-11: heredoc
-            ("ADD", DockerfileArbitraries.AddHeredocInstruction()),         // Bugs 7-11: heredoc
-            ("COPY", DockerfileArbitraries.CopyEmptyFlagInstruction()),    // Bug 12: empty flags
-            ("ADD", DockerfileArbitraries.AddEmptyFlagInstruction()),      // Bug 12: empty flags
-            // FromEmptyPlatformInstruction excluded: C# throws a parse error
-            // on FROM --platform= (empty value), which is a known C# limitation,
-            // not a Lean issue.
-            ("RUN", DockerfileArbitraries.RunEmptyFlagInstruction()),      // Bug 12: empty flags
-            // #259: empty exec-form arrays
-            ("VOLUME", DockerfileArbitraries.VolumeEmptyExecInstruction()),  // #259
-            ("COPY", DockerfileArbitraries.CopyEmptyExecInstruction()),     // #259
-            ("ADD", DockerfileArbitraries.AddEmptyExecInstruction()),       // #259
-            // #260: quoted file paths in COPY/ADD
-            ("COPY", DockerfileArbitraries.CopyQuotedPathInstruction()),    // #260
-            ("ADD", DockerfileArbitraries.AddQuotedPathInstruction()),      // #260
-            // #261: variable :? modifier
-            ("FROM", DockerfileArbitraries.FromErrorModifierInstruction()), // #261
-            ("ARG", DockerfileArbitraries.ArgErrorModifierInstruction()),   // #261
-            // #262: variable default value with slash
-            ("WORKDIR", DockerfileArbitraries.WorkdirSlashDefaultInstruction()), // #262
-            ("ENV", DockerfileArbitraries.EnvSlashDefaultInstruction()),    // #262
-            // #263: mount value trailing whitespace
-            ("RUN", DockerfileArbitraries.RunMinimalMountInstruction()),    // #263
-            // #264: trailing whitespace
-            ("FROM", DockerfileArbitraries.FromTrailingWhitespaceInstruction()),  // #264
-            ("ENV", DockerfileArbitraries.EnvTrailingWhitespaceInstruction()),    // #264
-            ("COPY", DockerfileArbitraries.CopyTrailingWhitespaceInstruction()), // #264
-            // #265: hash in shell-form and values
-            ("RUN", DockerfileArbitraries.RunHashInShellInstruction()),     // #265
-            ("CMD", DockerfileArbitraries.CmdHashInShellInstruction()),     // #265
-            ("LABEL", DockerfileArbitraries.LabelHashInValueInstruction()), // #265
-            // #266: line continuation in flag values
-            ("COPY", DockerfileArbitraries.CopyFlagLineContinuationInstruction()), // #266
-            ("ADD", DockerfileArbitraries.AddFlagLineContinuationInstruction()),   // #266
-        };
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
 
-        int perType = count / generators.Length;
-        int remainder = count % generators.Length;
+        IReadOnlyList<GeneratorSpec> generators = GetGenerators();
+        int perGenerator = count / generators.Count;
+        int remainder = count % generators.Count;
+        List<DiffCase> inputs = new(count);
 
-        List<(string InstructionType, string Text, char EscapeChar)> inputs = new();
-        Random escapeRng = new(seed + 1); // separate RNG for escape char selection
-
-        for (int g = 0; g < generators.Length; g++)
+        for (int generatorIndex = 0; generatorIndex < generators.Count; generatorIndex++)
         {
-            int n = perType + (g < remainder ? 1 : 0);
-            var samples = generators[g].Gen.Sample(SampleSize, n);
-            foreach (string text in samples)
+            GeneratorSpec spec = generators[generatorIndex];
+            int generatorCount = perGenerator + (generatorIndex < remainder ? 1 : 0);
+
+            for (int caseIndex = 0; caseIndex < generatorCount; caseIndex++)
             {
-                // ~10% of inputs use backtick escape char
-                if (escapeRng.NextDouble() < 0.10)
-                {
-                    // Replace backslash continuations with backtick continuations
-                    string backtickText = text.Replace("\\\n", "`\n").Replace("\\\r\n", "`\r\n");
-                    inputs.Add((generators[g].Type, backtickText, '`'));
-                }
-                else
-                {
-                    inputs.Add((generators[g].Type, text, '\\'));
-                }
+                inputs.Add(GenerateCase(spec, generatorIndex, caseIndex, seed));
             }
         }
 
-        // Shuffle with fixed seed for reproducibility
-        Random rng = new(seed);
+        Random shuffle = new(seed);
         for (int i = inputs.Count - 1; i > 0; i--)
         {
-            int j = rng.Next(i + 1);
+            int j = shuffle.Next(i + 1);
             (inputs[i], inputs[j]) = (inputs[j], inputs[i]);
         }
 
         return inputs;
     }
+
+    public static DiffCase Replay(string generatorName, int caseIndex, int seed)
+    {
+        IReadOnlyList<GeneratorSpec> generators = GetGenerators();
+        int generatorIndex = generators
+            .Select((spec, index) => (spec, index))
+            .Where(item => string.Equals(item.spec.Name, generatorName, StringComparison.Ordinal))
+            .Select(item => item.index)
+            .DefaultIfEmpty(-1)
+            .Single();
+
+        if (generatorIndex < 0)
+        {
+            throw new ArgumentException($"Unknown generator '{generatorName}'.", nameof(generatorName));
+        }
+
+        if (caseIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(caseIndex));
+        }
+
+        return GenerateCase(generators[generatorIndex], generatorIndex, caseIndex, seed)
+            with { Source = DiffCaseSource.Replay };
+    }
+
+    private static DiffCase GenerateCase(
+        GeneratorSpec spec,
+        int generatorIndex,
+        int caseIndex,
+        int seed)
+    {
+        ulong firstSeed = unchecked((ulong)(uint)seed);
+        ulong secondSeed = CreateGamma(generatorIndex, caseIndex);
+        string text = spec.Generator.Sample(
+            1,
+            new Rnd(firstSeed, secondSeed),
+            SampleSize).Single();
+
+        Random escapeRandom = new(unchecked(seed * 397 ^ generatorIndex * 31 ^ caseIndex));
+        char escapeChar = '\\';
+        if (escapeRandom.NextDouble() < 0.10)
+        {
+            text = text.Replace("\\\r\n", "`\r\n").Replace("\\\n", "`\n");
+            escapeChar = '`';
+        }
+
+        return new DiffCase(
+            $"{spec.Name}-{caseIndex}",
+            DiffCaseSource.Generated,
+            spec.InstructionType,
+            text,
+            escapeChar,
+            spec.Name,
+            seed,
+            caseIndex);
+    }
+
+    internal static ulong CreateGamma(int generatorIndex, int caseIndex) =>
+        unchecked(
+            ((ulong)(uint)(generatorIndex + 1) << 33) |
+            ((ulong)(uint)(caseIndex + 1) << 1) |
+            1UL);
+
+    private static IReadOnlyList<GeneratorSpec> GetGenerators() =>
+        new GeneratorSpec[]
+        {
+            new("from", "FROM", DockerfileArbitraries.FromInstruction()),
+            new("arg", "ARG", DockerfileArbitraries.ArgInstruction()),
+            new("run", "RUN", DockerfileArbitraries.RunInstruction()),
+            new("cmd", "CMD", DockerfileArbitraries.CmdInstruction()),
+            new("entrypoint", "ENTRYPOINT", DockerfileArbitraries.EntrypointInstruction()),
+            new("copy", "COPY", DockerfileArbitraries.CopyInstruction()),
+            new("add", "ADD", DockerfileArbitraries.AddInstruction()),
+            new("env", "ENV", DockerfileArbitraries.EnvInstruction()),
+            new("expose", "EXPOSE", DockerfileArbitraries.ExposeInstruction()),
+            new("volume", "VOLUME", DockerfileArbitraries.VolumeInstruction()),
+            new("user", "USER", DockerfileArbitraries.UserInstruction()),
+            new("workdir", "WORKDIR", DockerfileArbitraries.WorkdirInstruction()),
+            new("label", "LABEL", DockerfileArbitraries.LabelInstruction()),
+            new("stopsignal", "STOPSIGNAL", DockerfileArbitraries.StopSignalInstruction()),
+            new("healthcheck", "HEALTHCHECK", DockerfileArbitraries.HealthCheckInstruction()),
+            new("shell", "SHELL", DockerfileArbitraries.ShellInstruction()),
+            new("maintainer", "MAINTAINER", DockerfileArbitraries.MaintainerInstruction()),
+            new("onbuild", "ONBUILD", DockerfileArbitraries.OnBuildInstruction()),
+            // Edge-case generators targeting specific differential test bugs
+            new("run-heredoc", "RUN", DockerfileArbitraries.RunHeredocInstruction()),
+            new("copy-heredoc", "COPY", DockerfileArbitraries.CopyHeredocInstruction()),
+            new("add-heredoc", "ADD", DockerfileArbitraries.AddHeredocInstruction()),
+            new("copy-empty-flag", "COPY", DockerfileArbitraries.CopyEmptyFlagInstruction()),
+            new("add-empty-flag", "ADD", DockerfileArbitraries.AddEmptyFlagInstruction()),
+            // FromEmptyPlatformInstruction excluded: C# throws a parse error
+            // on FROM --platform= (empty value), which is a known C# limitation,
+            // not a Lean issue.
+            new("run-empty-flag", "RUN", DockerfileArbitraries.RunEmptyFlagInstruction()),
+            new("volume-empty-exec", "VOLUME", DockerfileArbitraries.VolumeEmptyExecInstruction()),
+            new("copy-empty-exec", "COPY", DockerfileArbitraries.CopyEmptyExecInstruction()),
+            new("add-empty-exec", "ADD", DockerfileArbitraries.AddEmptyExecInstruction()),
+            new("copy-quoted-path", "COPY", DockerfileArbitraries.CopyQuotedPathInstruction()),
+            new("add-quoted-path", "ADD", DockerfileArbitraries.AddQuotedPathInstruction()),
+            new("from-error-modifier", "FROM", DockerfileArbitraries.FromErrorModifierInstruction()),
+            new("arg-error-modifier", "ARG", DockerfileArbitraries.ArgErrorModifierInstruction()),
+            new("workdir-slash-default", "WORKDIR", DockerfileArbitraries.WorkdirSlashDefaultInstruction()),
+            new("env-slash-default", "ENV", DockerfileArbitraries.EnvSlashDefaultInstruction()),
+            new("run-minimal-mount", "RUN", DockerfileArbitraries.RunMinimalMountInstruction()),
+            new("from-trailing-whitespace", "FROM", DockerfileArbitraries.FromTrailingWhitespaceInstruction()),
+            new("env-trailing-whitespace", "ENV", DockerfileArbitraries.EnvTrailingWhitespaceInstruction()),
+            new("copy-trailing-whitespace", "COPY", DockerfileArbitraries.CopyTrailingWhitespaceInstruction()),
+            new("run-hash-shell", "RUN", DockerfileArbitraries.RunHashInShellInstruction()),
+            new("cmd-hash-shell", "CMD", DockerfileArbitraries.CmdHashInShellInstruction()),
+            new("label-hash-value", "LABEL", DockerfileArbitraries.LabelHashInValueInstruction()),
+            new("copy-flag-continuation", "COPY", DockerfileArbitraries.CopyFlagLineContinuationInstruction()),
+            new("add-flag-continuation", "ADD", DockerfileArbitraries.AddFlagLineContinuationInstruction()),
+        };
 }

--- a/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
@@ -6,10 +6,10 @@ namespace Valleysoft.DockerfileModel.DiffTest;
 
 /// <summary>
 /// Wraps the shared FsCheck generators (DockerfileArbitraries) to produce
-/// random test inputs for differential testing. Returns a list of
-/// (InstructionType, Text, EscapeChar) tuples distributed evenly across all 18
-/// Dockerfile instruction types, shuffled with a fixed seed for reproducibility.
-/// About 10% of inputs use backtick (`) as escape char instead of backslash (\).
+/// deterministic <see cref="DiffCase"/> values for differential testing,
+/// distributed evenly across instruction and targeted edge-case generators,
+/// then shuffled using the supplied seed. Each case includes the metadata
+/// required to regenerate its input.
 /// </summary>
 public static class InputGenerator
 {

--- a/src/Valleysoft.DockerfileModel.DiffTest/LeanProcessWorker.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/LeanProcessWorker.cs
@@ -1,0 +1,281 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+public interface ILeanParser : IAsyncDisposable
+{
+    Task<string> ParseAsync(string input, char escapeChar, CancellationToken cancellationToken);
+}
+
+public sealed class LeanParseException : Exception
+{
+    public LeanParseException(string message)
+        : base(message)
+    {
+    }
+}
+
+public sealed class LeanInfrastructureException : Exception
+{
+    public LeanInfrastructureException(string message)
+        : base(message)
+    {
+    }
+
+    public LeanInfrastructureException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+public sealed class LeanProcessWorker : ILeanParser
+{
+    private readonly string _leanCliPath;
+    private readonly string? _leanLibDir;
+    private readonly TimeSpan _timeout;
+    private Process? _process;
+    private Task<string>? _stderrTask;
+    private long _nextRequestId;
+
+    public LeanProcessWorker(string leanCliPath, TimeSpan? timeout = null)
+    {
+        _leanCliPath = Path.GetFullPath(leanCliPath);
+        _timeout = timeout ?? TimeSpan.FromSeconds(30);
+        _leanLibDir = FindLeanLibDir();
+    }
+
+    public async Task<string> ParseAsync(
+        string input,
+        char escapeChar,
+        CancellationToken cancellationToken)
+    {
+        EnsureStarted();
+        long requestId = Interlocked.Increment(ref _nextRequestId);
+        string payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(input));
+        string request = $"{requestId}\t{(int)escapeChar}\t{payload}";
+
+        try
+        {
+            await _process!.StandardInput.WriteLineAsync(request.AsMemory(), cancellationToken);
+            await _process.StandardInput.FlushAsync(cancellationToken);
+
+            string? response = await _process.StandardOutput
+                .ReadLineAsync(cancellationToken)
+                .AsTask()
+                .WaitAsync(_timeout, cancellationToken);
+
+            if (response is null)
+            {
+                throw await CreateExitedExceptionAsync("Lean batch process closed stdout.");
+            }
+
+            string[] fields = response.Split('\t');
+            if (fields.Length != 3 ||
+                !long.TryParse(fields[0], out long responseId) ||
+                responseId != requestId)
+            {
+                throw new LeanInfrastructureException(
+                    $"Malformed Lean response frame for request {requestId}: '{response}'.");
+            }
+
+            string body;
+            try
+            {
+                body = Encoding.UTF8.GetString(Convert.FromBase64String(fields[2]));
+            }
+            catch (FormatException ex)
+            {
+                throw new LeanInfrastructureException(
+                    $"Lean response {requestId} contained invalid base64.", ex);
+            }
+
+            return fields[1] switch
+            {
+                "ok" => body,
+                "parse-error" => throw new LeanParseException(body),
+                "error" => throw new LeanInfrastructureException(body),
+                _ => throw new LeanInfrastructureException(
+                    $"Lean response {requestId} had unknown status '{fields[1]}'.")
+            };
+        }
+        catch (LeanParseException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            await StopAsync();
+            throw;
+        }
+        catch (Exception ex) when (ex is not LeanInfrastructureException)
+        {
+            await StopAsync();
+            throw CreateRequestFailure(requestId, ex);
+        }
+        catch
+        {
+            await StopAsync();
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    internal static LeanInfrastructureException CreateRequestFailure(
+        long requestId,
+        Exception exception) =>
+        new(
+            $"Lean batch request {requestId} failed: " +
+            $"{exception.GetType().Name}: {exception.Message}",
+            exception);
+
+    private void EnsureStarted()
+    {
+        if (_process is { HasExited: false })
+        {
+            return;
+        }
+
+        _process?.Dispose();
+        Process process = new()
+        {
+            StartInfo = CreateStartInfo()
+        };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            process.Dispose();
+            throw new LeanInfrastructureException(
+                $"Failed to start Lean CLI '{_leanCliPath}'.", ex);
+        }
+
+        _process = process;
+        _stderrTask = process.StandardError.ReadToEndAsync();
+    }
+
+    private ProcessStartInfo CreateStartInfo()
+    {
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = _leanCliPath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("--batch");
+
+        if (_leanLibDir is not null)
+        {
+            string currentPath = startInfo.EnvironmentVariables["PATH"] ?? "";
+            startInfo.EnvironmentVariables["PATH"] =
+                _leanLibDir + Path.PathSeparator + currentPath;
+
+            if (!OperatingSystem.IsWindows())
+            {
+                string currentLdPath =
+                    Environment.GetEnvironmentVariable("LD_LIBRARY_PATH") ?? "";
+                startInfo.EnvironmentVariables["LD_LIBRARY_PATH"] =
+                    _leanLibDir + Path.PathSeparator + currentLdPath;
+            }
+        }
+
+        return startInfo;
+    }
+
+    private async Task<LeanInfrastructureException> CreateExitedExceptionAsync(string message)
+    {
+        string stderr = _stderrTask is null ? "" : (await _stderrTask).Trim();
+        int? exitCode = _process is { HasExited: true } ? _process.ExitCode : null;
+        return CreateExitedException(message, exitCode, stderr);
+    }
+
+    internal static LeanInfrastructureException CreateExitedException(
+        string message,
+        int? exitCode,
+        string stderr)
+    {
+        string exitDetail = exitCode is null ? "" : $" Exit code: {exitCode}.";
+        string stderrDetail = string.IsNullOrWhiteSpace(stderr) ? "" : $" {stderr.Trim()}";
+        return new LeanInfrastructureException(
+            $"{message}{exitDetail}{stderrDetail}");
+    }
+
+    private async Task StopAsync()
+    {
+        Process? process = _process;
+        Task<string>? stderrTask = _stderrTask;
+        _process = null;
+        _stderrTask = null;
+
+        if (process is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.StandardInput.Close();
+                if (!process.WaitForExit(1000))
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+
+            if (stderrTask is not null)
+            {
+                await stderrTask.WaitAsync(TimeSpan.FromSeconds(1));
+            }
+        }
+        catch (Exception) when (process.HasExited)
+        {
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+
+    private static string? FindLeanLibDir()
+    {
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string elanDirectory = Path.Combine(home, ".elan", "toolchains");
+        if (!Directory.Exists(elanDirectory))
+        {
+            return null;
+        }
+
+        string sharedLibrary = OperatingSystem.IsWindows()
+            ? "libInit_shared.dll"
+            : "libInit_shared.so";
+
+        foreach (string toolchain in Directory.GetDirectories(elanDirectory))
+        {
+            string binDirectory = Path.Combine(toolchain, "bin");
+            if (File.Exists(Path.Combine(binDirectory, sharedLibrary)))
+            {
+                return binDirectory;
+            }
+
+            string libraryDirectory = Path.Combine(toolchain, "lib", "lean");
+            if (File.Exists(Path.Combine(libraryDirectory, sharedLibrary)))
+            {
+                return libraryDirectory;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/LeanProcessWorker.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/LeanProcessWorker.cs
@@ -32,6 +32,7 @@ public sealed class LeanInfrastructureException : Exception
 public sealed class LeanProcessWorker : ILeanParser
 {
     private readonly string _leanCliPath;
+    private readonly IReadOnlyList<string> _arguments;
     private readonly string? _leanLibDir;
     private readonly TimeSpan _timeout;
     private Process? _process;
@@ -39,10 +40,36 @@ public sealed class LeanProcessWorker : ILeanParser
     private long _nextRequestId;
 
     public LeanProcessWorker(string leanCliPath, TimeSpan? timeout = null)
+        : this(
+            Path.GetFullPath(leanCliPath),
+            new[] { "--batch" },
+            timeout,
+            findLeanLibDirectory: true)
     {
-        _leanCliPath = Path.GetFullPath(leanCliPath);
+    }
+
+    internal LeanProcessWorker(
+        string executablePath,
+        IReadOnlyList<string> arguments,
+        TimeSpan? timeout = null)
+        : this(
+            executablePath,
+            arguments,
+            timeout,
+            findLeanLibDirectory: false)
+    {
+    }
+
+    private LeanProcessWorker(
+        string executablePath,
+        IReadOnlyList<string> arguments,
+        TimeSpan? timeout,
+        bool findLeanLibDirectory)
+    {
+        _leanCliPath = executablePath;
+        _arguments = arguments;
         _timeout = timeout ?? TimeSpan.FromSeconds(30);
-        _leanLibDir = FindLeanLibDir();
+        _leanLibDir = findLeanLibDirectory ? FindLeanLibDir() : null;
     }
 
     public async Task<string> ParseAsync(
@@ -173,7 +200,10 @@ public sealed class LeanProcessWorker : ILeanParser
             UseShellExecute = false,
             CreateNoWindow = true
         };
-        startInfo.ArgumentList.Add("--batch");
+        foreach (string argument in _arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
 
         if (_leanLibDir is not null)
         {

--- a/src/Valleysoft.DockerfileModel.DiffTest/LeanProcessWorker.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/LeanProcessWorker.cs
@@ -31,6 +31,9 @@ public sealed class LeanInfrastructureException : Exception
 
 public sealed class LeanProcessWorker : ILeanParser
 {
+    private static readonly Encoding StrictUtf8 =
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
     private readonly string _leanCliPath;
     private readonly IReadOnlyList<string> _arguments;
     private readonly string? _leanLibDir;
@@ -109,12 +112,12 @@ public sealed class LeanProcessWorker : ILeanParser
             string body;
             try
             {
-                body = Encoding.UTF8.GetString(Convert.FromBase64String(fields[2]));
+                body = StrictUtf8.GetString(Convert.FromBase64String(fields[2]));
             }
-            catch (FormatException ex)
+            catch (Exception ex) when (ex is FormatException or DecoderFallbackException)
             {
                 throw new LeanInfrastructureException(
-                    $"Lean response {requestId} contained invalid base64.", ex);
+                    $"Lean response {requestId} contained invalid base64 or UTF-8.", ex);
             }
 
             return fields[1] switch
@@ -225,9 +228,28 @@ public sealed class LeanProcessWorker : ILeanParser
 
     private async Task<LeanInfrastructureException> CreateExitedExceptionAsync(string message)
     {
-        string stderr = _stderrTask is null ? "" : (await _stderrTask).Trim();
+        string stderr = await ReadStderrAsync(_stderrTask, TimeSpan.FromSeconds(1));
         int? exitCode = _process is { HasExited: true } ? _process.ExitCode : null;
         return CreateExitedException(message, exitCode, stderr);
+    }
+
+    internal static async Task<string> ReadStderrAsync(
+        Task<string>? stderrTask,
+        TimeSpan timeout)
+    {
+        if (stderrTask is null)
+        {
+            return "";
+        }
+
+        try
+        {
+            return (await stderrTask.WaitAsync(timeout)).Trim();
+        }
+        catch (TimeoutException)
+        {
+            return "Timed out waiting for stderr to close.";
+        }
     }
 
     internal static LeanInfrastructureException CreateExitedException(

--- a/src/Valleysoft.DockerfileModel.DiffTest/Program.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/Program.cs
@@ -1,15 +1,21 @@
+using System.Text;
 using Valleysoft.DockerfileModel.DiffTest;
 
-// Parse command-line arguments
 string mode = "";
 string leanCliPath = "";
+string corpusPath = RegressionCorpus.ResolveDefaultDirectory();
+string? replayInstruction = null;
+string? replayInputBase64 = null;
 int count = 1000;
 int seed = 42;
-char escapeChar = '\\';
+int workers = Math.Min(Environment.ProcessorCount, 4);
+int escapeCode = '\\';
+bool promoteFailures = false;
 
-for (int i = 0; i < args.Length; i++)
+for (int index = 0; index < args.Length; index++)
 {
-    switch (args[i])
+    string argument = args[index];
+    switch (argument)
     {
         case "--parse":
             mode = "parse";
@@ -20,53 +26,95 @@ for (int i = 0; i < args.Length; i++)
         case "--generate":
             mode = "generate";
             break;
+        case "--replay":
+            mode = "replay";
+            break;
         case "--lean-cli":
-            if (i + 1 < args.Length) leanCliPath = args[++i];
+            leanCliPath = ReadValue(argument);
+            break;
+        case "--corpus":
+            corpusPath = ReadValue(argument);
             break;
         case "--count":
-            if (i + 1 < args.Length) count = int.Parse(args[++i]);
+            count = ReadInt(argument, minimum: 0);
             break;
         case "--seed":
-            if (i + 1 < args.Length) seed = int.Parse(args[++i]);
+            seed = ReadInt(argument);
+            break;
+        case "--workers":
+            workers = ReadInt(argument, minimum: 1);
             break;
         case "--escape":
-            if (i + 1 < args.Length && args[i + 1].Length == 1) escapeChar = args[++i][0];
+            string escape = ReadValue(argument);
+            if (escape.Length != 1)
+            {
+                throw new ArgumentException("--escape requires exactly one character.");
+            }
+
+            escapeCode = escape[0];
             break;
+        case "--escape-code":
+            escapeCode = ReadInt(argument, minimum: char.MinValue, maximum: char.MaxValue);
+            break;
+        case "--instruction":
+            replayInstruction = ReadValue(argument);
+            break;
+        case "--input-base64":
+            replayInputBase64 = ReadValue(argument);
+            break;
+        case "--promote-failures":
+            promoteFailures = true;
+            break;
+        default:
+            throw new ArgumentException($"Unknown argument '{argument}'.");
+    }
+
+    string ReadValue(string option)
+    {
+        if (index + 1 >= args.Length)
+        {
+            throw new ArgumentException($"{option} requires a value.");
+        }
+
+        return args[++index];
+    }
+
+    int ReadInt(
+        string option,
+        int minimum = int.MinValue,
+        int maximum = int.MaxValue)
+    {
+        string value = ReadValue(option);
+        if (!int.TryParse(value, out int parsed) || parsed < minimum || parsed > maximum)
+        {
+            throw new ArgumentException(
+                $"{option} requires an integer from {minimum} through {maximum}.");
+        }
+
+        return parsed;
     }
 }
 
-switch (mode)
+return mode switch
 {
-    case "parse":
-        return await RunParse();
-    case "compare":
-        return await RunCompare();
-    case "generate":
-        return RunGenerate();
-    default:
-        Console.Error.WriteLine("Usage:");
-        Console.Error.WriteLine("  --parse                          Read stdin, output JSON (symmetric with Lean CLI)");
-        Console.Error.WriteLine("  --compare --lean-cli <path> --count N  Compare both parsers on N random inputs");
-        Console.Error.WriteLine("  --generate --count N             Output test inputs as TYPE\\tBASE64 lines");
-        Console.Error.WriteLine("  --escape <char>                  Set escape character (default: \\)");
-        return 1;
-}
+    "parse" => await RunParseAsync(),
+    "compare" => await RunCompareAsync(),
+    "generate" => RunGenerate(),
+    "replay" => await RunReplayAsync(),
+    _ => ShowUsage()
+};
 
-/// <summary>
-/// Parse mode: read stdin, detect instruction type, output canonical JSON.
-/// Symmetric with the Lean CLI for manual smoke testing.
-/// </summary>
-async Task<int> RunParse()
+async Task<int> RunParseAsync()
 {
     string input = await Console.In.ReadToEndAsync();
-    string trimmed = input.TrimStart();
-    int spaceIdx = trimmed.IndexOfAny(new[] { ' ', '\t', '\n', '\r' });
-    string keyword = spaceIdx > 0 ? trimmed[..spaceIdx].ToUpperInvariant() : trimmed.ToUpperInvariant();
+    string instruction = DetectInstruction(input);
 
     try
     {
-        string json = DiffTestRunner.ParseCSharp(keyword, input, escapeChar);
-        Console.WriteLine(json);
+        Console.WriteLine(DiffTestRunner.ParseCSharp(
+            instruction,
+            input,
+            (char)escapeCode));
         return 0;
     }
     catch (Exception ex)
@@ -76,85 +124,176 @@ async Task<int> RunParse()
     }
 }
 
-/// <summary>
-/// Compare mode: generate random inputs, run both parsers, report mismatches.
-/// </summary>
-async Task<int> RunCompare()
+async Task<int> RunCompareAsync()
 {
-    if (string.IsNullOrEmpty(leanCliPath))
-    {
-        Console.Error.WriteLine("Error: --lean-cli <path> is required for --compare mode");
-        return 1;
-    }
-
-    Console.WriteLine($"Generating {count} random inputs (seed={seed}, escape='{escapeChar}')...");
-    List<(string InstructionType, string Text, char EscapeChar)> inputs = InputGenerator.Generate(count, seed);
-
-    Console.WriteLine($"Running differential test against Lean CLI: {leanCliPath}");
-    Console.WriteLine();
-
+    RequireLeanCli();
+    RegressionCorpus corpus = new(corpusPath);
+    IReadOnlyList<DiffCase> regressionCases = corpus.Load();
+    List<DiffCase> generatedCases = InputGenerator.Generate(count, seed);
     DiffTestRunner runner = new(leanCliPath);
-    int mismatches = 0;
-    int errors = 0;
 
-    List<DiffResult> results = await runner.RunBatchAsync(inputs, (current, total, result) =>
+    Console.WriteLine(
+        $"Running {regressionCases.Count} regression cases with {workers} persistent Lean worker(s)...");
+    IReadOnlyList<DiffResult> regressionResults =
+        await runner.RunBatchAsync(regressionCases, workers);
+    PrintProgress(regressionResults.Count, regressionResults.Count);
+
+    Console.WriteLine(
+        $"Running {generatedCases.Count} generated cases (seed={seed})...");
+    IReadOnlyList<DiffResult> generatedResults =
+        await runner.RunBatchAsync(generatedCases, workers);
+    PrintProgress(generatedResults.Count, generatedResults.Count);
+
+    DiffResult[] failures = regressionResults
+        .Concat(generatedResults)
+        .Where(result => !result.Match)
+        .ToArray();
+    int infrastructureErrors =
+        failures.Count(result => result.Outcome == DiffOutcomeKind.InfrastructureError);
+
+    foreach (DiffResult failure in failures)
     {
-        if (!result.Match)
+        DiffResult minimized = failure;
+        if (failure.Outcome != DiffOutcomeKind.InfrastructureError)
         {
-            if (result.Error != null)
-            {
-                errors++;
-                Console.Error.WriteLine($"[{current}/{total}] ERROR: {result.Error}");
-                Console.Error.WriteLine($"  Input: {Escape(result.Input)}");
-            }
-            else
-            {
-                mismatches++;
-                Console.Error.WriteLine($"[{current}/{total}] MISMATCH ({result.InstructionType}):");
-                Console.Error.WriteLine($"  Input:  {Escape(result.Input)}");
-                Console.Error.WriteLine($"  C#:     {result.CSharpJson}");
-                Console.Error.WriteLine($"  Lean:   {result.LeanJson}");
-            }
-            Console.Error.WriteLine();
+            FailureMinimizer minimizer = new(
+                () => new LeanProcessWorker(leanCliPath));
+            minimized = await minimizer.MinimizeAsync(failure);
         }
 
-        // Progress indicator every 1000 inputs
-        if (current % 1000 == 0 || current == total)
+        PrintFailure(failure, minimized);
+        if (promoteFailures && minimized.Outcome != DiffOutcomeKind.InfrastructureError)
         {
-            Console.Write($"\r  Progress: {current}/{total}");
-            if (current == total) Console.WriteLine();
+            string promotedPath = corpus.Promote(minimized.Case);
+            Console.Error.WriteLine($"  Promoted: {promotedPath}");
         }
-    });
 
-    Console.WriteLine();
-    Console.WriteLine($"Results: {count} inputs, {mismatches} mismatches, {errors} errors");
-
-    if (mismatches > 0 || errors > 0)
-    {
-        Console.WriteLine("FAIL");
-        return 1;
+        Console.Error.WriteLine();
     }
 
-    Console.WriteLine("PASS");
-    return 0;
+    Console.WriteLine(
+        $"Results: {regressionCases.Count} regression, {generatedCases.Count} generated, " +
+        $"{failures.Length - infrastructureErrors} parser differences, " +
+        $"{infrastructureErrors} infrastructure errors");
+    Console.WriteLine(failures.Length == 0 ? "PASS" : "FAIL");
+    return failures.Length == 0 ? 0 : 1;
 }
 
-/// <summary>
-/// Generate mode: output test inputs as TYPE\tBASE64 lines for external use.
-/// </summary>
+async Task<int> RunReplayAsync()
+{
+    RequireLeanCli();
+    if (string.IsNullOrWhiteSpace(replayInstruction) ||
+        string.IsNullOrWhiteSpace(replayInputBase64))
+    {
+        throw new ArgumentException(
+            "--replay requires --instruction and --input-base64.");
+    }
+
+    string input;
+    try
+    {
+        input = Encoding.UTF8.GetString(Convert.FromBase64String(replayInputBase64));
+    }
+    catch (FormatException ex)
+    {
+        throw new ArgumentException("--input-base64 is not valid base64.", ex);
+    }
+
+    DiffCase replayCase = new(
+        "replay",
+        DiffCaseSource.Replay,
+        replayInstruction,
+        input,
+        (char)escapeCode);
+    DiffResult result = await new DiffTestRunner(leanCliPath).RunSingleAsync(replayCase);
+    PrintFailure(result, result);
+    return result.Match ? 0 : 1;
+}
+
 int RunGenerate()
 {
-    List<(string InstructionType, string Text, char EscapeChar)> inputs = InputGenerator.Generate(count, seed);
-    foreach ((string type, string text, char esc) in inputs)
+    foreach (DiffCase testCase in InputGenerator.Generate(count, seed))
     {
-        string b64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(text));
-        Console.WriteLine($"{type}\t{b64}\t{esc}");
+        Console.WriteLine(
+            $"{testCase.InstructionType}\t{testCase.InputBase64}\t" +
+            $"{(int)testCase.EscapeChar}\t{testCase.Generator}\t{testCase.CaseIndex}");
     }
+
     return 0;
 }
 
-/// <summary>
-/// Escape control characters for display.
-/// </summary>
-static string Escape(string s) =>
-    s.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+void PrintFailure(DiffResult original, DiffResult minimized)
+{
+    DiffCase testCase = original.Case;
+    Console.Error.WriteLine(
+        $"{original.Outcome.ToString().ToUpperInvariant()} " +
+        $"({testCase.Source}, {testCase.InstructionType}, id={testCase.Id})");
+    if (testCase.Generator is not null)
+    {
+        Console.Error.WriteLine(
+            $"  Seed: {testCase.Seed}, generator: {testCase.Generator}, " +
+            $"case index: {testCase.CaseIndex}, escape: {(int)testCase.EscapeChar}");
+    }
+
+    Console.Error.WriteLine($"  Input:     {Escape(testCase.Input)}");
+    if (minimized.Case.Input != testCase.Input)
+    {
+        Console.Error.WriteLine($"  Minimized: {Escape(minimized.Case.Input)}");
+    }
+
+    if (original.Outcome == DiffOutcomeKind.JsonMismatch)
+    {
+        Console.Error.WriteLine($"  C#:   {minimized.CSharpJson}");
+        Console.Error.WriteLine($"  Lean: {minimized.LeanJson}");
+    }
+    else if (minimized.Error is not null || original.Error is not null)
+    {
+        Console.Error.WriteLine($"  Error: {minimized.Error ?? original.Error}");
+        if (original.Outcome == DiffOutcomeKind.CSharpParseError)
+        {
+            Console.Error.WriteLine($"  Lean: {minimized.LeanJson}");
+        }
+        else if (original.Outcome == DiffOutcomeKind.LeanParseError)
+        {
+            Console.Error.WriteLine($"  C#:   {minimized.CSharpJson}");
+        }
+    }
+
+    Console.Error.WriteLine(
+        $"  Replay: {ReplayCommand.Create(minimized.Case, leanCliPath)}");
+}
+
+void RequireLeanCli()
+{
+    if (string.IsNullOrWhiteSpace(leanCliPath))
+    {
+        throw new ArgumentException("--lean-cli <path> is required.");
+    }
+}
+
+static string DetectInstruction(string input)
+{
+    string trimmed = input.TrimStart();
+    int end = trimmed.IndexOfAny(new[] { ' ', '\t', '\n', '\r' });
+    return (end > 0 ? trimmed[..end] : trimmed).ToUpperInvariant();
+}
+
+static void PrintProgress(int current, int total) =>
+    Console.WriteLine($"  Progress: {current}/{total}");
+
+static string Escape(string value) =>
+    value.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+
+static int ShowUsage()
+{
+    Console.Error.WriteLine("Usage:");
+    Console.Error.WriteLine("  --parse [--escape <char>]");
+    Console.Error.WriteLine(
+        "  --compare --lean-cli <path> [--count N] [--seed N] [--workers N] " +
+        "[--corpus <path>] [--promote-failures]");
+    Console.Error.WriteLine(
+        "  --replay --lean-cli <path> --instruction <type> --input-base64 <value> " +
+        "[--escape-code N]");
+    Console.Error.WriteLine("  --generate [--count N] [--seed N]");
+    return 1;
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus.cs
@@ -1,0 +1,165 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+public sealed class RegressionCorpus
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    public RegressionCorpus(string directory)
+    {
+        DirectoryPath = Path.GetFullPath(directory);
+    }
+
+    public string DirectoryPath { get; }
+
+    public IReadOnlyList<DiffCase> Load()
+    {
+        if (!Directory.Exists(DirectoryPath))
+        {
+            throw new DirectoryNotFoundException(
+                $"Regression corpus directory not found: {DirectoryPath}");
+        }
+
+        List<DiffCase> cases = new();
+        HashSet<string> ids = new(StringComparer.Ordinal);
+        foreach (string path in Directory.EnumerateFiles(DirectoryPath, "*.json")
+            .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            RegressionFixture fixture;
+            try
+            {
+                fixture = JsonSerializer.Deserialize<RegressionFixture>(
+                    File.ReadAllText(path),
+                    JsonOptions)
+                    ?? throw new InvalidDataException("Fixture is empty.");
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidDataException(
+                    $"Invalid regression fixture '{path}': {ex.Message}", ex);
+            }
+
+            DiffCase testCase;
+            try
+            {
+                testCase = fixture.ToCase();
+            }
+            catch (InvalidDataException ex)
+            {
+                throw new InvalidDataException(
+                    $"Invalid regression fixture '{path}': {ex.Message}", ex);
+            }
+
+            if (!ids.Add(testCase.Id))
+            {
+                throw new InvalidDataException(
+                    $"Duplicate regression fixture ID '{testCase.Id}' in '{path}'.");
+            }
+
+            cases.Add(testCase);
+        }
+
+        return cases;
+    }
+
+    public string Promote(DiffCase minimizedCase)
+    {
+        if (!InstructionTypes.IsSupported(minimizedCase.InstructionType))
+        {
+            throw new InvalidDataException(
+                $"Cannot promote unsupported instruction type '{minimizedCase.InstructionType}'.");
+        }
+
+        Directory.CreateDirectory(DirectoryPath);
+        string hash = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(
+                $"{minimizedCase.InstructionType}\0{minimizedCase.EscapeChar}\0{minimizedCase.Input}")))
+            .ToLowerInvariant()[..12];
+        string instruction = minimizedCase.InstructionType.ToLowerInvariant();
+        string id = $"local-{instruction}-{hash}";
+        string path = Path.GetFullPath(
+            Path.Combine(DirectoryPath, $"{instruction}-{hash}.json"));
+        string corpusPrefix = DirectoryPath.TrimEnd(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (!path.StartsWith(corpusPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"Promoted fixture path escapes the regression corpus: {path}");
+        }
+
+        RegressionFixture fixture = RegressionFixture.FromCase(
+            minimizedCase with
+            {
+                Id = id,
+                Source = DiffCaseSource.Regression,
+                Generator = null,
+                Seed = null,
+                CaseIndex = null
+            });
+        string json = JsonSerializer.Serialize(fixture, JsonOptions) + Environment.NewLine;
+        string temporaryPath = path + $".{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(
+                temporaryPath,
+                json,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.Move(temporaryPath, path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+
+        return path;
+    }
+
+    public static string ResolveDefaultDirectory()
+    {
+        DirectoryInfo? current = new(Environment.CurrentDirectory);
+        while (current is not null)
+        {
+            string sourceDirectory = Path.Combine(
+                current.FullName,
+                "src",
+                "Valleysoft.DockerfileModel.DiffTest",
+                "RegressionCorpus");
+            if (Directory.Exists(sourceDirectory))
+            {
+                return sourceDirectory;
+            }
+
+            string projectDirectory = Path.Combine(
+                current.FullName,
+                "Valleysoft.DockerfileModel.DiffTest",
+                "RegressionCorpus");
+            if (Directory.Exists(projectDirectory))
+            {
+                return projectDirectory;
+            }
+
+            current = current.Parent;
+        }
+
+        string deployedDirectory = Path.Combine(AppContext.BaseDirectory, "RegressionCorpus");
+        return Directory.Exists(deployedDirectory)
+            ? deployedDirectory
+            : Path.Combine(
+                Environment.CurrentDirectory,
+                "src",
+                "Valleysoft.DockerfileModel.DiffTest",
+                "RegressionCorpus");
+    }
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/from-basic.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/from-basic.json
@@ -1,0 +1,9 @@
+{
+  "id": "local-from-basic",
+  "instructionType": "FROM",
+  "inputBase64": "RlJPTSBhbHBpbmU=",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/ReplayCommand.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/ReplayCommand.cs
@@ -13,14 +13,14 @@ internal static class ReplayCommand
             ? ResolveProjectPath(projectSearchPaths)
             : Path.GetFullPath(projectPath);
         string invocation = resolvedProjectPath is null
-            ? $"dotnet {Quote(typeof(ReplayCommand).Assembly.Location)}"
-            : $"dotnet run --project {Quote(resolvedProjectPath)} --";
+            ? $"dotnet {QuoteArgument(typeof(ReplayCommand).Assembly.Location)}"
+            : $"dotnet run --project {QuoteArgument(resolvedProjectPath)} --";
 
         return $"{invocation} --replay " +
-            $"--lean-cli {Quote(resolvedLeanCliPath)} " +
-            $"--instruction {testCase.InstructionType} " +
+            $"--lean-cli {QuoteArgument(resolvedLeanCliPath)} " +
+            $"--instruction {QuoteArgument(testCase.InstructionType)} " +
             $"--escape-code {(int)testCase.EscapeChar} " +
-            $"--input-base64 {testCase.InputBase64}";
+            $"--input-base64 {QuoteArgument(testCase.InputBase64)}";
     }
 
     internal static string? ResolveProjectPath(
@@ -62,6 +62,11 @@ internal static class ReplayCommand
         return null;
     }
 
-    private static string Quote(string value) =>
-        "\"" + value.Replace("\"", "\\\"") + "\"";
+    private static string QuoteArgument(string value) =>
+        QuoteArgument(value, OperatingSystem.IsWindows());
+
+    internal static string QuoteArgument(string value, bool isWindows) =>
+        isWindows
+            ? "'" + value.Replace("'", "''") + "'"
+            : "'" + value.Replace("'", "'\"'\"'") + "'";
 }

--- a/src/Valleysoft.DockerfileModel.DiffTest/ReplayCommand.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/ReplayCommand.cs
@@ -1,0 +1,67 @@
+namespace Valleysoft.DockerfileModel.DiffTest;
+
+internal static class ReplayCommand
+{
+    public static string Create(
+        DiffCase testCase,
+        string leanCliPath,
+        string? projectPath = null,
+        IEnumerable<string>? projectSearchPaths = null)
+    {
+        string resolvedLeanCliPath = Path.GetFullPath(leanCliPath);
+        string? resolvedProjectPath = projectPath is null
+            ? ResolveProjectPath(projectSearchPaths)
+            : Path.GetFullPath(projectPath);
+        string invocation = resolvedProjectPath is null
+            ? $"dotnet {Quote(typeof(ReplayCommand).Assembly.Location)}"
+            : $"dotnet run --project {Quote(resolvedProjectPath)} --";
+
+        return $"{invocation} --replay " +
+            $"--lean-cli {Quote(resolvedLeanCliPath)} " +
+            $"--instruction {testCase.InstructionType} " +
+            $"--escape-code {(int)testCase.EscapeChar} " +
+            $"--input-base64 {testCase.InputBase64}";
+    }
+
+    internal static string? ResolveProjectPath(
+        IEnumerable<string>? startingPaths = null)
+    {
+        string relativeProjectPath = Path.Combine(
+            "src",
+            "Valleysoft.DockerfileModel.DiffTest",
+            "Valleysoft.DockerfileModel.DiffTest.csproj");
+        string projectFileName = "Valleysoft.DockerfileModel.DiffTest.csproj";
+
+        startingPaths ??=
+            new[] { Environment.CurrentDirectory, AppContext.BaseDirectory };
+        foreach (string startingPath in startingPaths)
+        {
+            DirectoryInfo? directory = new(startingPath);
+            while (directory is not null)
+            {
+                string directCandidate = Path.Combine(
+                    directory.FullName,
+                    projectFileName);
+                if (File.Exists(directCandidate))
+                {
+                    return directCandidate;
+                }
+
+                string repositoryCandidate = Path.Combine(
+                    directory.FullName,
+                    relativeProjectPath);
+                if (File.Exists(repositoryCandidate))
+                {
+                    return repositoryCandidate;
+                }
+
+                directory = directory.Parent;
+            }
+        }
+
+        return null;
+    }
+
+    private static string Quote(string value) =>
+        "\"" + value.Replace("\"", "\\\"") + "\"";
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/Valleysoft.DockerfileModel.DiffTest.csproj
+++ b/src/Valleysoft.DockerfileModel.DiffTest/Valleysoft.DockerfileModel.DiffTest.csproj
@@ -18,4 +18,10 @@
     <ProjectReference Include="..\Valleysoft.DockerfileModel.TestSupport\Valleysoft.DockerfileModel.TestSupport.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="RegressionCorpus\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/src/Valleysoft.DockerfileModel.Tests/DiffTestInfrastructureTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DiffTestInfrastructureTests.cs
@@ -48,11 +48,15 @@ public class DiffTestInfrastructureTests
             projectPath);
 
         Assert.Contains(
-            $"--project \"{Path.GetFullPath(projectPath)}\"",
+            $"--project {ReplayCommand.QuoteArgument(
+                Path.GetFullPath(projectPath),
+                OperatingSystem.IsWindows())}",
             command,
             StringComparison.Ordinal);
         Assert.Contains(
-            $"--lean-cli \"{Path.GetFullPath(leanCliPath)}\"",
+            $"--lean-cli {ReplayCommand.QuoteArgument(
+                Path.GetFullPath(leanCliPath),
+                OperatingSystem.IsWindows())}",
             command,
             StringComparison.Ordinal);
     }
@@ -86,9 +90,22 @@ public class DiffTestInfrastructureTests
             projectSearchPaths: new[] { missingDirectory });
 
         Assert.StartsWith(
-            $"dotnet \"{typeof(DiffTestRunner).Assembly.Location}\" --replay",
+            $"dotnet {ReplayCommand.QuoteArgument(
+                typeof(DiffTestRunner).Assembly.Location,
+                OperatingSystem.IsWindows())} --replay",
             command,
             StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(false, "path/with $dollar `tick` \\\\ slash ' quote", "'path/with $dollar `tick` \\\\ slash '\"'\"' quote'")]
+    [InlineData(true, "C:\\path\\with $dollar `tick` ' quote", "'C:\\path\\with $dollar `tick` '' quote'")]
+    public void ReplayCommand_QuotesArgumentsForHostShell(
+        bool isWindows,
+        string value,
+        string expected)
+    {
+        Assert.Equal(expected, ReplayCommand.QuoteArgument(value, isWindows));
     }
 
     [Fact]
@@ -169,6 +186,21 @@ public class DiffTestInfrastructureTests
     }
 
     [Fact]
+    public async Task RunSingleAsync_KnownCrashPreservesLeanInfrastructureFailure()
+    {
+        DiffCase testCase = Case("empty-volume", "VOLUME []") with
+        {
+            InstructionType = "VOLUME"
+        };
+        DiffTestRunner runner = new(() => new InfrastructureFailingParser());
+
+        DiffResult result = await runner.RunSingleAsync(testCase);
+
+        Assert.Equal(DiffOutcomeKind.InfrastructureError, result.Outcome);
+        Assert.Equal("Lean process failed.", result.Error);
+    }
+
+    [Fact]
     public async Task RunBatchAsync_CancellationStopsTheBatch()
     {
         using CancellationTokenSource cancellation = new();
@@ -228,6 +260,79 @@ public class DiffTestInfrastructureTests
         Assert.Equal(
             "Lean batch process closed stdout. Exit code: -1073741511. loader failure",
             exception.Message);
+    }
+
+    [Fact]
+    public async Task LeanProcessWorker_ParsesOkResponseFromChildProcess()
+    {
+        await using FakeLeanProcess process = FakeLeanProcess.Create("1\tok\te30=");
+        await using LeanProcessWorker worker = process.CreateWorker();
+
+        string result = await worker.ParseAsync(
+            "FROM alpine",
+            '\\',
+            CancellationToken.None);
+
+        Assert.Equal("{}", result);
+    }
+
+    [Fact]
+    public async Task LeanProcessWorker_ParsesErrorStatusesFromChildProcess()
+    {
+        await using FakeLeanProcess parseErrorProcess =
+            FakeLeanProcess.Create("1\tparse-error\tcmVqZWN0ZWQ=");
+        await using LeanProcessWorker parseErrorWorker =
+            parseErrorProcess.CreateWorker();
+        LeanParseException parseException =
+            await Assert.ThrowsAsync<LeanParseException>(
+                () => parseErrorWorker.ParseAsync(
+                    "FROM alpine",
+                    '\\',
+                    CancellationToken.None));
+        Assert.Equal("rejected", parseException.Message);
+
+        await using FakeLeanProcess errorProcess =
+            FakeLeanProcess.Create("1\terror\tYnJva2Vu");
+        await using LeanProcessWorker errorWorker = errorProcess.CreateWorker();
+        LeanInfrastructureException infrastructureException =
+            await Assert.ThrowsAsync<LeanInfrastructureException>(
+                () => errorWorker.ParseAsync(
+                    "FROM alpine",
+                    '\\',
+                    CancellationToken.None));
+        Assert.Equal("broken", infrastructureException.Message);
+    }
+
+    [Fact]
+    public async Task LeanProcessWorker_RejectsMalformedResponseAndEof()
+    {
+        await using FakeLeanProcess malformedProcess =
+            FakeLeanProcess.Create("malformed");
+        await using LeanProcessWorker malformedWorker =
+            malformedProcess.CreateWorker();
+        LeanInfrastructureException malformedException =
+            await Assert.ThrowsAsync<LeanInfrastructureException>(
+                () => malformedWorker.ParseAsync(
+                    "FROM alpine",
+                    '\\',
+                    CancellationToken.None));
+        Assert.Contains(
+            "Malformed Lean response frame",
+            malformedException.Message,
+            StringComparison.Ordinal);
+
+        await using FakeLeanProcess eofProcess = FakeLeanProcess.Create(response: null);
+        await using LeanProcessWorker eofWorker = eofProcess.CreateWorker();
+        LeanInfrastructureException eofException =
+            await Assert.ThrowsAsync<LeanInfrastructureException>(
+                () => eofWorker.ParseAsync(
+                    "FROM alpine",
+                    '\\',
+                    CancellationToken.None));
+        Assert.Contains(
+            "closed stdout",
+            eofException.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -499,6 +604,17 @@ public class DiffTestInfrastructureTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
+    private sealed class InfrastructureFailingParser : ILeanParser
+    {
+        public Task<string> ParseAsync(
+            string input,
+            char escapeChar,
+            CancellationToken cancellationToken) =>
+            throw new LeanInfrastructureException("Lean process failed.");
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
     private sealed class CancelingParser : ILeanParser
     {
         public Task<string> ParseAsync(
@@ -533,5 +649,78 @@ public class DiffTestInfrastructureTests
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class FakeLeanProcess : IAsyncDisposable
+    {
+        private const string ExpectedRequest = "1\t92\tRlJPTSBhbHBpbmU=";
+
+        private FakeLeanProcess(
+            string directory,
+            string executablePath,
+            IReadOnlyList<string> arguments)
+        {
+            Directory = directory;
+            ExecutablePath = executablePath;
+            Arguments = arguments;
+        }
+
+        public string Directory { get; }
+
+        public string ExecutablePath { get; }
+
+        public IReadOnlyList<string> Arguments { get; }
+
+        public static FakeLeanProcess Create(string? response)
+        {
+            string directory = Path.Combine(
+                Path.GetTempPath(),
+                $"DockerfileModel-FakeLean-{Guid.NewGuid():N}");
+            System.IO.Directory.CreateDirectory(directory);
+
+            if (OperatingSystem.IsWindows())
+            {
+                string scriptPath = Path.Combine(directory, "fake-lean.cmd");
+                string output = response is null ? "" : $"echo({response}";
+                File.WriteAllText(
+                    scriptPath,
+                    $"@echo off{Environment.NewLine}" +
+                    $"set /p \"request=\"{Environment.NewLine}" +
+                    $"if not \"%request%\"==\"{ExpectedRequest}\" exit /b 23{Environment.NewLine}" +
+                    $"{output}{Environment.NewLine}");
+                return new FakeLeanProcess(
+                    directory,
+                    Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe",
+                    new[] { "/D", "/Q", "/C", scriptPath });
+            }
+
+            string unixScriptPath = Path.Combine(directory, "fake-lean.sh");
+            string escapedRequest = ExpectedRequest.Replace("'", "'\"'\"'");
+            string outputLine = response is null
+                ? ""
+                : $"printf '%s\\n' '{response}'";
+            File.WriteAllText(
+                unixScriptPath,
+                $"IFS= read -r request{Environment.NewLine}" +
+                $"[ \"$request\" = '{escapedRequest}' ] || exit 23{Environment.NewLine}" +
+                $"{outputLine}{Environment.NewLine}");
+            return new FakeLeanProcess(
+                directory,
+                "/bin/sh",
+                new[] { unixScriptPath });
+        }
+
+        public LeanProcessWorker CreateWorker() =>
+            new(ExecutablePath, Arguments, TimeSpan.FromSeconds(5));
+
+        public ValueTask DisposeAsync()
+        {
+            if (System.IO.Directory.Exists(Directory))
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/DiffTestInfrastructureTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DiffTestInfrastructureTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Valleysoft.DockerfileModel.DiffTest;
 
 namespace Valleysoft.DockerfileModel.Tests;
@@ -304,6 +305,35 @@ public class DiffTestInfrastructureTests
     }
 
     [Fact]
+    public async Task LeanProcessWorker_RejectsInvalidUtf8Response()
+    {
+        await using FakeLeanProcess process = FakeLeanProcess.Create("1\tok\t/w==");
+        await using LeanProcessWorker worker = process.CreateWorker();
+
+        LeanInfrastructureException exception =
+            await Assert.ThrowsAsync<LeanInfrastructureException>(
+                () => worker.ParseAsync(
+                    "FROM alpine",
+                    '\\',
+                    CancellationToken.None));
+
+        Assert.Contains("invalid base64 or UTF-8", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task LeanProcessWorker_BoundsStderrDrain()
+    {
+        TaskCompletionSource<string> stderr = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        string result = await LeanProcessWorker.ReadStderrAsync(
+            stderr.Task,
+            TimeSpan.FromMilliseconds(10));
+
+        Assert.Equal("Timed out waiting for stderr to close.", result);
+    }
+
+    [Fact]
     public async Task LeanProcessWorker_RejectsMalformedResponseAndEof()
     {
         await using FakeLeanProcess malformedProcess =
@@ -468,6 +498,22 @@ public class DiffTestInfrastructureTests
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void RegressionCorpus_RejectsInvalidUtf8Input()
+    {
+        RegressionFixture fixture = new(
+            "invalid-utf8",
+            "FROM",
+            "/w==",
+            "\\");
+
+        InvalidDataException exception =
+            Assert.Throws<InvalidDataException>(() => fixture.ToCase());
+
+        Assert.Contains("invalid base64 or UTF-8", exception.Message, StringComparison.Ordinal);
+        Assert.IsType<DecoderFallbackException>(exception.InnerException);
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/DiffTestInfrastructureTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DiffTestInfrastructureTests.cs
@@ -1,0 +1,537 @@
+using Valleysoft.DockerfileModel.DiffTest;
+
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class DiffTestInfrastructureTests
+{
+    [Fact]
+    public void Generate_IsDeterministicAndCarriesReplayMetadata()
+    {
+        IReadOnlyList<DiffCase> first = InputGenerator.Generate(100, seed: 1234);
+        IReadOnlyList<DiffCase> second = InputGenerator.Generate(100, seed: 1234);
+
+        Assert.Equal(first, second);
+        Assert.All(first, testCase =>
+        {
+            Assert.Equal(DiffCaseSource.Generated, testCase.Source);
+            Assert.NotNull(testCase.Generator);
+            Assert.Equal(1234, testCase.Seed);
+            Assert.NotNull(testCase.CaseIndex);
+        });
+    }
+
+    [Fact]
+    public void GeneratorGamma_IsOddAndUniquePerCase()
+    {
+        ulong[] values = Enumerable.Range(0, 1000)
+            .Select(caseIndex => InputGenerator.CreateGamma(7, caseIndex))
+            .ToArray();
+
+        Assert.All(values, value => Assert.Equal(1UL, value & 1UL));
+        Assert.Equal(values.Length, values.Distinct().Count());
+    }
+
+    [Fact]
+    public void ReplayCommand_ResolvesBothPathsAgainstCurrentDirectory()
+    {
+        string currentDirectory = Environment.CurrentDirectory;
+        string projectPath = Path.Combine(
+            currentDirectory,
+            "src",
+            "Valleysoft.DockerfileModel.DiffTest",
+            "Valleysoft.DockerfileModel.DiffTest.csproj");
+        string leanCliPath = Path.Combine("..", "lean", "DockerfileModelDiffTest");
+
+        string command = ReplayCommand.Create(
+            Case("replay", "FROM alpine"),
+            leanCliPath,
+            projectPath);
+
+        Assert.Contains(
+            $"--project \"{Path.GetFullPath(projectPath)}\"",
+            command,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"--lean-cli \"{Path.GetFullPath(leanCliPath)}\"",
+            command,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReplayCommand_DiscoversProjectFromCiWorkingDirectory()
+    {
+        string corpusDirectory = RegressionCorpus.ResolveDefaultDirectory();
+        string projectDirectory = Directory.GetParent(corpusDirectory)!.FullName;
+        string srcDirectory = Directory.GetParent(projectDirectory)!.FullName;
+
+        string? projectPath = ReplayCommand.ResolveProjectPath(new[] { srcDirectory });
+
+        Assert.Equal(
+            Path.Combine(
+                projectDirectory,
+                "Valleysoft.DockerfileModel.DiffTest.csproj"),
+            projectPath);
+    }
+
+    [Fact]
+    public void ReplayCommand_FallsBackToCompiledAssemblyWhenProjectIsUnavailable()
+    {
+        string missingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"DockerfileModel-Missing-{Guid.NewGuid():N}");
+
+        string command = ReplayCommand.Create(
+            Case("replay", "FROM alpine"),
+            "DockerfileModelDiffTest",
+            projectSearchPaths: new[] { missingDirectory });
+
+        Assert.StartsWith(
+            $"dotnet \"{typeof(DiffTestRunner).Assembly.Location}\" --replay",
+            command,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_BoundsConcurrencyAndPreservesOrder()
+    {
+        SharedParserState state = new();
+        DiffTestRunner runner = new(() => new FakeParser(state, delay: TimeSpan.FromMilliseconds(20)));
+        DiffCase[] cases = Enumerable.Range(0, 12)
+            .Select(index => Case($"case-{index}", $"FROM alpine:{index}"))
+            .ToArray();
+
+        IReadOnlyList<DiffResult> results = await runner.RunBatchAsync(cases, workerCount: 3);
+
+        Assert.Equal(cases.Select(testCase => testCase.Id), results.Select(result => result.Case.Id));
+        Assert.Equal(3, state.Created);
+        Assert.InRange(state.MaximumConcurrency, 2, 3);
+    }
+
+    [Fact]
+    public async Task FailureMinimizer_PreservesMismatchCategory()
+    {
+        SharedParserState state = new();
+        FailureMinimizer minimizer = new(() => new FakeParser(state));
+        DiffCase testCase = Case("failure", "RUN prefix bad suffix") with
+        {
+            InstructionType = "RUN"
+        };
+        DiffResult original = await new DiffTestRunner(() => new FakeParser(state))
+            .RunSingleAsync(testCase);
+
+        DiffResult minimized = await minimizer.MinimizeAsync(original);
+
+        Assert.Equal(DiffOutcomeKind.JsonMismatch, original.Outcome);
+        Assert.Equal(original.Outcome, minimized.Outcome);
+        Assert.Contains("bad", minimized.Case.Input, StringComparison.Ordinal);
+        Assert.True(minimized.Case.Input.Length < original.Case.Input.Length);
+    }
+
+    [Fact]
+    public async Task RunSingleAsync_BothParsersRejectInput_ReturnsMatch()
+    {
+        DiffCase testCase = Case("invalid", "FROM ");
+        DiffTestRunner runner = new(() => new RejectingParser());
+
+        DiffResult result = await runner.RunSingleAsync(testCase);
+
+        Assert.Equal(DiffOutcomeKind.Match, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RunSingleAsync_UnsupportedInstructionType_ReturnsParserCrash()
+    {
+        DiffCase testCase = Case("invalid-type", "BOGUS value") with
+        {
+            InstructionType = "BOGUS"
+        };
+        DiffTestRunner runner = new(() => new RejectingParser());
+
+        DiffResult result = await runner.RunSingleAsync(testCase);
+
+        Assert.Equal(DiffOutcomeKind.CSharpParserCrash, result.Outcome);
+        Assert.Contains("ArgumentException", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunSingleAsync_NestedVolumeBrackets_AreNotTreatedAsKnownCrash()
+    {
+        const string input = "VOLUME [[]]";
+        DiffCase testCase = Case("nested-volume", input) with
+        {
+            InstructionType = "VOLUME"
+        };
+        DiffTestRunner runner = new(() => new SelectiveParser(input));
+
+        DiffResult result = await runner.RunSingleAsync(testCase);
+
+        Assert.Equal(DiffOutcomeKind.CSharpParseError, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_CancellationStopsTheBatch()
+    {
+        using CancellationTokenSource cancellation = new();
+        cancellation.Cancel();
+        DiffTestRunner runner = new(() => new CancelingParser());
+        DiffCase[] cases = Enumerable.Range(0, 3)
+            .Select(index => Case($"case-{index}", "FROM alpine"))
+            .ToArray();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => runner.RunBatchAsync(cases, workerCount: 1, cancellation.Token));
+    }
+
+    [Fact]
+    public async Task LeanProcessWorker_StartupFailureReportsUnderlyingCause()
+    {
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"missing-lean-{Guid.NewGuid():N}.exe");
+        await using LeanProcessWorker worker = new(missingPath);
+
+        LeanInfrastructureException exception =
+            await Assert.ThrowsAsync<LeanInfrastructureException>(
+                () => worker.ParseAsync(
+                    "FROM alpine",
+                    '\\',
+                    CancellationToken.None));
+
+        Assert.Contains("Failed to start Lean CLI", exception.Message, StringComparison.Ordinal);
+        Assert.NotNull(exception.InnerException);
+    }
+
+    [Fact]
+    public void LeanProcessWorker_RequestFailureReportsUnderlyingCause()
+    {
+        TimeoutException timeout = new("The request exceeded 30 seconds.");
+
+        LeanInfrastructureException exception =
+            LeanProcessWorker.CreateRequestFailure(37, timeout);
+
+        Assert.Equal(
+            "Lean batch request 37 failed: TimeoutException: " +
+            "The request exceeded 30 seconds.",
+            exception.Message);
+        Assert.Same(timeout, exception.InnerException);
+    }
+
+    [Fact]
+    public void LeanProcessWorker_ExitedFailureReportsExitCodeAndStderr()
+    {
+        LeanInfrastructureException exception =
+            LeanProcessWorker.CreateExitedException(
+                "Lean batch process closed stdout.",
+                exitCode: -1073741511,
+                stderr: "loader failure");
+
+        Assert.Equal(
+            "Lean batch process closed stdout. Exit code: -1073741511. loader failure",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task FailureMinimizer_CSharpErrorRequiresLeanToAcceptCandidate()
+    {
+        const string input = "FROM --platform= alpine:latest AS build stage";
+        DiffCase testCase = Case("csharp-error", input);
+        DiffTestRunner runner = new(() => new SelectiveParser(input));
+        DiffResult original = await runner.RunSingleAsync(testCase);
+        FailureMinimizer minimizer = new(() => new SelectiveParser(input));
+
+        DiffResult minimized = await minimizer.MinimizeAsync(original);
+
+        Assert.Equal(DiffOutcomeKind.CSharpParseError, original.Outcome);
+        Assert.Equal(original.Outcome, minimized.Outcome);
+        Assert.Equal(input, minimized.Case.Input);
+        Assert.NotEqual("FROM ", minimized.Case.Input);
+    }
+
+    [Fact]
+    public void FailureMinimizer_LineCandidatesPreserveInstructionAndLineEndings()
+    {
+        string[] candidates = FailureMinimizer
+            .GetCandidates("RUN first\r\nbad\r\nthird")
+            .ToArray();
+
+        Assert.NotEmpty(candidates);
+        Assert.All(candidates, candidate =>
+        {
+            Assert.StartsWith("RUN", candidate, StringComparison.Ordinal);
+            Assert.True(char.IsWhiteSpace(candidate[3]));
+            string withoutCrLf = candidate.Replace("\r\n", "");
+            Assert.DoesNotContain('\r', withoutCrLf);
+            Assert.DoesNotContain('\n', withoutCrLf);
+        });
+        Assert.DoesNotContain("RUNbad\r\nthird", candidates);
+    }
+
+    [Fact]
+    public void FailureMinimizer_LargeInputHonorsCandidateBudget()
+    {
+        string input = "RUN " + new string('a', 100_000);
+
+        string[] candidates = FailureMinimizer
+            .GetCandidates(input, maximumCandidates: 10)
+            .ToArray();
+
+        Assert.NotEmpty(candidates);
+        Assert.True(candidates.Length <= 10);
+        Assert.All(candidates, candidate => Assert.True(candidate.Length < input.Length));
+    }
+
+    [Fact]
+    public void FailureMinimizer_RepetitiveInputSamplesBeyondDuplicatePrefixCandidates()
+    {
+        string input =
+            "RUN " + new string('a', 2_000) + "bad" + new string('a', 100_000);
+
+        string[] candidates = FailureMinimizer
+            .GetCandidates(input, maximumCandidates: 10)
+            .ToArray();
+
+        Assert.Contains(
+            candidates,
+            candidate =>
+                candidate.Contains("bad", StringComparison.Ordinal) &&
+                candidate.Length < input.Length);
+    }
+
+    [Fact]
+    public void RegressionCorpus_PromotionIsIdempotentAndLoadIsOrdered()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"DockerfileModel-DiffTest-{Guid.NewGuid():N}");
+
+        try
+        {
+            RegressionCorpus corpus = new(directory);
+            DiffCase from = Case("generated-from", "FROM alpine");
+            DiffCase run = Case("generated-run", "RUN echo hello") with
+            {
+                InstructionType = "RUN"
+            };
+
+            string firstPath = corpus.Promote(run);
+            string secondPath = corpus.Promote(from);
+            Assert.Equal(firstPath, corpus.Promote(run));
+
+            IReadOnlyList<DiffCase> loaded = corpus.Load();
+            Assert.Equal(2, loaded.Count);
+            Assert.Equal(
+                new[] { (Path: firstPath, Input: run.Input), (Path: secondPath, Input: from.Input) }
+                    .OrderBy(item => item.Path, StringComparer.Ordinal)
+                    .Select(item => item.Input),
+                loaded.Select(testCase => testCase.Input));
+            Assert.All(loaded, testCase =>
+            {
+                Assert.Equal(DiffCaseSource.Regression, testCase.Source);
+                Assert.Null(testCase.Generator);
+                Assert.Null(testCase.Seed);
+                Assert.Null(testCase.CaseIndex);
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void RegressionCorpus_MissingRequiredFieldReportsFixturePath()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"DockerfileModel-DiffTest-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "invalid.json");
+        File.WriteAllText(path, """{"id":"invalid","instructionType":"FROM"}""");
+
+        try
+        {
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(
+                () => new RegressionCorpus(directory).Load());
+
+            Assert.Contains(path, exception.Message, StringComparison.Ordinal);
+            Assert.Contains("inputBase64", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RegressionCorpus_RejectsUnsupportedInstructionType()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"DockerfileModel-DiffTest-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "invalid.json");
+        File.WriteAllText(
+            path,
+            """
+            {
+              "id": "invalid",
+              "instructionType": "..\\escaped",
+              "inputBase64": "Qk9HVVMgdmFsdWU=",
+              "escapeCharacter": "\\"
+            }
+            """);
+
+        try
+        {
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(
+                () => new RegressionCorpus(directory).Load());
+
+            Assert.Contains("unsupported instructionType", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RegressionCorpus_PromotionRejectsUnsupportedInstructionType()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"DockerfileModel-DiffTest-{Guid.NewGuid():N}");
+        RegressionCorpus corpus = new(directory);
+        DiffCase testCase = Case("invalid", "BOGUS value") with
+        {
+            InstructionType = "..\\escaped"
+        };
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => corpus.Promote(testCase));
+
+        Assert.Contains("unsupported instruction type", exception.Message, StringComparison.Ordinal);
+        Assert.False(Directory.Exists(directory));
+    }
+
+    private static DiffCase Case(string id, string input) =>
+        new(id, DiffCaseSource.Generated, "FROM", input, '\\', "test", 42, 0);
+
+    private sealed class SharedParserState
+    {
+        private int _active;
+        private int _created;
+        private int _maximumConcurrency;
+
+        public int Created => _created;
+
+        public int MaximumConcurrency => _maximumConcurrency;
+
+        public void CreatedParser() => Interlocked.Increment(ref _created);
+
+        public void Enter()
+        {
+            int active = Interlocked.Increment(ref _active);
+            int maximum;
+            while (active > (maximum = _maximumConcurrency))
+            {
+                if (Interlocked.CompareExchange(
+                    ref _maximumConcurrency,
+                    active,
+                    maximum) == maximum)
+                {
+                    break;
+                }
+            }
+        }
+
+        public void Exit() => Interlocked.Decrement(ref _active);
+    }
+
+    private sealed class FakeParser : ILeanParser
+    {
+        private readonly SharedParserState _state;
+        private readonly TimeSpan _delay;
+
+        public FakeParser(SharedParserState state, TimeSpan? delay = null)
+        {
+            _state = state;
+            _delay = delay ?? TimeSpan.Zero;
+            _state.CreatedParser();
+        }
+
+        public async Task<string> ParseAsync(
+            string input,
+            char escapeChar,
+            CancellationToken cancellationToken)
+        {
+            _state.Enter();
+            try
+            {
+                await Task.Delay(_delay, cancellationToken);
+                if (input.Contains("bad", StringComparison.Ordinal))
+                {
+                    return "{}";
+                }
+
+                string instruction = input.TrimStart().Split(' ', '\t', '\r', '\n')[0];
+                return DiffTestRunner.ParseCSharp(instruction, input, escapeChar);
+            }
+            finally
+            {
+                _state.Exit();
+            }
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RejectingParser : ILeanParser
+    {
+        public Task<string> ParseAsync(
+            string input,
+            char escapeChar,
+            CancellationToken cancellationToken) =>
+            throw new LeanParseException("Rejected by Lean.");
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class CancelingParser : ILeanParser
+    {
+        public Task<string> ParseAsync(
+            string input,
+            char escapeChar,
+            CancellationToken cancellationToken) =>
+            Task.FromCanceled<string>(cancellationToken);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class SelectiveParser : ILeanParser
+    {
+        private readonly string _acceptedInput;
+
+        public SelectiveParser(string acceptedInput)
+        {
+            _acceptedInput = acceptedInput;
+        }
+
+        public Task<string> ParseAsync(
+            string input,
+            char escapeChar,
+            CancellationToken cancellationToken)
+        {
+            if (!string.Equals(input, _acceptedInput, StringComparison.Ordinal))
+            {
+                throw new LeanParseException("Rejected by Lean.");
+            }
+
+            return Task.FromResult("{}");
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Valleysoft.DockerfileModel.Tests/Valleysoft.DockerfileModel.Tests.csproj
+++ b/src/Valleysoft.DockerfileModel.Tests/Valleysoft.DockerfileModel.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Valleysoft.DockerfileModel\Valleysoft.DockerfileModel.csproj" />
+    <ProjectReference Include="..\Valleysoft.DockerfileModel.DiffTest\Valleysoft.DockerfileModel.DiffTest.csproj" />
     <ProjectReference Include="..\Valleysoft.DockerfileModel.TestSupport\Valleysoft.DockerfileModel.TestSupport.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The differential test harness currently starts a Lean process per input and does not retain failures for deterministic replay. This makes sustained fuzzing expensive and leaves newly discovered parser differences difficult to reproduce and reduce.

This change adds:

- A framed batch protocol and bounded pool of persistent Lean parser workers, with stable result ordering and explicit parser-versus-infrastructure error classification.
- Deterministic FsCheck generation metadata, exact base64 replay commands, and category-preserving failure minimization with bounded, sampled candidate generation.
- A checked-in regression corpus that runs before generated cases, plus explicit atomic promotion of minimized failures.
- Fixed-seed pull request coverage and a scheduled workflow using deterministic daily rotating seeds.
- Infrastructure tests covering concurrency, cancellation, protocol failures, replay portability, minimization, and corpus validation.

Validation included the full .NET test suite, the Lean differential CLI build, and multi-worker differential runs against generated inputs.

Fixes: #354