### PR TITLE
Fix RUN mounts with omitted or reordered type entries

### DIFF
--- a/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
+++ b/src/Valleysoft.DockerfileModel.DiffTest/InputGenerator.cs
@@ -161,5 +161,6 @@ public static class InputGenerator
             new("label-hash-value", "LABEL", DockerfileArbitraries.LabelHashInValueInstruction()),
             new("copy-flag-continuation", "COPY", DockerfileArbitraries.CopyFlagLineContinuationInstruction()),
             new("add-flag-continuation", "ADD", DockerfileArbitraries.AddFlagLineContinuationInstruction()),
+            new("run-mount-type-entry", "RUN", DockerfileArbitraries.RunMountTypeEntryInstruction()),
         };
 }

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/onbuild-mount-empty-source.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/onbuild-mount-empty-source.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-onbuild-mount-empty-source",
+  "instructionType": "ONBUILD",
+  "inputBase64": "T05CVUlMRCBSVU4gLS1tb3VudD1zb3VyY2U9LHRhcmdldD0vc3JjIGVjaG8gaGVsbG8=",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/onbuild-mount-type-omitted.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/onbuild-mount-type-omitted.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-onbuild-mount-type-omitted",
+  "instructionType": "ONBUILD",
+  "inputBase64": "T05CVUlMRCBSVU4gLS1tb3VudD1mcm9tPWJ1aWxkLHRhcmdldD0vc3JjIGVjaG8gaGVsbG8=",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/onbuild-mount-type-reordered.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/onbuild-mount-type-reordered.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-onbuild-mount-type-reordered",
+  "instructionType": "ONBUILD",
+  "inputBase64": "T05CVUlMRCBSVU4gLS1tb3VudD1mcm9tPWJ1aWxkLHR5cGU9YmluZCx0YXJnZXQ9L3NyYyBlY2hvIGhlbGxv",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-empty-source.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-empty-source.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-run-mount-empty-source",
+  "instructionType": "RUN",
+  "inputBase64": "UlVOIC0tbW91bnQ9c291cmNlPSx0YXJnZXQ9L3NyYyBlY2hvIGhlbGxv",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-empty-value.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-empty-value.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-run-mount-empty-value",
+  "instructionType": "RUN",
+  "inputBase64": "UlVOIC0tbW91bnQ9IHQgZQ==",
+  "escapeCharacter": "`",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-multiple-types.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-multiple-types.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-run-mount-multiple-types",
+  "instructionType": "RUN",
+  "inputBase64": "UlVOIC0tbW91bnQ9ZnJvbT1idWlsZCx0YXJnZXQ9L3NyYyAtLW1vdW50PXRhcmdldD0vY2FjaGUsdHlwZT1jYWNoZSBlY2hvIGhlbGxv",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-trailing-empty-source.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-trailing-empty-source.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-run-mount-trailing-empty-source",
+  "instructionType": "RUN",
+  "inputBase64": "UlVOIC0tbW91bnQ9dGFyZ2V0PS9zcmMsc291cmNlPSBlY2hvIGhlbGxv",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-type-first.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-type-first.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-run-mount-type-first",
+  "instructionType": "RUN",
+  "inputBase64": "UlVOIC0tbW91bnQ9dHlwZT1iaW5kLGZyb209YnVpbGQsdGFyZ2V0PS9zcmMgZWNobyBoZWxsbw==",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-type-omitted.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-type-omitted.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-run-mount-type-omitted",
+  "instructionType": "RUN",
+  "inputBase64": "UlVOIC0tbW91bnQ9ZnJvbT1idWlsZCx0YXJnZXQ9L3NyYyBlY2hvIGhlbGxv",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-type-reordered.json
+++ b/src/Valleysoft.DockerfileModel.DiffTest/RegressionCorpus/run-mount-type-reordered.json
@@ -1,0 +1,9 @@
+{
+  "id": "issue-375-run-mount-type-reordered",
+  "instructionType": "RUN",
+  "inputBase64": "UlVOIC0tbW91bnQ9ZnJvbT1idWlsZCx0eXBlPWJpbmQsdGFyZ2V0PS9zcmMgZWNobyBoZWxsbw==",
+  "escapeCharacter": "\\",
+  "generator": null,
+  "seed": null,
+  "caseIndex": null
+}

--- a/src/Valleysoft.DockerfileModel.TestSupport/Generators/DockerfileArbitraries.cs
+++ b/src/Valleysoft.DockerfileModel.TestSupport/Generators/DockerfileArbitraries.cs
@@ -367,6 +367,7 @@ public static class DockerfileArbitraries
     /// </summary>
     private static Gen<string> MountSpec() =>
         Gen.OneOf(
+            BindMountSpec(),
             // Bind mount
             from src in PathSegment()
             from tgt in PathSegment()
@@ -374,12 +375,35 @@ public static class DockerfileArbitraries
             // Cache mount
             from tgt in PathSegment()
             select $"type=cache,target=/{tgt}",
+            from tgt in PathSegment()
+            select $"target=/{tgt},type=cache",
             // Secret mount
             from id in Identifier()
             select $"type=secret,id={id}",
             // Tmpfs mount
             from tgt in PathSegment()
             select $"type=tmpfs,target=/{tgt}");
+
+    private static Gen<string> BindMountSpec() =>
+        from source in Gen.Elements("build", "0", "alpine:3.21", "registry.example.com/team/base:latest")
+        from target in PathSegment()
+        from typePosition in Gen.Choose(0, 5)
+        select typePosition switch
+        {
+            0 => $"type=bind,from={source},target=/{target}",
+            1 => $"from={source},type=bind,target=/{target}",
+            2 => $"from={source},target=/{target},type=bind",
+            4 => $"source=,from={source},target=/{target}",
+            5 => $"from={source},target=/{target},source=",
+            _ => $"from={source},target=/{target}"
+        };
+
+    public static Gen<string> RunMountTypeEntryInstruction() =>
+        from bind in BindMountSpec()
+        from target in PathSegment()
+        from whitespace in Gen.Elements(" ", "  ", "\t")
+        from command in Gen.OneOf(ShellCommand(), ExecFormCommand())
+        select $"RUN --mount={bind} --mount=target=/{target},type=cache{whitespace}{command}";
 
     // ──────────────────────────────────────────────
     // Shell-form whitespace variation generators
@@ -713,6 +737,7 @@ public static class DockerfileArbitraries
     /// </summary>
     public static Gen<string> RunInstruction() =>
         Gen.OneOf(
+            RunMountTypeEntryInstruction(),
             // Shell form (simple)
             from cmd in ShellCommand()
             select $"RUN {cmd}",

--- a/src/Valleysoft.DockerfileModel.Tests/DockerfileTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DockerfileTests.cs
@@ -7,6 +7,27 @@ namespace Valleysoft.DockerfileModel.Tests;
 public class DockerfileTests
 {
     [Theory]
+    [InlineData("type=bind,from=build,target=/src")]
+    [InlineData("from=build,type=bind,target=/src")]
+    [InlineData("from=build,target=/src")]
+    public void Parse_RunAndOnBuildMountTypeEntries(string spec)
+    {
+        string text = $"FROM alpine\nRUN --mount={spec} echo hello\nONBUILD RUN --mount={spec} echo hello\n";
+        Dockerfile dockerfile = Dockerfile.Parse(text);
+        RunInstruction run = Assert.Single(dockerfile.Items.OfType<RunInstruction>());
+        RunInstruction trigger = Assert.IsType<RunInstruction>(
+            Assert.Single(dockerfile.Items.OfType<OnBuildInstruction>()).Instruction);
+
+        foreach (RunInstruction instruction in new[] { run, trigger })
+        {
+            Assert.Equal("bind", Assert.Single(instruction.Mounts).Type);
+            Assert.Equal(spec, instruction.Mounts[0].ToString());
+            Assert.Equal("echo hello", Assert.IsType<ShellFormCommand>(instruction.Command).ValueToken.Value);
+        }
+        Assert.Equal(text, dockerfile.ToString());
+    }
+
+    [Theory]
     [InlineData("# escape=`\nFROM scratch", '`')]
     [InlineData("# escape=\\\nFROM scratch", '\\')]
     [InlineData("FROM scratch", '\\')]

--- a/src/Valleysoft.DockerfileModel.Tests/MountTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/MountTests.cs
@@ -7,6 +7,203 @@ namespace Valleysoft.DockerfileModel.Tests;
 public class MountTests
 {
     [Theory]
+    [InlineData("type=bind ,target=/src")]
+    [InlineData("type=bind, target=/src")]
+    [InlineData("type=bind,\ttarget=/src")]
+    [InlineData("from=build , target=/src")]
+    [InlineData("  from=build ,\ttype=bind, target=/src  ")]
+    public void Parse_StandaloneCommaWhitespaceIsPreserved(string text)
+    {
+        Mount mount = Mount.Parse(text);
+
+        Assert.Equal(text, mount.ToString());
+        Assert.Equal(text, Mount.GetParser().End().Parse(text).ToString());
+        Assert.Equal("/src", mount.Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .Single(token => token.Key == "target").Value);
+        Assert.Equal("bind", mount.Type);
+    }
+
+    [Theory]
+    [InlineData("type=bind garbage")]
+    [InlineData("type=bind, target=/src garbage")]
+    [InlineData("type=bind ,target=/src,")]
+    public void Parse_StandaloneUnconsumedTextIsRejected(string text) =>
+        Assert.Throws<ParseException>(() => Mount.Parse(text));
+
+    [Theory]
+    [InlineData("source=,target=/src")]
+    [InlineData("source=,type=bind,target=/src")]
+    [InlineData("type=bind,source=,target=/src")]
+    [InlineData("target=/src,source=")]
+    [InlineData("source=")]
+    [InlineData("source=\\\n,target=/src")]
+    public void Parse_EmptyEntryValue(string text)
+    {
+        Mount mount = Mount.Parse(text);
+        var source = mount.Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .Single(token => token.Key == "source");
+
+        Assert.Equal("", source.Value);
+        Assert.Equal("bind", mount.Type);
+        Assert.Equal(text, mount.ToString());
+
+        source.Value = "/build";
+        Assert.Equal(text.Replace("source=", "source=/build"), mount.ToString());
+        Assert.Equal("/build", Mount.Parse(mount.ToString()).Tokens
+            .OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .Single(token => token.Key == "source").Value);
+    }
+
+    [Theory]
+    [InlineData("source=\"unterminated")]
+    [InlineData("readonly!invalid")]
+    [InlineData("source=,")]
+    [InlineData("source\\\n=\"unterminated")]
+    [InlineData("readonly\\\n!invalid")]
+    public void Parse_IncompleteEntryDoesNotReturnPartialMount(string text) =>
+        Assert.Throws<ParseException>(() => Mount.Parse(text));
+
+    [Theory]
+    [InlineData("type=bind,from=build,target=/src", "bind", true)]
+    [InlineData("from=build,type=bind,target=/src", "bind", true)]
+    [InlineData("from=build,target=/src", "bind", false)]
+    [InlineData("from=build,target=/src,type=cache", "cache", true)]
+    [InlineData("readonly,from=build,target=/src", "bind", false)]
+    public void Parse_TypeEntry(string text, string expectedType, bool hasType)
+    {
+        Mount mount = Mount.Parse(text);
+        Token[] originalTokens = mount.Tokens.ToArray();
+
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.Equal(expectedType, mount.Type);
+            Assert.Equal(hasType, mount.TypeToken is not null);
+            if (hasType)
+            {
+                Assert.Equal("type", mount.TypeToken!.Key);
+            }
+            Assert.Equal(text, mount.ToString());
+            Assert.Equal(originalTokens, mount.Tokens);
+        }
+
+        Assert.Equal("build", mount.Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .Single(token => token.Key == "from").Value);
+        Assert.Equal("/src", mount.Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .Single(token => token.Key == "target").Value);
+
+        MountFlag flag = MountFlag.Parse($"--mount={text}");
+        Assert.Equal(expectedType, flag.ValueToken!.Type);
+        Assert.Equal($"--mount={text}", flag.ToString());
+    }
+
+    [Theory]
+    [InlineData("from=build,type=bind,target=/src", "from=build,type=cache,target=/src")]
+    [InlineData("type=bind,from=build,target=/src", "type=cache,from=build,target=/src")]
+    [InlineData("from=build,target=/src", "type=cache,from=build,target=/src")]
+    [InlineData("readonly,target=/src", "type=cache,readonly,target=/src")]
+    [InlineData("  from=build,target=/src", "  type=cache,from=build,target=/src")]
+    [InlineData("from=build,\\\n# comment\n  target=\"/src\"", "type=cache,from=build,\\\n# comment\n  target=\"/src\"")]
+    [InlineData("from=build,\\\n# comment\n  ty\\\npe=bind,target='/src'", "from=build,\\\n# comment\n  ty\\\npe=cache,target='/src'")]
+    public void TypeMutation(string text, string expected)
+    {
+        Mount mount = Mount.Parse(text);
+        Token[] otherEntries = mount.Tokens.Where(token =>
+            token is KeywordToken ||
+            token is KeyValueToken<KeywordToken, LiteralToken> pair && pair.Key != "type").ToArray();
+
+        mount.Type = "cache";
+
+        Assert.Equal("cache", mount.Type);
+        Assert.Equal(expected, mount.ToString());
+        Assert.Equal("cache", Mount.Parse(mount.ToString()).Type);
+        Assert.All(otherEntries, entry => Assert.Contains(entry, mount.Tokens));
+    }
+
+    [Theory]
+    [InlineData("from=build,type=bind,target=/src", "from=build,type=cache,target=/src")]
+    [InlineData("from=build,target=/src,type=bind", "from=build,target=/src,type=cache")]
+    [InlineData("from=build,target=/src", "type=cache,from=build,target=/src")]
+    public void TypeTokenMutation(string text, string expected)
+    {
+        Mount mount = Mount.Parse(text);
+        var replacement = new KeyValueToken<KeywordToken, LiteralToken>(
+            new KeywordToken("type"), new LiteralToken("cache"));
+
+        mount.TypeToken = replacement;
+
+        Assert.Same(replacement, mount.TypeToken);
+        Assert.Equal("cache", mount.Type);
+        Assert.Equal(expected, mount.ToString());
+        Assert.Equal("cache", Mount.Parse(mount.ToString()).Type);
+    }
+
+    [Fact]
+    public void TypeMutation_ExplicitBindIsInserted()
+    {
+        Mount mount = Mount.Parse("target=/src");
+        mount.Type = "bind";
+        Assert.Equal("type=bind,target=/src", mount.ToString());
+        Assert.NotNull(mount.TypeToken);
+    }
+
+    [Theory]
+    [InlineData("type=bind,target=/src")]
+    [InlineData("target=/src")]
+    public void TypeMutation_RejectsInvalidValues(string text)
+    {
+        Mount mount = Mount.Parse(text);
+        Assert.Throws<ArgumentNullException>(() => mount.Type = null!);
+        Assert.Throws<ArgumentException>(() => mount.Type = "");
+        Assert.Throws<ArgumentNullException>(() => mount.TypeToken = null!);
+        Assert.Equal(text, mount.ToString());
+    }
+
+    [Theory]
+    [InlineData('\\')]
+    [InlineData('`')]
+    public void TypeMutation_PreservesEscapeCharacter(char escapeChar)
+    {
+        Mount mount = Mount.Parse("target=/src", escapeChar);
+        mount.Type = $"ca{escapeChar}\nche";
+
+        Assert.Equal("cache", mount.Type);
+        Assert.Equal($"type=ca{escapeChar}\nche,target=/src", mount.ToString());
+        Assert.Equal("cache", Mount.Parse(mount.ToString(), escapeChar).Type);
+    }
+
+    [Theory]
+    [InlineData('\\')]
+    [InlineData('`')]
+    public void MountFlag_TypeMutationPreservesEscapeCharacter(char escapeChar)
+    {
+        MountFlag flag = MountFlag.Parse($"--mount={escapeChar}\nfrom=build,target=/src", escapeChar);
+        Mount mount = flag.ValueToken!;
+        mount.Type = $"ca{escapeChar}\nche";
+
+        Assert.Equal("cache", mount.Type);
+        Assert.Equal($"--mount={escapeChar}\ntype=ca{escapeChar}\nche,from=build,target=/src", flag.ToString());
+        Assert.Equal("cache", MountFlag.Parse(flag.ToString(), escapeChar).ValueToken!.Type);
+    }
+
+    [Theory]
+    [InlineData("from=build,\\\n# comment\n  target=/src", '\\', "bind")]
+    [InlineData("from=build,`\n# comment\n  target=/src,t`\nype=cache", '`', "cache")]
+    [InlineData("readonly,\\\n  type=bind,target=\"/src\"", '\\', "bind")]
+    [InlineData("target='/src',type=$mountType", '\\', "$mountType")]
+    [InlineData("target=/src,TYPE=cache", '\\', "cache")]
+    public void Parse_TypeEntryFormatting(string text, char escapeChar, string expectedType)
+    {
+        Mount mount = Mount.Parse(text, escapeChar);
+        Assert.Equal(expectedType, mount.Type);
+        Assert.Equal(text, mount.ToString());
+
+        mount.Type = "tmpfs";
+
+        Assert.Equal("tmpfs", mount.Type);
+        Assert.Equal("tmpfs", Mount.Parse(mount.ToString(), escapeChar).Type);
+    }
+
+    [Theory]
     [MemberData(nameof(ParseTestInput))]
     public void Parse(ParseTestScenario<Mount> scenario) =>
         TestHelper.RunParseTest(scenario, Mount.Parse);

--- a/src/Valleysoft.DockerfileModel.Tests/OnBuildInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/OnBuildInstructionTests.cs
@@ -7,6 +7,22 @@ namespace Valleysoft.DockerfileModel.Tests;
 public class OnBuildInstructionTests
 {
     [Theory]
+    [InlineData("type=bind,from=build,target=/src")]
+    [InlineData("from=build,type=bind,target=/src")]
+    [InlineData("from=build,target=/src")]
+    public void Parse_RunMountTypeEntry(string spec)
+    {
+        string text = $"ONBUILD RUN --mount={spec} echo hello";
+        OnBuildInstruction onBuild = OnBuildInstruction.Parse(text);
+        RunInstruction run = Assert.IsType<RunInstruction>(onBuild.Instruction);
+
+        Assert.Equal("bind", Assert.Single(run.Mounts).Type);
+        Assert.Equal(spec, run.Mounts[0].ToString());
+        Assert.Equal("echo hello", run.Command!.ToString());
+        Assert.Equal(text, onBuild.ToString());
+    }
+
+    [Theory]
     [MemberData(nameof(ParseTestInput))]
     public void Parse(ParseTestScenario<OnBuildInstruction> scenario) =>
         TestHelper.RunParseTest(scenario, OnBuildInstruction.Parse);

--- a/src/Valleysoft.DockerfileModel.Tests/PropertyTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/PropertyTests.cs
@@ -58,6 +58,28 @@ public class PropertyTests
     }
 
     [Fact]
+    public void RunMountTypeEntries_AreStructuredAndRoundTrip()
+    {
+        AssertProperty(DockerfileArbitraries.RunMountTypeEntryInstruction(), text =>
+        {
+            RunInstruction run = RunInstruction.Parse(text);
+            OnBuildInstruction onBuild = OnBuildInstruction.Parse($"ONBUILD {text}");
+            RunInstruction trigger = Assert.IsType<RunInstruction>(onBuild.Instruction);
+
+            foreach (RunInstruction instruction in new[] { run, trigger })
+            {
+                Assert.Equal(new[] { "bind", "cache" }, instruction.Mounts.Select(mount => mount.Type));
+                Assert.Equal(2, instruction.Tokens.OfType<MountFlag>().Count());
+                Assert.DoesNotContain("--mount=", instruction.Command!.ToString());
+                Assert.Contains(instruction.Mounts[0].Tokens,
+                    token => token is KeyValueToken<KeywordToken, LiteralToken> pair && pair.Key == "from");
+                Assert.Equal(text, instruction.ToString());
+            }
+            Assert.Equal($"ONBUILD {text}", onBuild.ToString());
+        });
+    }
+
+    [Fact]
     public void CmdInstruction_RoundTrips()
     {
         AssertProperty(DockerfileArbitraries.CmdInstruction(), text =>

--- a/src/Valleysoft.DockerfileModel.Tests/RunInstructionTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/RunInstructionTests.cs
@@ -7,6 +7,141 @@ namespace Valleysoft.DockerfileModel.Tests;
 public class RunInstructionTests
 {
     [Theory]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Parse_MountFlagWhitespaceBeforeCommaEndsFlag(string whitespace)
+    {
+        string text = $"RUN --mount=type=bind{whitespace},target=/src echo hello";
+        RunInstruction run = RunInstruction.Parse(text);
+
+        Assert.Equal("type=bind", Assert.Single(run.Mounts).ToString());
+        Assert.Equal(",target=/src echo hello", run.Command!.ToString());
+        Assert.Equal(text, run.ToString());
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Parse_MountFlagWhitespaceAfterCommaDoesNotConsumeCommand(string whitespace)
+    {
+        string text = $"RUN --mount=type=bind,{whitespace}target=/src echo hello";
+        RunInstruction run = RunInstruction.Parse(text);
+
+        Assert.Empty(run.Mounts);
+        Assert.Equal($"--mount=type=bind,{whitespace}target=/src echo hello", run.Command!.ToString());
+        Assert.Equal(text, run.ToString());
+    }
+
+    [Theory]
+    [InlineData("source=,target=/src")]
+    [InlineData("source=,type=bind,target=/src")]
+    [InlineData("type=bind,source=,target=/src")]
+    [InlineData("target=/src,source=")]
+    [InlineData("source=")]
+    [InlineData("source=\\\n,target=/src")]
+    [InlineData("source=\\\n# comment\n,target=/src")]
+    public void Parse_EmptyMountEntryPreservesCommand(string spec)
+    {
+        string text = $"RUN --mount={spec} echo hello";
+        RunInstruction run = RunInstruction.Parse(text);
+
+        Assert.Equal(spec, Assert.Single(run.Mounts).ToString());
+        Assert.Equal("echo hello", run.Command!.ToString());
+        Assert.Equal(text, run.ToString());
+
+        run.Command = new ShellFormCommand("echo replacement");
+        Assert.Equal($"RUN --mount={spec} echo replacement", run.ToString());
+
+        OnBuildInstruction onBuild = OnBuildInstruction.Parse($"ONBUILD {text}");
+        RunInstruction trigger = Assert.IsType<RunInstruction>(onBuild.Instruction);
+        Assert.Equal(spec, Assert.Single(trigger.Mounts).ToString());
+        Assert.Equal("echo hello", trigger.Command!.ToString());
+        Assert.Equal($"ONBUILD {text}", onBuild.ToString());
+    }
+
+    [Theory]
+    [InlineData("source=\"unterminated")]
+    [InlineData("readonly!invalid")]
+    [InlineData("source=,")]
+    [InlineData("source\\\n=\"unterminated")]
+    [InlineData("readonly\\\n!invalid")]
+    public void Parse_IncompleteMountDoesNotSplitCommand(string spec)
+    {
+        string text = $"RUN --mount={spec} echo hello";
+        RunInstruction run = RunInstruction.Parse(text);
+
+        Assert.Empty(run.Mounts);
+        Assert.Equal($"--mount={spec} echo hello", run.Command!.ToString());
+        Assert.Equal(text, run.ToString());
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Parse_EmptyMountDoesNotConsumeCommand(string whitespace)
+    {
+        string text = $"RUN --mount={whitespace}apt-get update";
+        RunInstruction run = RunInstruction.Parse(text);
+
+        Assert.Empty(run.Mounts);
+        Assert.Equal($"--mount={whitespace}apt-get update", run.Command!.ToString());
+        Assert.Equal(text, run.ToString());
+        Assert.Throws<ParseException>(() => MountFlag.Parse($"--mount={whitespace}apt-get"));
+    }
+
+    [Theory]
+    [InlineData("type=bind,from=build,target=/src")]
+    [InlineData("from=build,type=bind,target=/src")]
+    [InlineData("from=build,target=/src")]
+    [InlineData("from=build,target=/src,type=bind")]
+    public void Parse_MountTypeEntry(string spec)
+    {
+        string text = $"RUN --mount={spec} echo hello";
+        RunInstruction run = RunInstruction.Parse(text);
+
+        Mount mount = Assert.Single(run.Mounts);
+        Assert.Equal("bind", mount.Type);
+        Assert.Equal(spec, mount.ToString());
+        Assert.Equal("echo hello", run.Command!.ToString());
+        Assert.Equal(text, run.ToString());
+    }
+
+    [Theory]
+    [InlineData("echo hello")]
+    [InlineData("[\"echo\", \"hello\"]")]
+    public void Parse_MultipleMountTypeEntries(string command)
+    {
+        string text = $"RUN --mount=from=build,target=/src --mount=target=/cache,type=cache\t{command}";
+        RunInstruction run = RunInstruction.Parse(text);
+
+        Assert.Equal(new[] { "bind", "cache" }, run.Mounts.Select(mount => mount.Type));
+        Assert.Equal(command, run.Command!.ToString());
+        Assert.Equal("target=/cache,type=cache", run.Mounts[1].ToString());
+        Assert.Equal(text, run.ToString());
+
+        run.Mounts[0].Type = "cache";
+        run.Mounts[1].Type = "bind";
+        Assert.Equal(
+            $"RUN --mount=type=cache,from=build,target=/src --mount=target=/cache,type=bind\t{command}",
+            run.ToString());
+    }
+
+    [Theory]
+    [InlineData('\\')]
+    [InlineData('`')]
+    public void Parse_MountTypeEntryContinuations(char escapeChar)
+    {
+        string spec = $"from=build,{escapeChar}\n# comment\n  target=/src,t{escapeChar}\nype=cache";
+        string text = $"RUN --mount={spec} echo hello";
+        RunInstruction run = RunInstruction.Parse(text, escapeChar);
+
+        Assert.Equal("cache", Assert.Single(run.Mounts).Type);
+        Assert.Equal(spec, run.Mounts[0].ToString());
+        Assert.Equal("echo hello", run.Command!.ToString());
+        Assert.Equal(text, run.ToString());
+    }
+
+    [Theory]
     [MemberData(nameof(ParseTestInput))]
     public void Parse(ParseTestScenario<RunInstruction> scenario) =>
         TestHelper.RunParseTest(scenario, RunInstruction.Parse);

--- a/src/Valleysoft.DockerfileModel.Tests/TokenBuilderTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/TokenBuilderTests.cs
@@ -6,6 +6,54 @@ namespace Valleysoft.DockerfileModel.Tests;
 
 public class TokenBuilderTests
 {
+    [Theory]
+    [InlineData("type=bind ,target=/src")]
+    [InlineData("type=bind, target=/src")]
+    [InlineData("type=bind,\ttarget=/src")]
+    [InlineData("from=build , target=/src")]
+    public void MountString_PreservesCommaWhitespaceAndEntries(string text)
+    {
+        TokenBuilder builder = new();
+        builder.Mount(text);
+        Mount mount = Assert.IsType<Mount>(Assert.Single(builder.Tokens));
+
+        Assert.Equal(text, builder.ToString());
+        Assert.Equal("/src", mount.Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .Single(token => token.Key == "target").Value);
+        mount.Type = "cache";
+        Assert.Equal("/src", Mount.Parse(builder.ToString()).Tokens
+            .OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .Single(token => token.Key == "target").Value);
+    }
+
+    [Fact]
+    public void MountString_RejectsUnconsumedText()
+    {
+        TokenBuilder builder = new();
+        Assert.Throws<ParseException>(() => builder.Mount("type=bind garbage"));
+        Assert.Empty(builder.Tokens);
+    }
+
+    [Theory]
+    [InlineData('\\')]
+    [InlineData('`')]
+    public void MountAction_TypeInsertionPreservesEscapeCharacter(char escapeChar)
+    {
+        TokenBuilder builder = new() { EscapeChar = escapeChar };
+        builder.Mount(mount => mount.KeyValue(new KeywordToken("target"), new LiteralToken("/src")));
+        Mount result = Assert.IsType<Mount>(Assert.Single(builder.Tokens));
+
+        result.Type = $"ca{escapeChar}\nche";
+
+        Assert.Equal("cache", result.Type);
+        Assert.Equal($"type=ca{escapeChar}\nche,target=/src", builder.ToString());
+        Assert.Collection(result.TypeToken!.ValueToken!.Tokens,
+            token => ValidateString(token, "ca"),
+            token => ValidateLineContinuation(token, escapeChar, "\n"),
+            token => ValidateString(token, "che"));
+        Assert.Equal(result.Type, Mount.Parse(result.ToString(), escapeChar).Type);
+    }
+
     [Fact]
     public void BuildAllTokens()
     {

--- a/src/Valleysoft.DockerfileModel.Tests/TokenJsonSerializerTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/TokenJsonSerializerTests.cs
@@ -10,6 +10,40 @@ namespace Valleysoft.DockerfileModel.Tests;
 /// </summary>
 public class TokenJsonSerializerTests
 {
+    [Theory]
+    [InlineData("type=bind,from=build,target=/src", false)]
+    [InlineData("from=build,type=bind,target=/src", false)]
+    [InlineData("from=build,target=/src", false)]
+    [InlineData("type=bind,from=build,target=/src", true)]
+    [InlineData("from=build,type=bind,target=/src", true)]
+    [InlineData("from=build,target=/src", true)]
+    public void MountTypeEntries_SerializeAsOpaqueValues(string spec, bool onBuild)
+    {
+        string prefix = onBuild ? "ONBUILD " : "";
+        string json = InstructionSerializer.ParseCSharp(
+            onBuild ? "ONBUILD" : "RUN", $"{prefix}RUN --mount={spec} echo hello", '\\');
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement instruction = document.RootElement;
+        if (onBuild)
+        {
+            instruction = instruction.GetProperty("children").EnumerateArray()
+                .Single(child => child.GetProperty("kind").GetString() == "instruction");
+        }
+
+        JsonElement mountFlag = instruction.GetProperty("children").EnumerateArray()
+            .Single(child => child.GetProperty("kind").GetString() == "keyValue");
+        JsonElement mountValue = mountFlag.GetProperty("children").EnumerateArray().Last();
+        Assert.Equal("literal", mountValue.GetProperty("kind").GetString());
+        JsonElement value = Assert.Single(mountValue.GetProperty("children").EnumerateArray());
+        Assert.Equal("string", value.GetProperty("kind").GetString());
+        Assert.Equal(spec, value.GetProperty("value").GetString());
+
+        JsonElement command = instruction.GetProperty("children").EnumerateArray()
+            .Single(child => child.GetProperty("kind").GetString() == "literal");
+        Assert.Equal("echo hello",
+            Assert.Single(command.GetProperty("children").EnumerateArray()).GetProperty("value").GetString());
+    }
+
     /// <summary>
     /// Shell form commands with whitespace before a line continuation must NOT
     /// split the trailing whitespace into a separate whitespace token. Instead,

--- a/src/Valleysoft.DockerfileModel/Mount.cs
+++ b/src/Valleysoft.DockerfileModel/Mount.cs
@@ -6,90 +6,160 @@ namespace Valleysoft.DockerfileModel;
 /// <summary>
 /// Represents a mount specification for RUN --mount flags.
 /// Handles all BuildKit mount types (bind, cache, tmpfs, secret, ssh) by parsing
-/// the mount value as a type=X prefix followed by zero or more comma-separated entries,
+/// the mount value as comma-separated entries,
 /// where each entry is either a key=value pair or a bare keyword (e.g., required, readonly).
+/// Key/value entries may have an empty value.
+/// The type entry may appear anywhere; an omitted type defaults to bind without adding text.
 /// </summary>
 public class Mount : AggregateToken
 {
-    internal Mount(IEnumerable<Token> tokens) : base(tokens)
+    private readonly char escapeChar;
+
+    internal Mount(IEnumerable<Token> tokens, char escapeChar = Dockerfile.DefaultEscapeChar) : base(tokens)
     {
+        this.escapeChar = escapeChar;
     }
 
+    /// <summary>
+    /// Gets the explicit type or "bind" if omitted. Setting this property inserts an explicit
+    /// type entry when absent; reading it does not change the mount text.
+    /// </summary>
     public string Type
     {
-        get => TypeToken.Value;
+        get => TypeToken?.Value ?? "bind";
         set
         {
             Guard.NotNullOrEmpty(value, nameof(value));
-            var valueToken = TypeToken.ValueToken
-                ?? throw new InvalidOperationException("Mount.TypeToken.ValueToken cannot be null when setting Mount.Type.");
-            valueToken.Value = value;
+            var typeToken = TypeToken;
+            if (typeToken is null)
+            {
+                TypeToken = new KeyValueToken<KeywordToken, LiteralToken>(
+                    new KeywordToken("type", escapeChar),
+                    new LiteralToken(value, canContainVariables: true, escapeChar),
+                    isFlag: false, escapeChar: escapeChar);
+            }
+            else
+            {
+                var valueToken = typeToken.ValueToken
+                    ?? throw new InvalidOperationException("Mount.TypeToken.ValueToken cannot be null when setting Mount.Type.");
+                valueToken.Value = value;
+            }
         }
     }
 
-    public KeyValueToken<KeywordToken, LiteralToken> TypeToken
+    /// <summary>
+    /// Gets the explicit type entry, or null if omitted. Setting a non-null token replaces
+    /// the existing entry or inserts it before the first entry. The setter rejects null.
+    /// </summary>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.DisallowNull]
+#endif
+    public KeyValueToken<KeywordToken, LiteralToken>? TypeToken
     {
-        get => Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>().First();
+        get => Tokens.OfType<KeyValueToken<KeywordToken, LiteralToken>>()
+            .FirstOrDefault(token => string.Equals(token.Key, "type", StringComparison.OrdinalIgnoreCase));
         set
         {
-            Guard.NotNull(value, nameof(value));
-            SetToken(TypeToken, value);
+            Guard.NotNull(value!, nameof(value));
+            SetToken(TypeToken, value, addToken: token =>
+            {
+                int entryIndex = TokenList.FindIndex(entry =>
+                    entry is KeyValueToken<KeywordToken, LiteralToken> or KeywordToken);
+                TokenList.InsertRange(entryIndex, new Token[] { token, new SymbolToken(',') });
+            });
         }
     }
 
+    /// <summary>
+    /// Parses a complete mount specification, preserving whitespace around entries.
+    /// Unlike a RUN flag parser, this method rejects unconsumed trailing text.
+    /// </summary>
     public static Mount Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-        new(GetTokens(text, GetInnerParser(escapeChar)));
+        new(GetTokens(text, GetInnerParser(escapeChar, isFlagValue: false).End()), escapeChar);
 
     public static Parser<Mount> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-        from tokens in GetInnerParser(escapeChar)
-        select new Mount(tokens);
+        GetParser(escapeChar, isFlagValue: false);
 
-    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar)
+    internal static Parser<Mount> GetParser(char escapeChar, bool isFlagValue) =>
+        from tokens in GetInnerParser(escapeChar, isFlagValue)
+        select new Mount(tokens, escapeChar);
+
+    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, bool isFlagValue)
     {
+        Parser<bool> wordBoundary = Sprache.Parse.WhiteSpace.Select(_ => true)
+            .Or(Sprache.Parse.Return(true).End());
+        Parser<IEnumerable<Token>> continuationTrivia =
+            from continuations in LineContinuations(escapeChar)
+            from comments in continuations.Any()
+                ? CommentText().Many().Flatten()
+                : Sprache.Parse.Return(Enumerable.Empty<Token>())
+            select ConcatTokens(continuations, comments);
+        Parser<LiteralToken> emptyValueParser =
+            from boundary in (
+                from trivia in continuationTrivia
+                from end in Sprache.Parse.Char(',').Select(_ => true).Or(wordBoundary)
+                select end).Preview()
+            where boundary.IsDefined
+            select new LiteralToken("", canContainVariables: true, escapeChar);
+
         Parser<LiteralToken> valueParser = LiteralWithVariables(
             escapeChar, new char[] { ',' });
 
+        // Check empty values before the whitespace-tolerant parser, so "source= echo"
+        // leaves the command untouched while nonempty values retain their continuation tokens.
         Parser<KeyValueToken<KeywordToken, LiteralToken>> keyValueParser =
             KeyValueToken<KeywordToken, LiteralToken>.GetParser(
-                KeywordToken.GetParser(escapeChar), valueParser, escapeChar: escapeChar);
+                KeywordToken.GetParser(escapeChar), emptyValueParser, escapeChar: escapeChar,
+                excludeLeadingWhitespaceInValue: true, excludeTrailingWhitespaceInSeparator: true)
+            .Or(KeyValueToken<KeywordToken, LiteralToken>.GetParser(
+                KeywordToken.GetParser(escapeChar), valueParser, escapeChar: escapeChar));
 
-        // Each comma-separated entry is either a key=value pair or a bare keyword (e.g. "required", "readonly").
-        // Note: .Or() is correct here, not .XOr(). In Sprache, .Or() always backtracks to the original
-        // input position when the first parser fails, even if it consumed input. When the keyValueParser
-        // consumes a keyword like "required" but then fails on the missing '=', .Or() retries from the
-        // original position so the bare KeywordToken parser can succeed. Using .XOr() would break this
-        // because it does NOT backtrack when input has been consumed (committed choice).
+        Parser<Token> bareKeyParser =
+            from keyword in KeywordToken.GetParser(escapeChar)
+            from noSeparator in (
+                from continuations in LineContinuations(escapeChar)
+                from separator in Symbol('=')
+                select separator).Not()
+            select (Token)keyword;
+
+        // Backtrack for bare keys, but not for a key whose '=' value failed to parse.
         Parser<Token> entryParser =
             keyValueParser.Cast<KeyValueToken<KeywordToken, LiteralToken>, Token>()
-            .Or(KeywordToken.GetParser(escapeChar).Cast<KeywordToken, Token>());
+            .Or(bareKeyParser);
 
-        // Parse: type=X followed by zero or more comma-separated entries.
         // Line continuations can appear between comma-separated pairs.
         // Whitespace() after each LineContinuations() handles indentation that may
         // appear on the next line after a line continuation (e.g., "type=bind,\\\n  readonly").
         // CommentText() handles comment lines that can appear after line continuations
         // (e.g., "type=bind,\\\n# comment\nreadonly").
         //
-        // excludeTrailingWhitespace: true is required so that trailing whitespace after the
-        // last mount key-value pair is NOT absorbed into the mount token. BuildKit stops
-        // accumulating a flag word when it hits whitespace, so "type=ssh " has value "type=ssh"
-        // and the trailing space must remain a separate token at the instruction level.
+        // Entries leave trailing whitespace for the surrounding context. RUN flags leave it
+        // at instruction level; standalone mounts retain it after all entries are parsed.
         return
-            from type in ArgTokens(
-                KeyValueToken<KeywordToken, LiteralToken>.GetParser(
-                    KeywordToken.GetParser("type", escapeChar), valueParser, escapeChar: escapeChar).AsEnumerable(), escapeChar,
+            from first in ArgTokens(
+                entryParser.AsEnumerable(), escapeChar,
                 excludeTrailingWhitespace: true)
             from rest in (
                 from lineCont1 in LineContinuations(escapeChar)
                 from comments1 in CommentText().Many()
                 from ws1 in Whitespace()
+                where !isFlagValue || !ws1.Any() || lineCont1.Any()
                 from comma in Symbol(',')
                 from wsAfterComma in Whitespace()
                 from lineCont2 in LineContinuations(escapeChar)
+                where !isFlagValue || !wsAfterComma.Any() || lineCont2.Any()
                 from comments2 in CommentText().Many()
                 from ws2 in Whitespace()
                 from entry in entryParser
                 select ConcatTokens(lineCont1, comments1.SelectMany(c => c), ws1, new Token[] { comma }, wsAfterComma, lineCont2, comments2.SelectMany(c => c), ws2, new Token[] { entry })).Many()
-            select ConcatTokens(type, rest.SelectMany(t => t));
+            from boundary in (
+                from trivia in continuationTrivia
+                from end in wordBoundary
+                select end).Preview()
+            where boundary.IsDefined
+            from trailingWhitespace in isFlagValue
+                ? Sprache.Parse.Return(Enumerable.Empty<Token>())
+                : ArgTrailingWhitespace(escapeChar)
+            select ConcatTokens(first, rest.SelectMany(t => t), trailingWhitespace);
     }
 }

--- a/src/Valleysoft.DockerfileModel/MountFlag.cs
+++ b/src/Valleysoft.DockerfileModel/MountFlag.cs
@@ -15,22 +15,21 @@ public class MountFlag : KeyValueToken<KeywordToken, Mount>
     }
 
     public static MountFlag Parse(string text, char escapeChar = Dockerfile.DefaultEscapeChar) =>
-        Parse(
-            text,
-            KeywordToken.GetParser("mount", escapeChar),
-            MountParser(escapeChar),
-            tokens => new MountFlag(tokens),
-            escapeChar: escapeChar,
-            isFlag: true);
+        GetParser(escapeChar).Parse(text);
 
     public static Parser<MountFlag> GetParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
         GetParser(
             KeywordToken.GetParser("mount", escapeChar),
             MountParser(escapeChar),
-            tokens => new MountFlag(tokens),
+            tokens => new MountFlag(tokens, escapeChar),
             escapeChar: escapeChar,
-            isFlag: true);
+            isFlag: true)
+        // Whitespace after '=' ends the flag word; it must not let an empty mount
+        // consume the first word of the shell command as a bare mount entry.
+        .Where(flag => !flag.Tokens
+            .After(flag.Tokens.OfType<SymbolToken>().Last())
+            .OfType<WhitespaceToken>().Any());
 
     private static Parser<Mount> MountParser(char escapeChar) =>
-        Mount.GetParser(escapeChar);
+        Mount.GetParser(escapeChar, isFlagValue: true);
 }

--- a/src/Valleysoft.DockerfileModel/Tokens/TokenBuilder.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/TokenBuilder.cs
@@ -92,7 +92,7 @@ public class TokenBuilder
         AddToken(DockerfileModel.Mount.Parse(text, EscapeChar));
 
     public TokenBuilder Mount(Action<TokenBuilder> configureBuilder) =>
-        AddToken(new DockerfileModel.Mount(GetTokens(configureBuilder)));
+        AddToken(new DockerfileModel.Mount(GetTokens(configureBuilder), EscapeChar));
 
     public TokenBuilder ShellFormCommand(string command) =>
         AddToken(new ShellFormCommand(command, EscapeChar));


### PR DESCRIPTION
Valid RUN mount flags with an omitted or non-leading `type` entry were being treated as shell-command text instead of appearing in `RunInstruction.Mounts`. This fixes the parser/model prerequisite for the dependency analysis in #348 without adding that analysis API.

## Changes

- Recognize omitted and reordered types through Mount, RUN, Dockerfile, and ONBUILD parsing. Reading an omitted type returns `bind` without inserting text.
- Locate the actual type entry for mutations, inserting it only when explicitly assigned. Preserve the configured escape character through token builders.
- Support empty mount entry values and prevent incomplete flags from consuming command text. Keep standalone mount parsing whitespace-tolerant and require complete input consumption, while retaining stricter RUN flag boundaries.
- Add structural, mutation, round-trip, generator, and differential regression coverage. The Lean oracle remains unchanged.

## Compatibility

`TypeToken` now returns null when the type entry is absent; its setter still rejects null. Existing explicit-type inputs retain their runtime behavior, but nullable-enabled callers may receive new warnings when dereferencing `TypeToken`.

## Validation

- All 1,560 unit/property tests pass.
- Both production target frameworks build without warnings or errors.
- All 11 regression fixtures and 10,000 generated cases (seed 42) match the unchanged Lean oracle.

Fixes: #375