### PR TITLE
Add tolerant parsing, diagnostics, and source spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ This .NET library provides a structured model of the Dockerfile syntax for the p
 * Full fidelity for input and output: the model's output is identical to the Dockerfile input.
 * Resolve ARG values that are referenced throughout a Dockerfile.
 * Ability to further organize a Dockerfile model in terms of its stages.
+* Opt-in recovery with structured diagnostics, opaque unknown instructions, and original-source spans.
 
 ## Usage
 
 The library is available as a NuGet package: [Valleysoft.DockerfileModel](https://www.nuget.org/packages/Valleysoft.DockerfileModel/).
 
 For code examples, check out the [scenario tests](https://github.com/mthalman/DockerfileModel/blob/main/src/Valleysoft.DockerfileModel.Tests/ScenarioTests.cs) which demonstrate how the API can be used for various scenarios.
+
+See [Parsing, recovery, and diagnostics](docs/parsing.md) for parse options, recovery behavior, diagnostic codes, and source locations.

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -1,0 +1,113 @@
+# Parsing, recovery, and diagnostics
+
+## Parse with diagnostics
+
+`Dockerfile.Parse(text)` retains its existing throwing behavior. Use `TryParse` to
+receive syntax errors as data instead:
+
+```csharp
+DockerfileParseResult result = Dockerfile.TryParse(text);
+if (!result.Success)
+{
+    foreach (DockerfileDiagnostic diagnostic in result.Diagnostics)
+    {
+        Console.WriteLine(
+            $"{diagnostic.Code}: {diagnostic.Message} " +
+            $"({diagnostic.SourceSpan.Start.Line},{diagnostic.SourceSpan.Start.Column})");
+    }
+}
+```
+
+`TryParse` defaults to `DockerfileParseMode.Strict`: it stops at the first error
+and returns a null `Dockerfile`. Null input and invalid option enum values are
+argument errors, not syntax diagnostics. An empty input produces an empty model
+with `Success == true`.
+
+## Recover malformed and unknown instructions
+
+Enable recovery to inspect valid instructions around malformed regions:
+
+```csharp
+string text = "FROM scratch\nFUTURE-COPY source target\nFROM\nRUN echo ready\n";
+DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions
+{
+    Mode = DockerfileParseMode.Recover,
+    UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+});
+
+Dockerfile model = result.Dockerfile!;
+bool roundTrips = model.ToString() == text; // true
+UnknownInstruction unknown = model.Items.OfType<UnknownInstruction>().Single();
+MalformedConstruct malformed = model.Items.OfType<MalformedConstruct>().Single();
+RunInstruction run = model.Items.OfType<RunInstruction>().Single();
+```
+
+Recovery returns a model even for wholly malformed input. `MalformedConstruct`
+retains the failed region verbatim and is **not** an `Instruction`.
+`UnknownInstruction` derives from `GenericInstruction`, but its arguments are
+opaque: they are not validated or expanded by variable resolution. Its
+`ArgLines` exposes the raw argument suffix, including whitespace and newlines.
+The existing `GenericInstruction.Parse` and constructors still accept only
+known instruction names.
+
+Unknown-instruction handling is independent of recovery:
+
+| Mode | Unknown behavior | Unknown instruction | Malformed known instruction |
+| --- | --- | --- | --- |
+| Strict | Error (default) | Error, no model | Error, no model |
+| Strict | Preserve | Opaque instruction and warning | Error, no model |
+| Recover | Error (default) | Malformed construct and error | Malformed construct and error |
+| Recover | Preserve | Opaque instruction and warning | Malformed construct and error |
+
+`Success` means there are no error-level diagnostics; warnings do not make it
+false. Diagnostics are read-only and ordered by source location. Parsing does
+not perform semantic, capability, or best-practice validation.
+
+Recovery boundaries account for line continuations, the active escape
+directive, comments in continued instructions, quoted text, and supported
+heredocs. A missing heredoc terminator retains everything through EOF as one
+malformed construct; instruction-looking lines inside its body cannot safely
+be treated as later instructions. Unlike legacy `Parse`, `TryParse` reports
+unterminated heredocs as errors. It also requires complete, lossless construct
+parsing and rejects malformed escape directives rather than applying an unsafe
+escape value. Recovery does not infer arbitrary custom frontend grammar:
+unknown instructions use standard Dockerfile continuation boundaries, not
+custom heredoc rules.
+
+Heredoc delimiter names use shell quoting and backslash rules independently of
+the Dockerfile escape directive. `#` can be part of a delimiter name. Continued
+heredoc operators and delimiters retain their original text while exposing
+their logical name and chomp behavior.
+An unquoted terminal backslash stays in the original marker text but is omitted
+from the decoded delimiter name. A delimiter that decodes to an empty string,
+including an empty quoted string, does not open a heredoc.
+
+## Source locations and diagnostic codes
+
+Both full-Dockerfile parse APIs populate `DockerfileConstruct.SourceSpan`.
+Standalone instruction parsers and programmatically created constructs leave
+it null. A span describes the **original input**, including the construct's
+whitespace and newline. Editing or reordering the model does not update spans;
+reparse the edited text to obtain new locations. Tokens do not have spans.
+
+`SourceSpan.Start` is inclusive and `End` is exclusive. Positions contain a
+zero-based UTF-16 `Offset` and one-based `Line` and `Column`. Tabs count as one
+column, as does each UTF-16 code unit. LF and CRLF each advance one line; a lone
+CR counts as a column character, not a line boundary. For an unchanged construct:
+
+```csharp
+SourceSpan span = run.SourceSpan!.Value;
+string original = text.Substring(span.Start.Offset, span.Length);
+```
+
+Diagnostic spans identify the offending keyword, failure position, or region
+when a narrower location is unavailable. EOF failures can have zero-length
+spans. Code strings and their named constants in `DockerfileDiagnosticCodes`
+are stable; message wording is not a machine-readable contract.
+
+| Code | Constant | Meaning |
+| --- | --- | --- |
+| DFP001 | InvalidSyntax | Invalid syntax or a construct that cannot be parsed without losing text |
+| DFP002 | UnknownInstruction | Unknown name; a warning when preserved, otherwise an error |
+| DFP003 | UnterminatedHeredoc | An opening heredoc marker has no terminator before EOF |
+| DFP004 | InvalidParserDirective | A malformed initial directive or invalid escape value |

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -1,6 +1,6 @@
 # Parsing, recovery, and diagnostics
 
-## Parse with diagnostics
+## Parse results
 
 `Dockerfile.Parse(text)` retains its existing throwing behavior. Use `TryParse` to
 receive syntax errors as data instead:
@@ -23,9 +23,19 @@ and returns a null `Dockerfile`. Null input and invalid option enum values are
 argument errors, not syntax diagnostics. An empty input produces an empty model
 with `Success == true`.
 
-## Recover malformed and unknown instructions
+`Success` means there are no error-level diagnostics, not that a model is
+available. Warnings do not make `Success` false. Diagnostics are read-only and
+ordered by source location. Parsing does not perform semantic, capability, or
+best-practice validation.
 
-Enable recovery to inspect valid instructions around malformed regions:
+## Recovery and unknown-instruction options
+
+Enable recovery to inspect valid instructions around malformed regions. In
+recovery mode, `result.Dockerfile` is non-null even when `result.Success` is
+false, including for wholly malformed input.
+
+In this example, `result.Success` is false because `FROM` has no argument, but
+the recovered model preserves the entire input:
 
 ```csharp
 string text = "FROM scratch\nFUTURE-COPY source target\nFROM\nRUN echo ready\n";
@@ -42,8 +52,8 @@ MalformedConstruct malformed = model.Items.OfType<MalformedConstruct>().Single()
 RunInstruction run = model.Items.OfType<RunInstruction>().Single();
 ```
 
-Recovery returns a model even for wholly malformed input. `MalformedConstruct`
-retains the failed region verbatim and is **not** an `Instruction`.
+`MalformedConstruct` retains the failed region verbatim and is **not** an
+`Instruction`.
 `UnknownInstruction` derives from `GenericInstruction`, but its arguments are
 opaque: they are not validated or expanded by variable resolution. Its
 `ArgLines` exposes the raw argument suffix, including whitespace and newlines.
@@ -59,13 +69,14 @@ Unknown-instruction handling is independent of recovery:
 | Recover | Error (default) | Malformed construct and error | Malformed construct and error |
 | Recover | Preserve | Opaque instruction and warning | Malformed construct and error |
 
-`Success` means there are no error-level diagnostics; warnings do not make it
-false. Diagnostics are read-only and ordered by source location. Parsing does
-not perform semantic, capability, or best-practice validation.
+## Recovery boundaries and heredocs
 
 Recovery boundaries account for line continuations, the active escape
-directive, comments in continued instructions, quoted text, and supported
-heredocs. A missing heredoc terminator retains everything through EOF as one
+directive, comments in continued instructions, quoted text, and heredocs.
+`TryParse` recognizes heredocs in `RUN`, `COPY`, and `ADD`, including their
+`ONBUILD` forms.
+
+A missing heredoc terminator retains everything through EOF as one
 malformed construct; instruction-looking lines inside its body cannot safely
 be treated as later instructions. Unlike legacy `Parse`, `TryParse` reports
 unterminated heredocs as errors. It also requires complete, lossless construct
@@ -75,20 +86,27 @@ unknown instructions use standard Dockerfile continuation boundaries, not
 custom heredoc rules.
 
 Heredoc delimiter names use shell quoting and backslash rules independently of
-the Dockerfile escape directive. `#` can be part of a delimiter name. Continued
-heredoc operators and delimiters retain their original text while exposing
-their logical name and chomp behavior.
-An unquoted terminal backslash stays in the original marker text but is omitted
+the Dockerfile escape directive. `#` can be part of a delimiter name. A delimiter
+containing `<` does not open a heredoc, even when that character is quoted or
+escaped.
+
+Continued heredoc operators and delimiters retain their original text while
+exposing their logical name and leading-tab stripping (`<<-`) behavior. An
+unquoted terminal backslash stays in the original marker text but is omitted
 from the decoded delimiter name. A delimiter that decodes to an empty string,
 including an empty quoted string, does not open a heredoc.
 
-## Source locations and diagnostic codes
+## Source locations
 
-Both full-Dockerfile parse APIs populate `DockerfileConstruct.SourceSpan`.
-Standalone instruction parsers and programmatically created constructs leave
-it null. A span describes the **original input**, including the construct's
-whitespace and newline. Editing or reordering the model does not update spans;
-reparse the edited text to obtain new locations. Tokens do not have spans.
+`Dockerfile.Parse` and `Dockerfile.TryParse` populate
+`DockerfileConstruct.SourceSpan` on top-level constructs in `Dockerfile.Items`.
+Nested instructions, such as the instruction wrapped by `ONBUILD`, have no span.
+Standalone instruction parsers and programmatically created constructs also
+leave `SourceSpan` null.
+
+A span describes the **original input**, including the construct's whitespace
+and newline. Editing or reordering the model does not update spans; reparse the
+edited text to obtain new locations. Tokens do not have spans.
 
 `SourceSpan.Start` is inclusive and `End` is exclusive. Positions contain a
 zero-based UTF-16 `Offset` and one-based `Line` and `Column`. Tabs count as one
@@ -99,6 +117,8 @@ CR counts as a column character, not a line boundary. For an unchanged construct
 SourceSpan span = run.SourceSpan!.Value;
 string original = text.Substring(span.Start.Offset, span.Length);
 ```
+
+## Diagnostic codes
 
 Diagnostic spans identify the offending keyword, failure position, or region
 when a narrower location is unavailable. EOF failures can have zero-length

--- a/src/Valleysoft.DockerfileModel.Tests/ConstructReaderTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ConstructReaderTests.cs
@@ -41,6 +41,37 @@ public class ConstructReaderTests
     }
 
     [Theory]
+    [InlineData('\\', 1)]
+    [InlineData('\\', 2)]
+    [InlineData('\\', 3)]
+    [InlineData('`', 1)]
+    [InlineData('`', 2)]
+    [InlineData('`', 3)]
+    public void RepeatedEscapesFollowBuildKitContinuationBoundaries(char escapeChar, int count)
+    {
+        foreach (string newline in new[] { "\n", "\r\n" })
+        {
+            string suffix = new string(escapeChar, count) + " \t" + newline;
+            string nextLine = "RUN echo next" + newline;
+            string header = "RUN echo ready " + suffix;
+            ConstructReader.Region ordinary = ConstructReader.Read(
+                header + nextLine + "FROM scratch" + newline, 0, escapeChar);
+            Assert.Equal(header.Length + (count == 1 ? nextLine.Length : 0), ordinary.End);
+            Assert.Null(ordinary.UnterminatedMarker);
+
+            header = "RUN <<EOF " + suffix;
+            string regionText = header + nextLine + "body" + newline + "EOF" + newline;
+            ConstructReader.Region region = ConstructReader.Read(
+                regionText + "FROM scratch" + newline, 0, escapeChar);
+            int expectedHeaderEnd = header.Length + (count == 1 ? nextLine.Length : 0);
+            Assert.Equal(expectedHeaderEnd, region.HeaderEnd);
+            Assert.Equal(expectedHeaderEnd, Assert.Single(region.Heredocs).BodyStart);
+            Assert.Equal(regionText.Length, region.End);
+            Assert.Null(region.UnterminatedMarker);
+        }
+    }
+
+    [Theory]
     [InlineData("COPY <<EOF /dest #tail\n")]
     [InlineData("COPY <<EOF \\\n# header 'comment\n \"/dest #name\" #tail\r\n")]
     [InlineData("COPY <\\\n<EOF \\\n /dest #tail\n")]

--- a/src/Valleysoft.DockerfileModel.Tests/ConstructReaderTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ConstructReaderTests.cs
@@ -1,0 +1,42 @@
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class ConstructReaderTests
+{
+    [Theory]
+    [InlineData("RUN <<EOF \\\n && echo ready\nbody\nEOF\n")]
+    [InlineData("RUN <<FIRST \\\n <<SECOND\none\nFIRST\ntwo\nSECOND\n")]
+    [InlineData("ONBUILD RUN <<EOF\nFROM body\nEOF\n")]
+    [InlineData("R\\\nUN <<EOF\nbody\nEOF\n")]
+    [InlineData("RUN echo \"\\\n<<NOT_A_MARKER\"\n")]
+    [InlineData("RUN <<EOF # <<NOT_A_MARKER\nbody\nEOF\n")]
+    [InlineData("RUN <<-\"EOF\"\n\tbody\n\tEOF\n")]
+    [InlineData("RUN echo hi \\\n# comment \\\n\n && echo done\n")]
+    public void ReadsCompleteLogicalRegion(string region)
+    {
+        string text = region + "FROM scratch\n";
+        ConstructReader.Region result = ConstructReader.Read(text, 0, '\\');
+
+        Assert.Equal(region.Length, result.End);
+        Assert.Null(result.UnterminatedMarker);
+    }
+
+    [Theory]
+    [InlineData("RUN <<EOF", 4)]
+    [InlineData("RUN <<EOF\nRUN echo body\n", 4)]
+    [InlineData("RUN <<FIRST \\\n <<SECOND\none\nFIRST\n", 15)]
+    public void MissingTerminatorConsumesToEnd(string text, int markerOffset)
+    {
+        ConstructReader.Region result = ConstructReader.Read(text, 0, '\\');
+
+        Assert.Equal(text.Length, result.End);
+        Assert.Equal(markerOffset, result.UnterminatedMarker);
+    }
+
+    [Fact]
+    public void TopLevelCommentDoesNotContinue()
+    {
+        string text = "# comment \\\nFROM scratch\n";
+        ConstructReader.Region result = ConstructReader.Read(text, 0, '\\');
+        Assert.Equal(text.IndexOf('\n') + 1, result.End);
+    }
+}

--- a/src/Valleysoft.DockerfileModel.Tests/ConstructReaderTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ConstructReaderTests.cs
@@ -39,4 +39,22 @@ public class ConstructReaderTests
         ConstructReader.Region result = ConstructReader.Read(text, 0, '\\');
         Assert.Equal(text.IndexOf('\n') + 1, result.End);
     }
+
+    [Theory]
+    [InlineData("COPY <<EOF /dest #tail\n")]
+    [InlineData("COPY <<EOF \\\n# header 'comment\n \"/dest #name\" #tail\r\n")]
+    [InlineData("COPY <\\\n<EOF \\\n /dest #tail\n")]
+    [InlineData("RUN <<EOF echo \"#name\" #tail\n")]
+    public void TrailingCommentOffsetRefersToOriginalSource(string header)
+    {
+        const string prefix = "FROM scratch\n";
+        string text = prefix + header + "body\nEOF\nFROM next\n";
+        ConstructReader.Region result = ConstructReader.Read(text, prefix.Length, '\\');
+
+        Assert.Equal(text.IndexOf("#tail", StringComparison.Ordinal), result.TrailingCommentStart);
+        Assert.Equal(prefix.Length + header.Length, result.HeaderEnd);
+        Assert.Equal(prefix.Length + header.Length + "body\nEOF\n".Length, result.End);
+        Assert.Equal("EOF", Assert.Single(result.Heredocs).Name);
+        Assert.Null(result.UnterminatedMarker);
+    }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/DockerfileParseTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DockerfileParseTests.cs
@@ -1,0 +1,333 @@
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class DockerfileParseTests
+{
+    [Fact]
+    public void DefaultsAreStrictAndRejectUnknownInstructions()
+    {
+        DockerfileParseOptions options = new();
+        Assert.Equal(DockerfileParseMode.Strict, options.Mode);
+        Assert.Equal(UnknownInstructionBehavior.Error, options.UnknownInstructionBehavior);
+        DockerfileParseResult result = Dockerfile.TryParse("FUTURE-COPY a b\nRUN echo after");
+        Assert.False(result.Success);
+        Assert.Null(result.Dockerfile);
+        Assert.Equal("DFP002", Assert.Single(result.Diagnostics).Code);
+    }
+
+    [Theory]
+    [InlineData(DockerfileParseMode.Strict, UnknownInstructionBehavior.Error)]
+    [InlineData(DockerfileParseMode.Recover, UnknownInstructionBehavior.Error)]
+    [InlineData(DockerfileParseMode.Strict, UnknownInstructionBehavior.Preserve)]
+    [InlineData(DockerfileParseMode.Recover, UnknownInstructionBehavior.Preserve)]
+    public void UnknownInstructionModeMatrix(DockerfileParseMode mode, UnknownInstructionBehavior behavior)
+    {
+        const string text = "FROM scratch\nFUTURE-COPY $src 'unfinished\nRUN echo after";
+        DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions
+        {
+            Mode = mode,
+            UnknownInstructionBehavior = behavior
+        });
+        bool preserved = behavior == UnknownInstructionBehavior.Preserve;
+        Assert.Equal(preserved, result.Success);
+        DockerfileDiagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("DFP002", diagnostic.Code);
+        Assert.Equal(preserved ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.False(string.IsNullOrWhiteSpace(diagnostic.Message));
+        Assert.Equal("FUTURE-COPY", text.Substring(diagnostic.SourceSpan.Start.Offset, diagnostic.SourceSpan.Length));
+        if (!preserved && mode == DockerfileParseMode.Strict)
+        {
+            Assert.Null(result.Dockerfile);
+            return;
+        }
+
+        Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+        Assert.Equal(text, model.ToString());
+        Assert.IsType<FromInstruction>(model.Items[0]);
+        Assert.IsType<RunInstruction>(model.Items[2]);
+        if (preserved)
+        {
+            Assert.IsAssignableFrom<GenericInstruction>(Assert.IsType<UnknownInstruction>(model.Items[1]));
+        }
+        else
+        {
+            Assert.IsType<MalformedConstruct>(model.Items[1]);
+            Assert.Equal(ConstructType.Malformed, model.Items[1].Type);
+            Assert.False(model.Items[1] is Instruction);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \t")]
+    [InlineData("\r\n\n \t\r\n")]
+    [InlineData("# comment without final newline")]
+    public void EmptyAndTriviaInputSucceedsInBothModes(string text)
+    {
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+            Assert.True(result.Success);
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(text, Assert.IsType<Dockerfile>(result.Dockerfile).ToString());
+        }
+    }
+
+    [Fact]
+    public void NullAndInvalidOptionsAreProgrammerErrors()
+    {
+        Assert.Throws<ArgumentNullException>(() => Dockerfile.TryParse(null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Dockerfile.TryParse("", new DockerfileParseOptions
+        {
+            Mode = (DockerfileParseMode)42
+        }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Dockerfile.TryParse("", new DockerfileParseOptions
+        {
+            UnknownInstructionBehavior = (UnknownInstructionBehavior)42
+        }));
+        Assert.True(Dockerfile.TryParse("FROM scratch", null).Success);
+    }
+
+    [Theory]
+    [InlineData("RUNNING echo text", "RUNNING")]
+    [InlineData("FROMAGE scratch", "FROMAGE")]
+    [InlineData("future-copy $src $dest", "future-copy")]
+    public void UnknownKeywordsAreWholeIdentifiersAndOpaque(string text, string keyword)
+    {
+        DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions
+        {
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        });
+        Assert.True(result.Success);
+        Assert.Equal(text, Assert.IsType<UnknownInstruction>(Assert.Single(result.Dockerfile!.Items)).ToString());
+        SourceSpan span = Assert.Single(result.Diagnostics).SourceSpan;
+        Assert.Equal(keyword, text.Substring(span.Start.Offset, span.Length));
+    }
+
+    [Fact]
+    public void StandaloneGenericParserStillRejectsUnknownName()
+    {
+        Assert.Throws<ParseException>(() => GenericInstruction.Parse("FUTURE-COPY $src $dest"));
+    }
+
+    [Theory]
+    [InlineData("FROM\n")]
+    [InlineData("ARG\n")]
+    [InlineData("SHELL [\"unterminated\n")]
+    [InlineData("FROM scratch extra tokens\n")]
+    public void KnownSyntaxFailuresAreNeverPreservedAsUnknown(string malformed)
+    {
+        string text = malformed + "FROM scratch\nRUN echo after\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Assert.False(result.Success);
+        Assert.Equal("DFP001", Assert.Single(result.Diagnostics).Code);
+        Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+        Assert.Equal(text, model.ToString());
+        Assert.IsType<MalformedConstruct>(model.Items[0]);
+        Assert.IsType<FromInstruction>(model.Items[1]);
+        Assert.IsType<RunInstruction>(model.Items[2]);
+        Assert.Empty(model.Items.OfType<UnknownInstruction>());
+    }
+
+    [Theory]
+    [InlineData("RUN")]
+    [InlineData("CMD")]
+    [InlineData("ENTRYPOINT")]
+    [InlineData("HEALTHCHECK CMD")]
+    public void BareCommandsProduceSyntaxDiagnosticsRatherThanArgumentExceptions(string command)
+    {
+        foreach (string ending in new[] { "", " ", "\n", "\r\n" })
+        {
+            string malformed = command + ending;
+            DockerfileParseResult strict = Dockerfile.TryParse(malformed);
+            Assert.False(strict.Success);
+            Assert.Null(strict.Dockerfile);
+            DockerfileDiagnostic diagnostic = Assert.Single(strict.Diagnostics);
+            Assert.Equal("DFP001", diagnostic.Code);
+            Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+
+            DockerfileParseResult recovered = Dockerfile.TryParse(malformed, RecoverPreservingUnknown());
+            Assert.False(recovered.Success);
+            Assert.Equal("DFP001", Assert.Single(recovered.Diagnostics).Code);
+            Assert.IsType<MalformedConstruct>(Assert.Single(recovered.Dockerfile!.Items));
+            SourceSpanTests.AssertPartition(malformed, recovered.Dockerfile);
+        }
+
+        string text = command + "\nFROM scratch\nRUN echo after\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Assert.False(result.Success);
+        Assert.Equal("DFP001", Assert.Single(result.Diagnostics).Code);
+        Assert.IsType<MalformedConstruct>(result.Dockerfile!.Items[0]);
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+        Assert.IsType<RunInstruction>(result.Dockerfile.Items[2]);
+        SourceSpanTests.AssertPartition(text, result.Dockerfile);
+    }
+
+    [Fact]
+    public void StrictStopsAtFirstErrorAndRetainsEarlierWarnings()
+    {
+        const string text = "FUTURE a\nFROM\nARG\nRUN echo after\n";
+        DockerfileParseResult strict = Dockerfile.TryParse(text, new DockerfileParseOptions
+        {
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        });
+        Assert.False(strict.Success);
+        Assert.Null(strict.Dockerfile);
+        Assert.Equal(new[] { "DFP002", "DFP001" }, strict.Diagnostics.Select(d => d.Code));
+        Assert.Equal(new[] { DiagnosticSeverity.Warning, DiagnosticSeverity.Error }, strict.Diagnostics.Select(d => d.Severity));
+
+        DockerfileParseResult recovered = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Assert.False(recovered.Success);
+        Assert.Equal(3, recovered.Diagnostics.Count);
+        Assert.Equal(2, recovered.Dockerfile!.Items.OfType<MalformedConstruct>().Count());
+        Assert.Single(recovered.Dockerfile.Items.OfType<RunInstruction>());
+        Assert.Equal(text, recovered.Dockerfile.ToString());
+    }
+
+    [Theory]
+    [InlineData("# escape=\n")]
+    [InlineData("# escape= \r\n")]
+    public void EmptyDirectiveReportsDiagnosticWithoutChangingEscape(string directive)
+    {
+        string text = directive + "FROM \\\nscratch\nRUN echo after\n";
+        DockerfileParseResult strict = Dockerfile.TryParse(text);
+        Assert.Null(strict.Dockerfile);
+        Assert.Equal("DFP004", Assert.Single(strict.Diagnostics).Code);
+
+        DockerfileParseResult result = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Assert.False(result.Success);
+        Assert.Equal("DFP004", Assert.Single(result.Diagnostics).Code);
+        Assert.Equal('\\', result.Dockerfile!.EscapeChar);
+        Assert.IsType<MalformedConstruct>(result.Dockerfile.Items[0]);
+        Assert.Single(result.Dockerfile.Items.OfType<FromInstruction>());
+        Assert.Single(result.Dockerfile.Items.OfType<RunInstruction>());
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Theory]
+    [InlineData("\\", "")]
+    [InlineData("`", "# escape=`\r\n")]
+    public void ContinuedUnknownAndMalformedRegionsKeepCommentsAndBoundaries(string escape, string directive)
+    {
+        string unknown = $"FUTURE-COPY a {escape}\r\n# embedded comment\r\n\r\n b\r\n";
+        string malformed = $"FR{escape}\r\nOM {escape}\r\n# continued comment\r\n\r\n scratch extra tokens\r\n";
+        string text = directive + unknown + malformed + "RUN echo after\r\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Assert.False(result.Success);
+        Assert.Equal(text, result.Dockerfile!.ToString());
+        Assert.Equal(unknown, Assert.Single(result.Dockerfile.Items.OfType<UnknownInstruction>()).ToString());
+        Assert.Single(result.Dockerfile.Items.OfType<MalformedConstruct>());
+        Assert.Single(result.Dockerfile.Items.OfType<RunInstruction>());
+    }
+
+    [Theory]
+    [InlineData("RUN <<EOF\nFROM not-a-stage\nRUN not-an-instruction\n")]
+    [InlineData("COPY <<'EOF' /target\nFROM not-a-stage\n")]
+    [InlineData("ADD <<-EOF /target\n\tbody\n")]
+    [InlineData("ONBUILD RUN <<EOF\nFROM not-a-stage\n")]
+    public void UnterminatedHeredocRetainsThroughEof(string heredoc)
+    {
+        string text = "FROM scratch\n" + heredoc;
+        DockerfileParseResult strict = Dockerfile.TryParse(text);
+        Assert.False(strict.Success);
+        Assert.Null(strict.Dockerfile);
+        Assert.Equal("DFP003", Assert.Single(strict.Diagnostics).Code);
+
+        DockerfileParseResult result = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Assert.False(result.Success);
+        DockerfileDiagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("DFP003", diagnostic.Code);
+        Assert.Equal(text.Length, diagnostic.SourceSpan.End.Offset);
+        Assert.Equal(heredoc, Assert.Single(result.Dockerfile!.Items.OfType<MalformedConstruct>()).ToString());
+        Assert.Single(result.Dockerfile.Items.OfType<FromInstruction>());
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Fact]
+    public void LegacyStillAcceptsUnterminatedRunHeredoc()
+    {
+        const string text = "RUN <<EOF\nbody\nFROM part-of-body\n";
+        Dockerfile legacy = Dockerfile.Parse(text);
+        Assert.IsType<RunInstruction>(Assert.Single(legacy.Items));
+        Assert.Equal(text, legacy.ToString());
+        Assert.Equal("DFP003", Assert.Single(Dockerfile.TryParse(text).Diagnostics).Code);
+    }
+
+    [Theory]
+    [InlineData("RUN <<'ONE' <<-\"TWO\"\nFROM body\nONE\n\tRUN body\n\tTWO\n")]
+    [InlineData("COPY <<'EOF' /target\nRUN body\nEOF\n")]
+    [InlineData("ADD <<-EOF /target\n\tFROM body\n\tEOF\n")]
+    [InlineData("ONBUILD RUN <<EOF\nFROM body\nEOF\n")]
+    public void CompletedHeredocsDoNotSplitInstructionLikeBodies(string heredoc)
+    {
+        string text = heredoc + "FROM scratch";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        Assert.Equal(text, result.Dockerfile!.ToString());
+        Assert.Equal(2, result.Dockerfile.Items.Count);
+        Assert.Equal(heredoc, result.Dockerfile.Items[0].ToString());
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+    }
+
+    [Fact]
+    public void HeredocTerminatorAtEofIsComplete()
+    {
+        const string text = "RUN <<EOF\nbody\nEOF";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+        Assert.True(result.Success);
+        Assert.Empty(result.Diagnostics);
+        Assert.IsType<RunInstruction>(Assert.Single(result.Dockerfile!.Items));
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Theory]
+    [InlineData("RUN echo \"<<EOF\"\n")]
+    [InlineData("RUN echo '<<EOF'\n")]
+    [InlineData("RUN [\"echo\", \"<<EOF\"]\n")]
+    [InlineData("# RUN <<EOF\n")]
+    public void QuotedAndCommentMarkersAreNotHeredocs(string firstLine)
+    {
+        string text = firstLine + "FROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+        Assert.True(result.Success);
+        Assert.Equal(text, result.Dockerfile!.ToString());
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items.Last());
+        Assert.Equal(2, result.Dockerfile.Items.Count);
+    }
+
+    [Fact]
+    public void UnknownFrontendHeredocSyntaxIsNotInferred()
+    {
+        const string text = "FUTURE <<EOF\nFROM scratch\nRUN echo after\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Assert.True(result.Success);
+        Assert.Equal("DFP002", Assert.Single(result.Diagnostics).Code);
+        Assert.IsType<UnknownInstruction>(result.Dockerfile!.Items[0]);
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+        Assert.IsType<RunInstruction>(result.Dockerfile.Items[2]);
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Fact]
+    public void MixedModelSupportsStagesAndNonMutatingResolution()
+    {
+        const string text = "ARG BASE=scratch\nARG\nFROM $BASE AS first\nARG VALUE=resolved\n" +
+            "FUTURE $VALUE\nFROM scratch extra tokens\nLABEL key=$VALUE\nFROM scratch AS second\nRUN echo ready\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, RecoverPreservingUnknown());
+        Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+        StagesView stages = new(model);
+        Assert.Single(stages.GlobalArgs);
+        Assert.Equal(new[] { "first", "second" }, stages.Stages.Select(s => s.Name));
+        Assert.Equal(2, model.Items.OfType<MalformedConstruct>().Count());
+        UnknownInstruction unknown = Assert.Single(model.Items.OfType<UnknownInstruction>());
+        Assert.Equal("FUTURE $VALUE\n", model.ResolveVariables(unknown));
+        Assert.Equal("LABEL key=resolved\n", model.ResolveVariables(Assert.Single(model.Items.OfType<LabelInstruction>())));
+        model.ResolveVariables();
+        Assert.Equal(text, model.ToString());
+    }
+
+    private static DockerfileParseOptions RecoverPreservingUnknown() => new()
+    {
+        Mode = DockerfileParseMode.Recover,
+        UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+    };
+}

--- a/src/Valleysoft.DockerfileModel.Tests/DockerfileTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/DockerfileTests.cs
@@ -8,6 +8,7 @@ public class DockerfileTests
 {
     [Theory]
     [InlineData("# escape=`\nFROM scratch", '`')]
+    [InlineData("# ESCAPE=`\nFROM scratch", '`')]
     [InlineData("# escape=\\\nFROM scratch", '\\')]
     [InlineData("FROM scratch", '\\')]
     public void EscapeChar(string content, char expectedEscapeChar)

--- a/src/Valleysoft.DockerfileModel.Tests/HeredocRecoveryModelTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/HeredocRecoveryModelTests.cs
@@ -289,4 +289,139 @@ public class HeredocRecoveryModelTests
             SourceSpanTests.AssertPartition(text, result.Dockerfile);
         }
     }
+
+    [Theory]
+    [InlineData("COPY", " /dest")]
+    [InlineData("ADD", " /dest")]
+    [InlineData("RUN", " echo done")]
+    [InlineData("RUN", " echo \"#notcomment\"")]
+    [InlineData("ONBUILD COPY", " /dest")]
+    [InlineData("ONBUILD RUN", "")]
+    public void TrailingHeredocCommentsRemainCommentTokens(string instructionName, string arguments)
+    {
+        foreach (string newline in new[] { "\n", "\r\n" })
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            string text = $"{instructionName} <<EOF{arguments} #comment <<IGNORED '{newline}body{newline}EOF{newline}FROM scratch{newline}";
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            Assert.Empty(result.Diagnostics);
+            Instruction instruction = Assert.IsAssignableFrom<Instruction>(result.Dockerfile!.Items[0]);
+            if (instruction is OnBuildInstruction onBuild)
+            {
+                instruction = onBuild.Instruction;
+            }
+            Assert.Equal("comment <<IGNORED '", Assert.Single(instruction.Comments));
+            Assert.Single(instruction.CommentTokens);
+            Assert.Equal($"{instruction.InstructionName} <<EOF{arguments} {newline}body{newline}EOF{newline}",
+                instruction.ToString(new TokenStringOptions(excludeComments: true)));
+            Heredoc heredoc;
+            if (instruction is FileTransferInstruction transfer)
+            {
+                Assert.Equal("/dest", transfer.Destination);
+                Assert.Empty(transfer.Sources);
+                heredoc = Assert.Single(transfer.Heredocs);
+            }
+            else
+            {
+                heredoc = Assert.Single(Assert.IsType<RunInstruction>(instruction).Heredocs);
+            }
+            Assert.Equal("EOF", heredoc.Name);
+            Assert.Equal("body" + newline, heredoc.Content);
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
+
+    [Theory]
+    [InlineData("\"/dest #name\"", "/dest #name", '\\')]
+    [InlineData("'/dest #name'", "/dest #name", '\\')]
+    [InlineData("/dest\\#name", "/dest\\#name", '\\')]
+    [InlineData("\"/dest\\\"#name\\\"\"", "/dest\\\"#name\\\"", '\\')]
+    [InlineData("/dest\\\\", "/dest\\\\", '\\')]
+    [InlineData("/dest`#name", "/dest`#name", '`')]
+    [InlineData("/dest\\", "/dest\\", '`')]
+    public void TrailingHeredocCommentRespectsQuotedAndEscapedDestination(
+        string destinationText, string destination, char escapeChar)
+    {
+        string text = $"# escape={escapeChar}\nCOPY <<EOF {destinationText} #comment\nbody\nEOF\nFROM scratch\n";
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            Assert.Empty(result.Diagnostics);
+            CopyInstruction instruction = Assert.IsType<CopyInstruction>(result.Dockerfile!.Items[1]);
+            Assert.Equal(destination, instruction.Destination);
+            Assert.Equal("comment", Assert.Single(instruction.Comments));
+            Assert.Equal("body\n", Assert.Single(instruction.Heredocs).Content);
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[2]);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
+
+    [Fact]
+    public void ContinuedHeaderCommentsDoNotHideTrailingHeredocComment()
+    {
+        const string text = "COPY <<EOF \\\n# header 'comment\n /dest #comment\nbody\nEOF\nFROM scratch\n";
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            CopyInstruction instruction = Assert.IsType<CopyInstruction>(result.Dockerfile!.Items[0]);
+            Assert.Equal("/dest", instruction.Destination);
+            Assert.Equal(new[] { "header 'comment", "comment" }, instruction.Comments);
+            Assert.Equal("body\n", Assert.Single(instruction.Heredocs).Content);
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
+
+    [Theory]
+    [InlineData("COPY <<EOF /dest\\ #literal\n", '\\')]
+    [InlineData("COPY <<EOF /dest` #literal\n", '`')]
+    [InlineData("COPY <<EOF '/dest'#literal\n", '\\')]
+    [InlineData("COPY <<EOF \"/dest #literal\"\n", '\\')]
+    [InlineData("RUN <<EOF echo \"#literal\"\n", '\\')]
+    [InlineData("RUN <<EOF echo '#literal'\n", '\\')]
+    public void LiteralHashesInHeredocHeaderDoNotBecomeComments(string header, char escapeChar)
+    {
+        string instructionText = header + "body\nEOF\n";
+        string text = $"# escape={escapeChar}\n{instructionText}FROM scratch\n";
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            Assert.Empty(result.Diagnostics);
+            Instruction instruction = Assert.IsAssignableFrom<Instruction>(result.Dockerfile!.Items[1]);
+            Assert.Empty(instruction.Comments);
+            Assert.Equal(instructionText, instruction.ToString(new TokenStringOptions(excludeComments: true)));
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[2]);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
+
+    [Theory]
+    [InlineData("#\n", "")]
+    [InlineData("#first \\\n second\n", "first \\\n second")]
+    public void TrailingCommentRemovalPreservesHeaderNewline(string comment, string expectedText)
+    {
+        string text = $"COPY <<EOF /dest {comment}body\nEOF\nFROM scratch\n";
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            CopyInstruction instruction = Assert.IsType<CopyInstruction>(result.Dockerfile!.Items[0]);
+            Assert.Equal("/dest", instruction.Destination);
+            Assert.Equal(expectedText, Assert.Single(instruction.Comments));
+            Assert.Equal("COPY <<EOF /dest \nbody\nEOF\n",
+                instruction.ToString(new TokenStringOptions(excludeComments: true)));
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
 }

--- a/src/Valleysoft.DockerfileModel.Tests/HeredocRecoveryModelTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/HeredocRecoveryModelTests.cs
@@ -1,0 +1,283 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class HeredocRecoveryModelTests
+{
+    [Theory]
+    [InlineData("RUN <<EO\\\nF\nbody\nEOF\n")]
+    [InlineData("RUN <<EOF \\\n && echo ready\nbody\nEOF\n")]
+    [InlineData("RUN cat << EOF\nbody\nEOF\n")]
+    [InlineData("RUN << 'EOF'\nbody\nEOF\n")]
+    [InlineData("RUN <<EOF \\\n # header comment\n && echo ready\nbody\nEOF\n")]
+    public void LogicalHeaderProducesCorrectTypedHeredoc(string instruction)
+    {
+        string text = instruction + "FROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        Assert.Equal(text, result.Dockerfile!.ToString());
+        RunInstruction run = Assert.IsType<RunInstruction>(result.Dockerfile.Items[0]);
+        Heredoc heredoc = Assert.Single(run.Heredocs);
+        Assert.Equal("EOF", heredoc.Name);
+        Assert.Equal("body\n", heredoc.Content);
+        Assert.Equal("EOF", Assert.Single(run.HeredocBodyTokens).ClosingDelimiter);
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+    }
+
+    [Fact]
+    public void MultipleHeredocsOnContinuedHeaderHaveSeparateBodies()
+    {
+        const string text = "RUN <<ONE \\\n <<TWO\nfirst\nONE\nsecond\nTWO\nFROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        RunInstruction run = Assert.IsType<RunInstruction>(result.Dockerfile!.Items[0]);
+        Assert.Collection(run.Heredocs,
+            first =>
+            {
+                Assert.Equal("ONE", first.Name);
+                Assert.Equal("first\n", first.Content);
+            },
+            second =>
+            {
+                Assert.Equal("TWO", second.Name);
+                Assert.Equal("second\n", second.Content);
+            });
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Theory]
+    [InlineData("COPY <<EOF \\\n /destination\nbody\nEOF\n")]
+    [InlineData("ADD << EOF \\\n /destination\nbody\nEOF\n")]
+    public void ContinuedDestinationRemainsAFileTransferDestination(string text)
+    {
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        FileTransferInstruction instruction = Assert.IsAssignableFrom<FileTransferInstruction>(Assert.Single(result.Dockerfile!.Items));
+        Assert.Equal("/destination", instruction.Destination);
+        Assert.Equal("body\n", Assert.Single(instruction.Heredocs).Content);
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Theory]
+    [InlineData("RUN <<<word\n")]
+    [InlineData("RUN echo foo<<EOF\n")]
+    [InlineData("RUN echo \"<<EOF\"\n")]
+    [InlineData("RUN [\"echo\", \"<<EOF\"]\n")]
+    public void FalseMarkersDoNotConsumeLaterInstructions(string instruction)
+    {
+        string text = instruction + "FROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        Assert.Equal(text, result.Dockerfile!.ToString());
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+        Assert.Empty(Assert.IsType<RunInstruction>(result.Dockerfile.Items[0]).Heredocs);
+    }
+
+    [Fact]
+    public void OnBuildSharesLogicalHeredocBoundaries()
+    {
+        const string text = "ONBUILD RUN <<EO\\\nF\nbody\nEOF\nFROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        OnBuildInstruction onBuild = Assert.IsType<OnBuildInstruction>(result.Dockerfile!.Items[0]);
+        RunInstruction run = Assert.IsType<RunInstruction>(onBuild.Instruction);
+        Assert.Equal("EOF", Assert.Single(run.Heredocs).Name);
+        Assert.Equal("body\n", Assert.Single(run.Heredocs).Content);
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Fact]
+    public void CustomEscapeAppliesToContinuedMarkerAndSourceModel()
+    {
+        const string text = "# ESCAPE=`\nRUN <<EO`\nF\nbody\nEOF\nFROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        Assert.Equal('`', result.Dockerfile!.EscapeChar);
+        RunInstruction run = Assert.IsType<RunInstruction>(result.Dockerfile.Items[1]);
+        Assert.Equal("EOF", Assert.Single(run.Heredocs).Name);
+        Assert.Equal("body\n", Assert.Single(run.Heredocs).Content);
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Theory]
+    [InlineData("'space name'", "space name")]
+    [InlineData("\0EOF", "\0EOF")]
+    public void DelimiterTextDoesNotUseProgrammaticIdentifierGuards(string marker, string name)
+    {
+        string text = $"RUN <<{marker}\nbody\n{name}\nFROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        RunInstruction run = Assert.IsType<RunInstruction>(result.Dockerfile!.Items[0]);
+        Assert.Equal(name, Assert.Single(run.Heredocs).Name);
+        Assert.Equal("body\n", Assert.Single(run.Heredocs).Content);
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+        Assert.Equal(text, result.Dockerfile.ToString());
+    }
+
+    [Theory]
+    [InlineData(DockerfileParseMode.Strict)]
+    [InlineData(DockerfileParseMode.Recover)]
+    public void HashPrefixedDelimiterKeepsBodyOutOfStages(DockerfileParseMode mode)
+    {
+        const string text = "RUN <<#EOF\nFROM scratch\n#EOF\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Diagnostics);
+        RunInstruction run = Assert.IsType<RunInstruction>(Assert.Single(result.Dockerfile!.Items));
+        Assert.Equal("#EOF", Assert.Single(run.Heredocs).Name);
+        Assert.Equal("FROM scratch\n", Assert.Single(run.Heredocs).Content);
+        Assert.Empty(new StagesView(result.Dockerfile).Stages);
+        SourceSpanTests.AssertPartition(text, result.Dockerfile);
+    }
+
+    [Theory]
+    [InlineData("\"E\\OF\"", "E\\OF", '\\', false)]
+    [InlineData("'E\\OF'", "E\\OF", '\\', false)]
+    [InlineData("\"E\\$OF\"", "E$OF", '\\', false)]
+    [InlineData("\"E\\\\OF\"", "E\\OF", '\\', false)]
+    [InlineData("E\\OF", "EOF", '\\', true)]
+    [InlineData("E`OF", "E`OF", '`', true)]
+    [InlineData("\"E`OF\"", "E`OF", '`', false)]
+    [InlineData("\"E\\OF\"", "E\\OF", '`', false)]
+    [InlineData("\"E\\$OF\"", "E$OF", '`', false)]
+    [InlineData("\"E\\`OF\"", "E\\`OF", '\\', false)]
+    [InlineData("\"E\\\"OF\"", "E\"OF", '\\', false)]
+    [InlineData("'E'\"OF\"", "EOF", '\\', false)]
+    [InlineData("E\"OF\"", "EOF", '\\', false)]
+    [InlineData("EOF\\", "EOF", '`', true)]
+    [InlineData("'EOF'\\", "EOF", '`', false)]
+    [InlineData("EOF\\\\", "EOF\\", '`', true)]
+    [InlineData("EOF\\\\\\", "EOF\\", '`', true)]
+    [InlineData("EOF\\ ", "EOF ", '`', true)]
+    public void ShellDelimiterEscapesAreIndependentOfDockerfileEscape(
+        string marker, string name, char escapeChar, bool expand)
+    {
+        string directive = $"# escape={escapeChar}\n";
+        string text = $"{directive}RUN <<{marker}\n{name}\nFROM scratch\n";
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            Assert.Empty(result.Diagnostics);
+            RunInstruction run = Assert.IsType<RunInstruction>(result.Dockerfile!.Items[1]);
+            Heredoc heredoc = Assert.Single(run.Heredocs);
+            Assert.Equal(name, heredoc.Name);
+            Assert.Equal("", heredoc.Content);
+            Assert.Equal(expand, heredoc.Expand);
+            Assert.Equal(name, Assert.Single(run.HeredocBodyTokens).ClosingDelimiter);
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[2]);
+            Assert.Single(new StagesView(result.Dockerfile).Stages);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
+
+    [Theory]
+    [InlineData("<\\\n<EOF", '\\', false)]
+    [InlineData("<\\\n<-EOF", '\\', true)]
+    [InlineData("<<\\\n-EOF", '\\', true)]
+    [InlineData("<\\\r\n<\\\r\n-EOF", '\\', true)]
+    [InlineData("<`\n<EOF", '`', false)]
+    [InlineData("<<`\n-EOF", '`', true)]
+    [InlineData("<\\\n# operator comment\n<\\\n-EOF", '\\', true)]
+    public void SplitOperatorsKeepPhysicalTokensAndLogicalChomp(string marker, char escapeChar, bool chomp)
+    {
+        string body = chomp ? "\tbody\n" : "body\n";
+        string closing = chomp ? "\tEOF\n" : "EOF\n";
+        string text = $"# escape={escapeChar}\nRUN {marker}\n{body}{closing}FROM scratch\n";
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            RunInstruction run = Assert.IsType<RunInstruction>(result.Dockerfile!.Items[1]);
+            Heredoc heredoc = Assert.Single(run.Heredocs);
+            Assert.Equal("EOF", heredoc.Name);
+            Assert.Equal(chomp, heredoc.Chomp);
+            Assert.Equal("body\n", heredoc.Content);
+            Assert.Equal(body, Assert.Single(run.HeredocBodyTokens).Content);
+            Assert.Equal(marker, Assert.Single(run.HeredocMarkerTokens).ToString());
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[2]);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
+
+    [Theory]
+    [InlineData("COPY", " /target")]
+    [InlineData("ADD", " /target")]
+    [InlineData("ONBUILD RUN", "")]
+    public void SharedInstructionPathsUseSourceAwareHeredocMarkers(string instruction, string arguments)
+    {
+        string text = $"{instruction} <\\\n<\\\n-\"E\\OF\"{arguments}\n\tbody\n\tE\\OF\nFROM scratch\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        Instruction parsed = Assert.IsAssignableFrom<Instruction>(result.Dockerfile!.Items[0]);
+        Heredoc heredoc;
+        if (parsed is FileTransferInstruction transfer)
+        {
+            Assert.Equal("/target", transfer.Destination);
+            heredoc = Assert.Single(transfer.Heredocs);
+        }
+        else
+        {
+            OnBuildInstruction onBuild = Assert.IsType<OnBuildInstruction>(parsed);
+            heredoc = Assert.Single(Assert.IsType<RunInstruction>(onBuild.Instruction).Heredocs);
+        }
+        Assert.Equal("E\\OF", heredoc.Name);
+        Assert.Equal("body\n", heredoc.Content);
+        Assert.True(heredoc.Chomp);
+        Assert.False(heredoc.Expand);
+        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+        SourceSpanTests.AssertPartition(text, result.Dockerfile);
+    }
+
+    [Fact]
+    public void DecodedDelimiterNameReflectsTokenEdits()
+    {
+        DockerfileParseResult result = Dockerfile.TryParse("RUN <<\"E\\$OF\"\nE$OF\n");
+        Assert.True(result.Success);
+        RunInstruction run = Assert.IsType<RunInstruction>(Assert.Single(result.Dockerfile!.Items));
+        HeredocMarkerToken marker = Assert.Single(run.HeredocMarkerTokens);
+        HeredocDelimiterToken delimiter = Assert.Single(marker.Tokens.OfType<HeredocDelimiterToken>());
+
+        delimiter.Value = "OTHER\\$END";
+
+        Assert.Equal("OTHER$END", marker.DelimiterName);
+        Assert.Equal("OTHER$END", Assert.Single(run.Heredocs).Name);
+        Assert.Equal("<<\"OTHER\\$END\"", marker.ToString());
+    }
+
+    [Theory]
+    [InlineData("\\")]
+    [InlineData("''")]
+    [InlineData("\"\"")]
+    [InlineData("''\\")]
+    [InlineData("\"\"\\")]
+    [InlineData("''\"\"\\")]
+    [InlineData("\"\"''\\")]
+    public void EmptyDecodedDelimiterDoesNotCreateAHeredoc(string marker)
+    {
+        string text = $"# escape=`\nRUN <<{marker}\nFROM scratch\n";
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            Assert.Empty(result.Diagnostics);
+            RunInstruction run = Assert.IsType<RunInstruction>(result.Dockerfile!.Items[1]);
+            Assert.Empty(run.Heredocs);
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[2]);
+            Assert.Single(new StagesView(result.Dockerfile).Stages);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
+    }
+}

--- a/src/Valleysoft.DockerfileModel.Tests/HeredocRecoveryModelTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/HeredocRecoveryModelTests.cs
@@ -66,15 +66,24 @@ public class HeredocRecoveryModelTests
     [InlineData("RUN echo foo<<EOF\n")]
     [InlineData("RUN echo \"<<EOF\"\n")]
     [InlineData("RUN [\"echo\", \"<<EOF\"]\n")]
+    [InlineData("RUN <<'E<F'\n")]
+    [InlineData("RUN <<\"E<F\"\n")]
+    [InlineData("RUN <<E\\<F\n")]
+    [InlineData("RUN <<E<F\n")]
     public void FalseMarkersDoNotConsumeLaterInstructions(string instruction)
     {
         string text = instruction + "FROM scratch\n";
-        DockerfileParseResult result = Dockerfile.TryParse(text);
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
 
-        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
-        Assert.Equal(text, result.Dockerfile!.ToString());
-        Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
-        Assert.Empty(Assert.IsType<RunInstruction>(result.Dockerfile.Items[0]).Heredocs);
+            Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(2, result.Dockerfile!.Items.Count);
+            Assert.IsType<FromInstruction>(result.Dockerfile.Items[1]);
+            Assert.Empty(Assert.IsType<RunInstruction>(result.Dockerfile.Items[0]).Heredocs);
+            SourceSpanTests.AssertPartition(text, result.Dockerfile);
+        }
     }
 
     [Fact]

--- a/src/Valleysoft.DockerfileModel.Tests/ParsingCompatibilityTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ParsingCompatibilityTests.cs
@@ -12,6 +12,44 @@ public class ParsingCompatibilityTests
         Assert.Equal(text, Dockerfile.Parse(text).ToString());
     }
 
+    [Theory]
+    [InlineData("COPY", null)]
+    [InlineData("COPY src", "src")]
+    [InlineData("COPY []", null)]
+    [InlineData("ADD", null)]
+    [InlineData("ADD src", "src")]
+    [InlineData("ADD []", null)]
+    public void FileTransferOperandCountsPreserveLegacyBehavior(string instructionText, string? destination)
+    {
+        FileTransferInstruction standalone = instructionText.StartsWith("COPY", StringComparison.Ordinal)
+            ? CopyInstruction.Parse(instructionText)
+            : AddInstruction.Parse(instructionText);
+        Assert.Equal(instructionText, standalone.ToString());
+        Assert.Empty(standalone.Sources);
+        Assert.Equal(destination, standalone.Destination);
+
+        string text = instructionText + "\nFROM scratch\n";
+        AssertModel(Dockerfile.Parse(text));
+        foreach (DockerfileParseMode mode in Enum.GetValues<DockerfileParseMode>())
+        {
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions { Mode = mode });
+            Assert.True(result.Success);
+            Assert.Empty(result.Diagnostics);
+            AssertModel(result.Dockerfile!);
+        }
+
+        void AssertModel(Dockerfile model)
+        {
+            Assert.Equal(2, model.Items.Count);
+            FileTransferInstruction instruction = Assert.IsAssignableFrom<FileTransferInstruction>(model.Items[0]);
+            Assert.IsType(standalone.GetType(), instruction);
+            Assert.Empty(instruction.Sources);
+            Assert.Equal(destination, instruction.Destination);
+            Assert.IsType<FromInstruction>(model.Items[1]);
+            SourceSpanTests.AssertPartition(text, model);
+        }
+    }
+
     [Fact]
     public void LegacyGenericParserRejectsUnknownInstruction()
     {

--- a/src/Valleysoft.DockerfileModel.Tests/ParsingCompatibilityTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ParsingCompatibilityTests.cs
@@ -1,0 +1,42 @@
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class ParsingCompatibilityTests
+{
+    [Theory]
+    [InlineData("RUN <<EOF\nbody\n")]
+    [InlineData("# escape=`\nFROM scratch\nRUN echo `\n # comment\n hello")]
+    [InlineData("# custom=value\nFROM scratch")]
+    [InlineData("FROM scratch\r\nRUN echo hello\n")]
+    public void LegacyParsePreservesAcceptedText(string text)
+    {
+        Assert.Equal(text, Dockerfile.Parse(text).ToString());
+    }
+
+    [Fact]
+    public void LegacyGenericParserRejectsUnknownInstruction()
+    {
+        Assert.Throws<ParseException>(() => GenericInstruction.Parse("FUTURE-COPY source target"));
+    }
+
+    [Theory]
+    [InlineData("RUN")]
+    [InlineData("CMD")]
+    [InlineData("ENTRYPOINT")]
+    [InlineData("HEALTHCHECK CMD")]
+    public void LegacyEmptyCommandsKeepTheirExceptionContract(string text)
+    {
+        Assert.Throws<ArgumentException>(() => Dockerfile.Parse(text));
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+        Assert.False(result.Success);
+        Assert.Null(result.Dockerfile);
+        Assert.Equal(DockerfileDiagnosticCodes.InvalidSyntax, Assert.Single(result.Diagnostics).Code);
+    }
+
+    [Fact]
+    public void LegacyFailurePositionIsConstructLocal()
+    {
+        ParseException standalone = Assert.Throws<ParseException>(() => FromInstruction.Parse("FROM"));
+        ParseException dockerfile = Assert.Throws<ParseException>(() => Dockerfile.Parse("RUN echo hello\nFROM"));
+        Assert.Equal(standalone.Position, dockerfile.Position);
+    }
+}

--- a/src/Valleysoft.DockerfileModel.Tests/RecoveryBoundaryFuzzTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/RecoveryBoundaryFuzzTests.cs
@@ -1,0 +1,46 @@
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class RecoveryBoundaryFuzzTests
+{
+    [Fact]
+    public void CorruptedInstructionsNeverThrowOrLoseSource()
+    {
+        string[] names = { "FROM", "RUN", "CMD", "ENTRYPOINT", "COPY", "ADD", "ENV", "ARG",
+            "LABEL", "USER", "WORKDIR", "EXPOSE", "VOLUME", "SHELL", "STOPSIGNAL", "HEALTHCHECK",
+            "ONBUILD", "MAINTAINER", "FUTURE-COPY", "# escape=", "# syntax=" };
+        string[] fragments = { "", " ", "\t", "\"", "'", "\\", "\\\n", "#", "# comment\n",
+            "CMD", "RUN", "FROM", "--", "--mount=", "--interval=..s", "--network=host",
+            "=", "${", "$x", "[", "]", "[]", "\0", "\r", "abc", "<<EOF", "<<<word",
+            "<< EOF", "<<'EOF'", "<<EO\\\nF", "\nEOF\n", "\n", "\r\n", "\uD83D\uDE80" };
+        Random random = new(347);
+        DockerfileParseOptions options = new()
+        {
+            Mode = DockerfileParseMode.Recover,
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        };
+
+        for (int sample = 0; sample < 2000; sample++)
+        {
+            string corrupted = names[random.Next(names.Length)] + " " +
+                string.Concat(Enumerable.Range(0, random.Next(1, 7)).Select(_ => fragments[random.Next(fragments.Length)]));
+            string text = "FROM scratch\n" + corrupted + "\nRUN echo after\n";
+            DockerfileParseResult result = Dockerfile.TryParse(text, options);
+            Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+            Assert.Equal(text, model.ToString());
+            int offset = 0;
+            foreach (DockerfileConstruct construct in model.Items)
+            {
+                SourceSpan span = Assert.IsType<SourceSpan>(construct.SourceSpan);
+                Assert.Equal(offset, span.Start.Offset);
+                Assert.Equal(construct.ToString(), text.Substring(span.Start.Offset, span.Length));
+                offset = span.End.Offset;
+            }
+            Assert.Equal(text.Length, offset);
+            foreach (DockerfileDiagnostic diagnostic in result.Diagnostics)
+            {
+                Assert.InRange(diagnostic.SourceSpan.Start.Offset, 0, text.Length);
+                Assert.InRange(diagnostic.SourceSpan.End.Offset, diagnostic.SourceSpan.Start.Offset, text.Length);
+            }
+        }
+    }
+}

--- a/src/Valleysoft.DockerfileModel.Tests/RecoveryPropertyTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/RecoveryPropertyTests.cs
@@ -1,0 +1,110 @@
+using FsCheck;
+using FsCheck.Fluent;
+using Valleysoft.DockerfileModel.TestSupport.Generators;
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class RecoveryPropertyTests
+{
+    [Fact]
+    public void GeneratedValidDockerfilesKeepTypedTokenTreesAndSourceSpans()
+    {
+        foreach (string text in DockerfileArbitraries.ValidDockerfile().Sample(30, 100))
+        {
+            Dockerfile legacy = Dockerfile.Parse(text);
+            DockerfileParseResult result = Dockerfile.TryParse(text);
+            Assert.True(result.Success, text + "\n" + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+            Assert.Empty(result.Diagnostics);
+            Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+            SourceSpanTests.AssertPartition(text, model);
+            Assert.Equal(legacy.Items.Select(item => item.GetType()), model.Items.Select(item => item.GetType()));
+            foreach ((DockerfileConstruct expected, DockerfileConstruct actual) in legacy.Items.Zip(model.Items))
+            {
+                AssertTokenTree(expected, actual);
+            }
+        }
+    }
+
+    [Fact]
+    public void GeneratedInstructionsSurviveInjectedRecoveryBoundaries()
+    {
+        Gen<string> instructions = DockerfileArbitraries.SingleBodyInstruction();
+        foreach (string instruction in instructions.Sample(30, 100))
+        {
+            string suffix = instruction + "\nFROM scratch AS after\n";
+            string text = "FROM scratch\nFUTURE-COPY a \\\n# embedded\n\n $opaque\n" +
+                "FROM scratch extra tokens\nRUN <<EOF\nFROM body\nEOF\n" + suffix;
+            DockerfileParseOptions options = new()
+            {
+                Mode = DockerfileParseMode.Recover,
+                UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+            };
+            DockerfileParseResult result = Dockerfile.TryParse(text, options);
+            Assert.False(result.Success);
+            Assert.Equal(new[] { "DFP002", "DFP001" }, result.Diagnostics.Select(d => d.Code));
+            Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+            SourceSpanTests.AssertPartition(text, model);
+            Assert.Single(model.Items.OfType<UnknownInstruction>());
+            Assert.Single(model.Items.OfType<MalformedConstruct>());
+            Dockerfile standalone = Dockerfile.Parse(suffix);
+            DockerfileConstruct[] recoveredSuffix = model.Items.TakeLast(standalone.Items.Count).ToArray();
+            foreach ((DockerfileConstruct expected, DockerfileConstruct actual) in standalone.Items.Zip(recoveredSuffix))
+            {
+                AssertTokenTree(expected, actual);
+            }
+            DockerfileParseResult repeated = Dockerfile.TryParse(text, options);
+            Assert.Equal(result.Diagnostics.Select(d => (d.Code, d.SourceSpan)),
+                repeated.Diagnostics.Select(d => (d.Code, d.SourceSpan)));
+        }
+    }
+
+    [Fact]
+    public void GeneratedVariableModelsRemainUnchangedDuringRecoveryInspection()
+    {
+        foreach (string valid in DockerfileArbitraries.DockerfileWithVariables().Sample(30, 100))
+        {
+            string text = valid + "\nFUTURE $opaque\nFROM\nRUN echo after\n";
+            DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions
+            {
+                Mode = DockerfileParseMode.Recover,
+                UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+            });
+            Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+            SourceSpan?[] spans = model.Items.Select(item => item.SourceSpan).ToArray();
+            Assert.Single(new StagesView(model).Stages);
+            Assert.Single(model.Items.OfType<MalformedConstruct>());
+            model.ResolveVariables();
+            Assert.Equal(text, model.ToString());
+            Assert.Equal(spans, model.Items.Select(item => item.SourceSpan));
+            SourceSpanTests.AssertPartition(text, model);
+        }
+    }
+
+    private static void AssertTokenTree(Token expected, Token actual)
+    {
+        Assert.Equal(expected.GetType(), actual.GetType());
+        Assert.Equal(expected.ToString(), actual.ToString());
+        if (expected is AggregateToken expectedAggregate)
+        {
+            AggregateToken actualAggregate = Assert.IsAssignableFrom<AggregateToken>(actual);
+            Token[] expectedChildren = expectedAggregate.Tokens.ToArray();
+            Token[] actualChildren = actualAggregate.Tokens.ToArray();
+            Assert.Equal(expectedChildren.Length, actualChildren.Length);
+            string fromChildren = string.Concat(actualChildren.Select(token => token.ToString()));
+            if (actual is VariableRefToken)
+            {
+                fromChildren = "$" + fromChildren;
+            }
+            if (actual is IQuotableToken quotable && quotable.QuoteChar.HasValue)
+            {
+                fromChildren = $"{quotable.QuoteChar}{fromChildren}{quotable.QuoteChar}";
+            }
+            Assert.Equal(actual.ToString(), fromChildren);
+            foreach ((Token expectedChild, Token actualChild) in expectedChildren.Zip(actualChildren))
+            {
+                AssertTokenTree(expectedChild, actualChild);
+            }
+        }
+    }
+}

--- a/src/Valleysoft.DockerfileModel.Tests/ScenarioTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/ScenarioTests.cs
@@ -4,6 +4,41 @@ namespace Valleysoft.DockerfileModel.Tests;
 
 public class ScenarioTests
 {
+    [Fact]
+    public void RecoverAndInspectOriginalSource()
+    {
+        string text = "FROM scratch\nFUTURE-COPY source target\nFROM\nRUN echo ready\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions
+        {
+            Mode = DockerfileParseMode.Recover,
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        });
+
+        Assert.False(result.Success);
+        Dockerfile model = Assert.IsType<Dockerfile>(result.Dockerfile);
+        Assert.Equal(text, model.ToString());
+        Assert.Single(model.Items.OfType<UnknownInstruction>());
+        Assert.Single(model.Items.OfType<MalformedConstruct>());
+        RunInstruction run = Assert.Single(model.Items.OfType<RunInstruction>());
+        SourceSpan span = Assert.IsType<SourceSpan>(run.SourceSpan);
+        Assert.Equal(run.ToString(), text.Substring(span.Start.Offset, span.Length));
+        Assert.Collection(result.Diagnostics,
+            warning => Assert.Equal(DiagnosticSeverity.Warning, warning.Severity),
+            error => Assert.Equal(DiagnosticSeverity.Error, error.Severity));
+    }
+
+    [Fact]
+    public void StrictTryParseReportsErrorsWithoutReturningAPartialModel()
+    {
+        DockerfileParseResult result = Dockerfile.TryParse("FROM scratch\nFROM\nRUN echo ready\n");
+
+        Assert.False(result.Success);
+        Assert.Null(result.Dockerfile);
+        DockerfileDiagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(DockerfileDiagnosticCodes.InvalidSyntax, diagnostic.Code);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
     /// <summary>
     /// The structure of a Dockerfile consists of instructions, whitespace, comments, and parser directives.
     /// </summary>

--- a/src/Valleysoft.DockerfileModel.Tests/SourceSpanTests.cs
+++ b/src/Valleysoft.DockerfileModel.Tests/SourceSpanTests.cs
@@ -1,0 +1,207 @@
+namespace Valleysoft.DockerfileModel.Tests;
+
+public class SourceSpanTests
+{
+    [Fact]
+    public void PositionsAndSpansHaveValueEquality()
+    {
+        SourcePosition start = new(3, 2, 1);
+        SourcePosition end = new(8, 2, 6);
+        SourcePosition equalStart = new(3, 2, 1);
+        SourceSpan span = new(start, end);
+        SourceSpan equalSpan = new(equalStart, new SourcePosition(8, 2, 6));
+        Assert.Equal(5, span.Length);
+        Assert.Equal(start, span.Start);
+        Assert.Equal(end, span.End);
+        Assert.True(start == equalStart);
+        Assert.False(start != equalStart);
+        Assert.True(span == equalSpan);
+        Assert.False(span != equalSpan);
+        Assert.Equal(start.GetHashCode(), equalStart.GetHashCode());
+        Assert.Equal(span.GetHashCode(), equalSpan.GetHashCode());
+        Assert.False(start.Equals((object?)null));
+        Assert.False(span.Equals((object?)null));
+        Assert.NotEqual(start, end);
+        Assert.NotEqual(span, new SourceSpan(start, start));
+        Assert.Equal(0, new SourceSpan(end, end).Length);
+    }
+
+    [Theory]
+    [InlineData(-1, 1, 1)]
+    [InlineData(0, 0, 1)]
+    [InlineData(0, 1, 0)]
+    public void PositionRejectsInvalidCoordinates(int offset, int line, int column)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SourcePosition(offset, line, column));
+    }
+
+    [Fact]
+    public void SpanRejectsReversedRange()
+    {
+        Assert.Throws<ArgumentException>(() => new SourceSpan(new SourcePosition(4, 1, 5), new SourcePosition(2, 1, 3)));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \t\r\n# café 🚀\nFROM scratch\r\nRUN echo end")]
+    [InlineData("# escape=`\nFROM `\r\n scratch\n\nRUN echo hi\n")]
+    [InlineData("RUN <<EOF\r\nFROM body\r\nEOF\r\nFROM scratch")]
+    public void BothDockerfileParsersAssignPartitioningOriginalSpans(string text)
+    {
+        AssertPartition(text, Dockerfile.Parse(text));
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        AssertPartition(text, Assert.IsType<Dockerfile>(result.Dockerfile));
+    }
+
+    [Theory]
+    [InlineData("# 🚀\t\rx\nFUTURE café🚀", 2, 14)]
+    [InlineData("# first\r\nFUTURE 🚀\r", 2, 11)]
+    [InlineData("# first\nFUTURE 🚀\r\n", 3, 1)]
+    public void Utf16TabsNewlinesAndLoneCarriageReturnHaveDefinedCoordinates(string text, int endLine, int endColumn)
+    {
+        DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions
+        {
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        });
+        Assert.True(result.Success);
+        AssertPartition(text, result.Dockerfile!);
+        SourceSpan last = Assert.IsType<SourceSpan>(result.Dockerfile!.Items.Last().SourceSpan);
+        Assert.Equal(new SourcePosition(text.Length, endLine, endColumn), last.End);
+        SourceSpan keyword = Assert.Single(result.Diagnostics).SourceSpan;
+        Assert.Equal(new SourcePosition(text.IndexOf("FUTURE", StringComparison.Ordinal), 2, 1), keyword.Start);
+    }
+
+    [Fact]
+    public void DiagnosticAfterMultilineHeredocUsesGlobalCoordinates()
+    {
+        const string prefix = "RUN <<EOF\r\n🚀 body\r\nEOF\r\n\t";
+        const string text = prefix + "FUTURE value";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+        DockerfileDiagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("DFP002", diagnostic.Code);
+        Assert.Equal(new SourcePosition(prefix.Length, 4, 2), diagnostic.SourceSpan.Start);
+        Assert.Equal(new SourcePosition(prefix.Length + 6, 4, 8), diagnostic.SourceSpan.End);
+    }
+
+    [Fact]
+    public void EofSyntaxFailureCanHaveZeroLengthSpan()
+    {
+        const string text = "FROM scratch\nFROM ";
+        DockerfileParseResult result = Dockerfile.TryParse(text);
+        DockerfileDiagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("DFP001", diagnostic.Code);
+        Assert.Equal(new SourcePosition(text.Length, 2, 6), diagnostic.SourceSpan.Start);
+        Assert.Equal(diagnostic.SourceSpan.Start, diagnostic.SourceSpan.End);
+        Assert.Equal(0, diagnostic.SourceSpan.Length);
+    }
+
+    [Fact]
+    public void RecoverySpansCoverEveryCharacterAndDiagnosticsAreRepeatable()
+    {
+        const string text = "# escape=\r\nFROM scratch\nFUTURE 🚀 \\\n # comment\n value\nARG\nRUN echo end";
+        DockerfileParseOptions options = new()
+        {
+            Mode = DockerfileParseMode.Recover,
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        };
+        DockerfileParseResult first = Dockerfile.TryParse(text, options);
+        DockerfileParseResult second = Dockerfile.TryParse(text, options);
+        Assert.False(first.Success);
+        AssertPartition(text, first.Dockerfile!);
+        Assert.Equal(first.Diagnostics.Select(d => (d.Code, d.Severity, d.SourceSpan)),
+            second.Diagnostics.Select(d => (d.Code, d.Severity, d.SourceSpan)));
+        Assert.Equal(first.Diagnostics.OrderBy(d => d.SourceSpan.Start.Offset), first.Diagnostics);
+        foreach (DockerfileDiagnostic diagnostic in first.Diagnostics)
+        {
+            Assert.InRange(diagnostic.SourceSpan.Start.Offset, 0, text.Length);
+            Assert.InRange(diagnostic.SourceSpan.End.Offset, diagnostic.SourceSpan.Start.Offset, text.Length);
+            Assert.Equal(PositionAt(text, diagnostic.SourceSpan.Start.Offset), diagnostic.SourceSpan.Start);
+            Assert.Equal(PositionAt(text, diagnostic.SourceSpan.End.Offset), diagnostic.SourceSpan.End);
+        }
+    }
+
+    [Fact]
+    public void StandaloneConstructsAndNestedInstructionsHaveNoSpan()
+    {
+        Assert.Null(new FromInstruction("scratch").SourceSpan);
+        Assert.Null(FromInstruction.Parse("FROM scratch").SourceSpan);
+        Assert.Null(Comment.Parse("# comment").SourceSpan);
+        Dockerfile model = Dockerfile.TryParse("ONBUILD RUN echo hi").Dockerfile!;
+        OnBuildInstruction onBuild = Assert.IsType<OnBuildInstruction>(Assert.Single(model.Items));
+        Assert.NotNull(onBuild.SourceSpan);
+        Assert.Null(onBuild.Instruction.SourceSpan);
+        Assert.Empty(new Dockerfile().Items);
+    }
+
+    [Fact]
+    public void MutationAndReorderingKeepSpansAndDiagnosticsAsOriginalSnapshots()
+    {
+        const string text = "FROM scratch\nFUTURE arg\nRUN echo end\n";
+        DockerfileParseResult result = Dockerfile.TryParse(text, new DockerfileParseOptions
+        {
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        });
+        Dockerfile model = result.Dockerfile!;
+        DockerfileConstruct[] items = model.Items.ToArray();
+        SourceSpan?[] spans = items.Select(item => item.SourceSpan).ToArray();
+        DockerfileDiagnostic[] diagnostics = result.Diagnostics.ToArray();
+        SourceSpan diagnosticSpan = diagnostics[0].SourceSpan;
+        Assert.IsType<FromInstruction>(items[0]).ImageName = "longer/image:tag";
+        model.Items.Remove(items[0]);
+        model.Items.Add(items[0]);
+        Assert.Equal(spans, items.Select(item => item.SourceSpan));
+        Assert.Equal(diagnostics, result.Diagnostics);
+        Assert.Equal(diagnosticSpan, result.Diagnostics[0].SourceSpan);
+        Assert.Equal("FROM scratch\n", text.Substring(spans[0]!.Value.Start.Offset, spans[0]!.Value.Length));
+
+        if (result.Diagnostics is IList<DockerfileDiagnostic> mutableInterface)
+        {
+            Assert.True(mutableInterface.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => mutableInterface.Clear());
+        }
+
+        Dockerfile reparsed = Dockerfile.TryParse(model.ToString(), new DockerfileParseOptions
+        {
+            UnknownInstructionBehavior = UnknownInstructionBehavior.Preserve
+        }).Dockerfile!;
+        AssertPartition(model.ToString(), reparsed);
+        Assert.NotEqual(spans[0], reparsed.Items.Last().SourceSpan);
+    }
+
+    internal static void AssertPartition(string text, Dockerfile model)
+    {
+        Assert.Equal(text, model.ToString());
+        int offset = 0;
+        foreach (DockerfileConstruct construct in model.Items)
+        {
+            SourceSpan span = Assert.IsType<SourceSpan>(construct.SourceSpan);
+            Assert.Equal(offset, span.Start.Offset);
+            Assert.InRange(span.End.Offset, offset, text.Length);
+            Assert.Equal(construct.ToString(), text.Substring(offset, span.Length));
+            Assert.Equal(PositionAt(text, offset), span.Start);
+            Assert.Equal(PositionAt(text, span.End.Offset), span.End);
+            offset = span.End.Offset;
+        }
+        Assert.Equal(text.Length, offset);
+    }
+
+    private static SourcePosition PositionAt(string text, int offset)
+    {
+        int line = 1;
+        int column = 1;
+        foreach (char character in text.Take(offset))
+        {
+            if (character == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+        return new SourcePosition(offset, line, column);
+    }
+}

--- a/src/Valleysoft.DockerfileModel/AddInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/AddInstruction.cs
@@ -172,13 +172,16 @@ public class AddInstruction : FileTransferInstruction
         from tokens in GetInnerParser(escapeChar)
         select new AddInstruction(tokens, escapeChar);
 
-    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
+    internal static AddInstruction ParseDiagnostic(string text, char escapeChar, InstructionParseContext context) =>
+        new(GetTokens(text, GetInnerParser(escapeChar, context)), escapeChar);
+
+    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, InstructionParseContext? context = null) =>
         GetInnerParser(escapeChar, Name,
             ArgTokens(ChecksumFlag.GetParser(escapeChar).AsEnumerable(), escapeChar)
                 .Or(ArgTokens(KeepGitDirFlag.GetParser(escapeChar).AsEnumerable(), escapeChar))
                 .Or(ArgTokens(LinkFlag.GetParser(escapeChar).AsEnumerable(), escapeChar))
                 .Or(ArgTokens(UnpackFlag.GetParser(escapeChar).AsEnumerable(), escapeChar))
-                .Or(ArgTokens(ExcludeFlag.GetParser(escapeChar).AsEnumerable(), escapeChar)));
+                .Or(ArgTokens(ExcludeFlag.GetParser(escapeChar).AsEnumerable(), escapeChar)), context);
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> sources, string destination,
         string? changeOwner, string? permissions, string? checksum, bool keepGitDir, bool link,

--- a/src/Valleysoft.DockerfileModel/CmdInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/CmdInstruction.cs
@@ -31,8 +31,11 @@ public class CmdInstruction : CommandInstruction
         from tokens in GetInnerParser(escapeChar)
         select new CmdInstruction(tokens);
 
-    internal static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
-        Instruction("CMD", escapeChar, GetArgsParser(escapeChar));
+    internal static CmdInstruction ParseDiagnostic(string text, char escapeChar) =>
+        new(GetTokens(text, GetInnerParser(escapeChar, diagnostic: true)));
+
+    internal static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, bool diagnostic = false) =>
+        Instruction("CMD", escapeChar, GetArgsParser(escapeChar, diagnostic));
 
     private static IEnumerable<Token> GetTokens(string commandWithArgs, char escapeChar)
     {

--- a/src/Valleysoft.DockerfileModel/CommandInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/CommandInstruction.cs
@@ -36,13 +36,19 @@ public abstract class CommandInstruction : Instruction
     }
 
     protected static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
+        GetArgsParser(escapeChar, false);
+
+    private protected static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar, bool diagnostic) =>
         from whitespace in Whitespace()
-        from command in ArgTokens(GetCommandParser(escapeChar).AsEnumerable(), escapeChar)
+        from command in ArgTokens(GetCommandParser(escapeChar, diagnostic).AsEnumerable(), escapeChar)
         select ConcatTokens(
             whitespace, command);
 
     protected static Parser<Command> GetCommandParser(char escapeChar) =>
+        GetCommandParser(escapeChar, false);
+
+    private protected static Parser<Command> GetCommandParser(char escapeChar, bool diagnostic) =>
         ExecFormCommand.GetParser(escapeChar)
             .Cast<ExecFormCommand, Command>()
-            .XOr(ShellFormCommand.GetParser(escapeChar));
+            .XOr(diagnostic ? ShellFormCommand.GetDiagnosticParser(escapeChar) : ShellFormCommand.GetParser(escapeChar));
 }

--- a/src/Valleysoft.DockerfileModel/ConstructReader.cs
+++ b/src/Valleysoft.DockerfileModel/ConstructReader.cs
@@ -1,0 +1,239 @@
+using System.Text;
+
+namespace Valleysoft.DockerfileModel;
+
+// Recovery framing is separate from legacy framing: notably it finishes continued
+// headers before reading bodies and reports missing terminators instead of accepting them.
+internal static class ConstructReader
+{
+    internal readonly struct Region
+    {
+        public Region(int end, int? unterminatedMarker = null, int headerEnd = 0, IReadOnlyList<HeredocRegion>? heredocs = null)
+        {
+            End = end;
+            UnterminatedMarker = unterminatedMarker;
+            HeaderEnd = headerEnd;
+            Heredocs = heredocs ?? Array.Empty<HeredocRegion>();
+        }
+
+        public int End { get; }
+        public int? UnterminatedMarker { get; }
+        public int HeaderEnd { get; }
+        public IReadOnlyList<HeredocRegion> Heredocs { get; }
+    }
+
+    internal sealed class HeredocRegion
+    {
+        public int MarkerStart { get; set; }
+        public int SecondOperatorStart { get; set; }
+        public int? ChompStart { get; set; }
+        public int DelimiterStart { get; set; }
+        public int MarkerEnd { get; set; }
+        public string Name { get; set; } = "";
+        public bool Chomp => ChompStart.HasValue;
+        public int BodyStart { get; set; }
+        public int ClosingLineStart { get; set; }
+        public int ClosingNameStart { get; set; }
+        public int ClosingNameEnd { get; set; }
+        public int End { get; set; }
+    }
+
+    public static Region Read(string text, int start, char escapeChar)
+    {
+        StringBuilder header = new();
+        List<int> headerOffsets = new();
+        int position = start;
+        bool continued = false;
+
+        while (position < text.Length)
+        {
+            int end = LineEnd(text, position);
+            int contentEnd = ContentEnd(text, position, end);
+            int first = position;
+            while (first < contentEnd && char.IsWhiteSpace(text[first]))
+            {
+                first++;
+            }
+
+            bool commentOrEmpty = first == contentEnd || text[first] == '#';
+            if (commentOrEmpty)
+            {
+                if (!continued)
+                {
+                    return new Region(end);
+                }
+                position = end;
+                continue;
+            }
+
+            int last = contentEnd - 1;
+            while (last >= position && (text[last] == ' ' || text[last] == '\t'))
+            {
+                last--;
+            }
+
+            // BuildKit's continuation rule excludes an escape preceded by another escape.
+            continued = end > contentEnd && last >= position && text[last] == escapeChar &&
+                (last == position || text[last - 1] != escapeChar);
+            int headerEnd = continued ? last : contentEnd;
+            for (int i = position; i < headerEnd; i++)
+            {
+                header.Append(text[i]);
+                headerOffsets.Add(i);
+            }
+
+            position = end;
+            if (!continued)
+            {
+                break;
+            }
+        }
+
+        string logicalHeader = header.ToString();
+        if (!CanContainHeredoc(logicalHeader))
+        {
+            return new Region(position);
+        }
+
+        int headerEndOffset = position;
+        List<HeredocRegion> heredocs = FindHeredocs(logicalHeader, headerOffsets);
+        foreach (HeredocRegion heredoc in heredocs)
+        {
+            heredoc.BodyStart = position;
+            bool closed = false;
+            while (position < text.Length)
+            {
+                int end = LineEnd(text, position);
+                int contentEnd = ContentEnd(text, position, end);
+                int delimiterStart = position;
+                if (heredoc.Chomp)
+                {
+                    while (delimiterStart < contentEnd && text[delimiterStart] == '\t')
+                    {
+                        delimiterStart++;
+                    }
+                }
+
+                closed = contentEnd - delimiterStart == heredoc.Name.Length &&
+                    string.CompareOrdinal(text, delimiterStart, heredoc.Name, 0, heredoc.Name.Length) == 0;
+                heredoc.ClosingLineStart = position;
+                heredoc.ClosingNameStart = delimiterStart;
+                heredoc.ClosingNameEnd = contentEnd;
+                heredoc.End = end;
+                position = end;
+                if (closed)
+                {
+                    break;
+                }
+            }
+
+            if (!closed)
+            {
+                return new Region(text.Length, heredoc.MarkerStart);
+            }
+        }
+
+        return new Region(position, headerEnd: headerEndOffset, heredocs: heredocs);
+    }
+
+    private static List<HeredocRegion> FindHeredocs(string header, List<int> offsets)
+    {
+        List<HeredocRegion> result = new();
+        int position = 0;
+        while (position < header.Length)
+        {
+            while (position < header.Length && char.IsWhiteSpace(header[position]))
+            {
+                position++;
+            }
+            if (position == header.Length || header[position] == '#')
+            {
+                break;
+            }
+
+            int wordStart = position;
+            int marker = wordStart;
+            while (marker < header.Length && char.IsDigit(header[marker]))
+            {
+                marker++;
+            }
+            bool candidate = marker + 1 < header.Length && header[marker] == '<' && header[marker + 1] == '<';
+            bool chomp = candidate && marker + 2 < header.Length && header[marker + 2] == '-';
+            if (candidate)
+            {
+                position = marker + (chomp ? 3 : 2);
+                while (position < header.Length && char.IsWhiteSpace(header[position]))
+                {
+                    position++;
+                }
+            }
+
+            int delimiterStart = position;
+            HeredocWord word = HeredocWord.Read(header, position);
+            position = word.End;
+
+            // BuildKit identifies complete heredoc words, not substrings such as
+            // foo<<EOF or here-strings (<<<word). Keep those from swallowing later instructions.
+            if (candidate && word.IsTerminated && !word.ContainsLessThan && position > delimiterStart &&
+                word.Value.Length > 0)
+            {
+                result.Add(new HeredocRegion
+                {
+                    MarkerStart = offsets[marker],
+                    SecondOperatorStart = offsets[marker + 1],
+                    ChompStart = chomp ? offsets[marker + 2] : null,
+                    DelimiterStart = offsets[delimiterStart],
+                    MarkerEnd = offsets[position - 1] + 1,
+                    Name = word.Value
+                });
+            }
+        }
+        return result;
+    }
+
+    private static bool CanContainHeredoc(string header)
+    {
+        int position = 0;
+        string name = ReadWord(header, ref position);
+        if (name.Equals("ONBUILD", StringComparison.OrdinalIgnoreCase))
+        {
+            name = ReadWord(header, ref position);
+        }
+        return name.Equals("RUN", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("COPY", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("ADD", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ReadWord(string text, ref int position)
+    {
+        while (position < text.Length && char.IsWhiteSpace(text[position]))
+        {
+            position++;
+        }
+        int start = position;
+        while (position < text.Length && !char.IsWhiteSpace(text[position]))
+        {
+            position++;
+        }
+        return text.Substring(start, position - start);
+    }
+
+    private static int LineEnd(string text, int start)
+    {
+        int newline = text.IndexOf('\n', start);
+        return newline < 0 ? text.Length : newline + 1;
+    }
+
+    private static int ContentEnd(string text, int start, int end)
+    {
+        if (end > start && text[end - 1] == '\n')
+        {
+            end--;
+            if (end > start && text[end - 1] == '\r')
+            {
+                end--;
+            }
+        }
+        return end;
+    }
+}

--- a/src/Valleysoft.DockerfileModel/ConstructReader.cs
+++ b/src/Valleysoft.DockerfileModel/ConstructReader.cs
@@ -8,18 +8,21 @@ internal static class ConstructReader
 {
     internal readonly struct Region
     {
-        public Region(int end, int? unterminatedMarker = null, int headerEnd = 0, IReadOnlyList<HeredocRegion>? heredocs = null)
+        public Region(int end, int? unterminatedMarker = null, int headerEnd = 0,
+            IReadOnlyList<HeredocRegion>? heredocs = null, int? trailingCommentStart = null)
         {
             End = end;
             UnterminatedMarker = unterminatedMarker;
             HeaderEnd = headerEnd;
             Heredocs = heredocs ?? Array.Empty<HeredocRegion>();
+            TrailingCommentStart = trailingCommentStart;
         }
 
         public int End { get; }
         public int? UnterminatedMarker { get; }
         public int HeaderEnd { get; }
         public IReadOnlyList<HeredocRegion> Heredocs { get; }
+        public int? TrailingCommentStart { get; }
     }
 
     internal sealed class HeredocRegion
@@ -97,6 +100,21 @@ internal static class ConstructReader
 
         int headerEndOffset = position;
         List<HeredocRegion> heredocs = FindHeredocs(logicalHeader, headerOffsets);
+        int? trailingCommentStart = null;
+        if (heredocs.Count > 0)
+        {
+            int lastMarkerEnd = heredocs[heredocs.Count - 1].MarkerEnd;
+            int tailStart = headerOffsets.FindIndex(offset => offset >= lastMarkerEnd);
+            if (tailStart >= 0)
+            {
+                string tail = logicalHeader.Substring(tailStart);
+                int commentOffset = DockerfileParser.StripTrailingComment(tail, escapeChar).Length;
+                if (commentOffset < tail.Length)
+                {
+                    trailingCommentStart = headerOffsets[tailStart + commentOffset];
+                }
+            }
+        }
         foreach (HeredocRegion heredoc in heredocs)
         {
             heredoc.BodyStart = position;
@@ -133,7 +151,8 @@ internal static class ConstructReader
             }
         }
 
-        return new Region(position, headerEnd: headerEndOffset, heredocs: heredocs);
+        return new Region(position, headerEnd: headerEndOffset, heredocs: heredocs,
+            trailingCommentStart: trailingCommentStart);
     }
 
     private static List<HeredocRegion> FindHeredocs(string header, List<int> offsets)

--- a/src/Valleysoft.DockerfileModel/ConstructType.cs
+++ b/src/Valleysoft.DockerfileModel/ConstructType.cs
@@ -5,5 +5,6 @@ public enum ConstructType
     Instruction,
     Comment,
     ParserDirective,
-    Whitespace
+    Whitespace,
+    Malformed
 }

--- a/src/Valleysoft.DockerfileModel/CopyInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/CopyInstruction.cs
@@ -140,12 +140,15 @@ public class CopyInstruction : FileTransferInstruction
         from tokens in GetInnerParser(escapeChar)
         select new CopyInstruction(tokens, escapeChar);
 
-    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
+    internal static CopyInstruction ParseDiagnostic(string text, char escapeChar, InstructionParseContext context) =>
+        new(GetTokens(text, GetInnerParser(escapeChar, context)), escapeChar);
+
+    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, InstructionParseContext? context = null) =>
         GetInnerParser(escapeChar, Name,
             ArgTokens(FromFlag.GetParser(escapeChar).AsEnumerable(), escapeChar)
                 .Or(ArgTokens(LinkFlag.GetParser(escapeChar).AsEnumerable(), escapeChar))
                 .Or(ArgTokens(ParentsFlag.GetParser(escapeChar).AsEnumerable(), escapeChar))
-                .Or(ArgTokens(ExcludeFlag.GetParser(escapeChar).AsEnumerable(), escapeChar)));
+                .Or(ArgTokens(ExcludeFlag.GetParser(escapeChar).AsEnumerable(), escapeChar)), context);
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> sources, string destination,
         string? fromStageName, string? changeOwner, string? permissions, bool link, bool parents,

--- a/src/Valleysoft.DockerfileModel/Dockerfile.cs
+++ b/src/Valleysoft.DockerfileModel/Dockerfile.cs
@@ -23,13 +23,33 @@ public class Dockerfile : IConstructContainer
     public char EscapeChar =>
         Items
             .OfType<ParserDirective>()
-            .FirstOrDefault(directive => directive.DirectiveName == ParserDirective.EscapeDirective)
+            .FirstOrDefault(directive => directive.DirectiveName.Equals(ParserDirective.EscapeDirective, StringComparison.OrdinalIgnoreCase))
             ?.DirectiveValue[0] ?? DefaultEscapeChar; 
 
     public static Dockerfile Parse(string text)
     {
         Guard.NotNull(text, nameof(text));
         return DockerfileParser.ParseContent(text);
+    }
+
+    /// <summary>
+    /// Reports source errors without throwing. Defaults to strict, fail-fast results;
+    /// recovery and unknown-instruction preservation must be explicitly enabled.
+    /// Null input and invalid options remain argument errors.
+    /// </summary>
+    public static DockerfileParseResult TryParse(string text, DockerfileParseOptions? options = null)
+    {
+        Guard.NotNull(text, nameof(text));
+        options ??= new DockerfileParseOptions();
+        if (options.Mode is not DockerfileParseMode.Strict and not DockerfileParseMode.Recover)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "Unknown parse mode.");
+        }
+        if (options.UnknownInstructionBehavior is not UnknownInstructionBehavior.Error and not UnknownInstructionBehavior.Preserve)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "Unknown instruction behavior.");
+        }
+        return TolerantDockerfileParser.Parse(text, options.Mode, options.UnknownInstructionBehavior);
     }
 
     public string ResolveVariables<TInstruction>(

--- a/src/Valleysoft.DockerfileModel/DockerfileConstruct.cs
+++ b/src/Valleysoft.DockerfileModel/DockerfileConstruct.cs
@@ -9,4 +9,10 @@ public abstract class DockerfileConstruct : AggregateToken
     }
 
     public abstract ConstructType Type { get; }
+
+    /// <summary>
+    /// Original-input provenance from a full Dockerfile parse, or null for standalone/constructed items.
+    /// Editing or moving this construct does not update its original source span.
+    /// </summary>
+    public SourceSpan? SourceSpan { get; internal set; }
 }

--- a/src/Valleysoft.DockerfileModel/DockerfileDiagnostic.cs
+++ b/src/Valleysoft.DockerfileModel/DockerfileDiagnostic.cs
@@ -1,0 +1,39 @@
+namespace Valleysoft.DockerfileModel;
+
+public sealed class DockerfileDiagnostic
+{
+    public DockerfileDiagnostic(string code, DiagnosticSeverity severity, string message, SourceSpan sourceSpan)
+    {
+        Guard.NotNullOrEmpty(code, nameof(code));
+        Guard.NotNullOrEmpty(message, nameof(message));
+        if (severity is not DiagnosticSeverity.Info and not DiagnosticSeverity.Warning and not DiagnosticSeverity.Error)
+        {
+            throw new ArgumentOutOfRangeException(nameof(severity));
+        }
+
+        Code = code;
+        Severity = severity;
+        Message = message;
+        SourceSpan = sourceSpan;
+    }
+
+    public string Code { get; }
+    public DiagnosticSeverity Severity { get; }
+    public string Message { get; }
+    public SourceSpan SourceSpan { get; }
+}
+
+public enum DiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+public static class DockerfileDiagnosticCodes
+{
+    public const string InvalidSyntax = "DFP001";
+    public const string UnknownInstruction = "DFP002";
+    public const string UnterminatedHeredoc = "DFP003";
+    public const string InvalidParserDirective = "DFP004";
+}

--- a/src/Valleysoft.DockerfileModel/DockerfileParseOptions.cs
+++ b/src/Valleysoft.DockerfileModel/DockerfileParseOptions.cs
@@ -1,0 +1,19 @@
+namespace Valleysoft.DockerfileModel;
+
+public sealed class DockerfileParseOptions
+{
+    public DockerfileParseMode Mode { get; set; } = DockerfileParseMode.Strict;
+    public UnknownInstructionBehavior UnknownInstructionBehavior { get; set; } = UnknownInstructionBehavior.Error;
+}
+
+public enum DockerfileParseMode
+{
+    Strict,
+    Recover
+}
+
+public enum UnknownInstructionBehavior
+{
+    Error,
+    Preserve
+}

--- a/src/Valleysoft.DockerfileModel/DockerfileParseResult.cs
+++ b/src/Valleysoft.DockerfileModel/DockerfileParseResult.cs
@@ -1,0 +1,16 @@
+namespace Valleysoft.DockerfileModel;
+
+public sealed class DockerfileParseResult
+{
+    internal DockerfileParseResult(Dockerfile? dockerfile, IEnumerable<DockerfileDiagnostic> diagnostics)
+    {
+        Dockerfile = dockerfile;
+        Diagnostics = Array.AsReadOnly(diagnostics.ToArray());
+        Success = !Diagnostics.Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    /// <summary>Null on strict failure; recovery retains even wholly malformed input.</summary>
+    public Dockerfile? Dockerfile { get; }
+    public IReadOnlyList<DockerfileDiagnostic> Diagnostics { get; }
+    public bool Success { get; }
+}

--- a/src/Valleysoft.DockerfileModel/DockerfileParser.cs
+++ b/src/Valleysoft.DockerfileModel/DockerfileParser.cs
@@ -254,6 +254,15 @@ internal static class DockerfileParser
             }
         }
 
+        SourceMap sourceMap = new(text);
+        int offset = 0;
+        for (int i = 0; i < dockerfileConstructs.Count; i++)
+        {
+            int end = offset + constructLines[i].Length;
+            dockerfileConstructs[i].SourceSpan = sourceMap.GetSpan(offset, end);
+            offset = end;
+        }
+
         return new Dockerfile(dockerfileConstructs);
     }
 

--- a/src/Valleysoft.DockerfileModel/EntrypointInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/EntrypointInstruction.cs
@@ -51,7 +51,10 @@ public class EntrypointInstruction : CommandInstruction
         return GetTokens($"ENTRYPOINT {StringHelper.FormatAsJson(new string[] { command }.Concat(args))}", GetInnerParser(escapeChar));
     }
 
-    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
+    internal static EntrypointInstruction ParseDiagnostic(string text, char escapeChar) =>
+        new(GetTokens(text, GetInnerParser(escapeChar, diagnostic: true)));
+
+    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar, bool diagnostic = false) =>
         Instruction("ENTRYPOINT", escapeChar,
-            GetArgsParser(escapeChar));
+            GetArgsParser(escapeChar, diagnostic));
 }

--- a/src/Valleysoft.DockerfileModel/FileTransferInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/FileTransferInstruction.cs
@@ -147,7 +147,11 @@ public abstract class FileTransferInstruction : Instruction
 
     protected static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, string instructionName,
         Parser<IEnumerable<Token>>? optionalFlagParser = null) =>
-        Instruction(instructionName, escapeChar, GetArgsParser(escapeChar, optionalFlagParser));
+        GetInnerParser(escapeChar, instructionName, optionalFlagParser, null);
+
+    private protected static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, string instructionName,
+        Parser<IEnumerable<Token>>? optionalFlagParser, InstructionParseContext? context) =>
+        Instruction(instructionName, escapeChar, GetArgsParser(escapeChar, optionalFlagParser, context));
 
     private static IEnumerable<Token> GetTokens(IEnumerable<string> sources, string destination,
         string? changeOwner, string? permissions, char escapeChar, string instructionName)
@@ -186,16 +190,23 @@ public abstract class FileTransferInstruction : Instruction
         }
     }
 
-    private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar, Parser<IEnumerable<Token>>? optionalFlagParser) =>
+    private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar,
+        Parser<IEnumerable<Token>>? optionalFlagParser, InstructionParseContext? context) =>
         from flags in FlagOption(escapeChar, optionalFlagParser).Many().Flatten()
         from whitespace in Whitespace()
-        from files in HeredocTokenParser(escapeChar)
-            .Or(ArgTokens(JsonArray(escapeChar, canContainVariables: true, allowEmpty: true), escapeChar))
+        from files in context is { HasHeredocs: true }
+            ? context.HeredocParser(escapeChar, canContainVariables: true)
+            : context is null
+                ? HeredocTokenParser(escapeChar).Or(FileArgs(escapeChar))
+                : FileArgs(escapeChar)
+        select ConcatTokens(flags, whitespace, files);
+
+    private static Parser<IEnumerable<Token>> FileArgs(char escapeChar) =>
+        ArgTokens(JsonArray(escapeChar, canContainVariables: true, allowEmpty: true), escapeChar)
             .Or(from literals in ArgTokens(
                     LiteralWithVariables(escapeChar, whitespaceMode: WhitespaceMode.AllowedInQuotes).AsEnumerable(),
                     escapeChar).Many()
-                select literals.Flatten())
-        select ConcatTokens(flags, whitespace, files);
+                select literals.Flatten());
 
     private static Parser<IEnumerable<Token>> FlagOption(char escapeChar, Parser<IEnumerable<Token>>? optionalFlagParser)
     {

--- a/src/Valleysoft.DockerfileModel/GenericInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/GenericInstruction.cs
@@ -11,7 +11,7 @@ public class GenericInstruction : Instruction
             
     }
 
-    private GenericInstruction(IEnumerable<Token> tokens)
+    protected GenericInstruction(IEnumerable<Token> tokens)
         : base(tokens)
     {
         ArgLines = new ProjectedItemList<LiteralToken, string>(

--- a/src/Valleysoft.DockerfileModel/HealthCheckInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/HealthCheckInstruction.cs
@@ -251,21 +251,25 @@ public class HealthCheckInstruction : Instruction
         return builder.ToString();
     }
 
-    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
-        Instruction("HEALTHCHECK", escapeChar,
-            GetArgsParser(escapeChar));
+    internal static HealthCheckInstruction ParseDiagnostic(string text, char escapeChar) =>
+        new(GetTokens(text, GetInnerParser(escapeChar, diagnostic: true)), escapeChar);
 
-    private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
+    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, bool diagnostic = false) =>
+        Instruction("HEALTHCHECK", escapeChar,
+            GetArgsParser(escapeChar, diagnostic));
+
+    private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar, bool diagnostic) =>
         from options in Options(escapeChar)
-        from command in CmdTokens(escapeChar)
+        from command in CmdTokens(escapeChar, diagnostic)
             .Or(ArgTokens(KeywordToken.GetParser("NONE", escapeChar).AsEnumerable(), escapeChar))
         select ConcatTokens(options, command);
 
-    private static Parser<IEnumerable<Token>> CmdTokens(char escapeChar) =>
+    private static Parser<IEnumerable<Token>> CmdTokens(char escapeChar, bool diagnostic) =>
         from cmdKeyword in ArgTokens(KeywordToken.GetParser("CMD", escapeChar).AsEnumerable(), escapeChar)
         from cmd in ArgTokens(
             ExecFormCommand.GetParser(escapeChar).Cast<ExecFormCommand, Token>()
-                .XOr(ShellFormCommand.GetParser(escapeChar).Cast<ShellFormCommand, Token>())
+                .XOr((diagnostic ? ShellFormCommand.GetDiagnosticParser(escapeChar) : ShellFormCommand.GetParser(escapeChar))
+                    .Cast<ShellFormCommand, Token>())
                 .AsEnumerable(), escapeChar)
         select ConcatTokens(cmdKeyword, cmd);
 

--- a/src/Valleysoft.DockerfileModel/HeredocWord.cs
+++ b/src/Valleysoft.DockerfileModel/HeredocWord.cs
@@ -1,0 +1,68 @@
+using System.Text;
+
+namespace Valleysoft.DockerfileModel;
+
+internal readonly struct HeredocWord
+{
+    private HeredocWord(string value, int end, bool isTerminated, char? quoteChar, bool containsLessThan)
+    {
+        Value = value;
+        End = end;
+        IsTerminated = isTerminated;
+        QuoteChar = quoteChar;
+        ContainsLessThan = containsLessThan;
+    }
+
+    public string Value { get; }
+    public int End { get; }
+    public bool IsTerminated { get; }
+    public char? QuoteChar { get; }
+    public bool ContainsLessThan { get; }
+
+    public static HeredocWord Read(string text, int start)
+    {
+        StringBuilder value = new();
+        char? quote = null;
+        char? firstQuote = null;
+        bool containsLessThan = false;
+        int position = start;
+        while (position < text.Length)
+        {
+            char ch = text[position];
+            if (quote is null && char.IsWhiteSpace(ch))
+            {
+                break;
+            }
+
+            containsLessThan |= ch == '<';
+            if (ch == '\\' && quote is null && position + 1 == text.Length)
+            {
+                position++;
+                continue;
+            }
+
+            // BuildKit's heredoc shell lexer always uses backslash. Inside double
+            // quotes it escapes only quotes, dollars and backslashes, not arbitrary characters.
+            if (ch == '\\' && quote != '\'' && position + 1 < text.Length &&
+                (quote is null || text[position + 1] is '"' or '$' or '\\'))
+            {
+                containsLessThan |= text[position + 1] == '<';
+                value.Append(text[position + 1]);
+                position += 2;
+            }
+            else if ((ch == '\'' || ch == '"') && (quote is null || quote == ch))
+            {
+                firstQuote ??= ch;
+                quote = quote is null ? ch : null;
+                position++;
+            }
+            else
+            {
+                value.Append(ch);
+                position++;
+            }
+        }
+
+        return new HeredocWord(value.ToString(), position, quote is null, firstQuote, containsLessThan);
+    }
+}

--- a/src/Valleysoft.DockerfileModel/Instruction.cs
+++ b/src/Valleysoft.DockerfileModel/Instruction.cs
@@ -54,6 +54,22 @@ public abstract class Instruction : DockerfileConstruct, ICommentable
         return instructionParsers[instructionName](text, escapeChar);
     }
 
+    internal static bool IsKnownInstruction(string name) => instructionParsers.ContainsKey(name);
+
+    internal static Instruction CreateDiagnosticInstruction(
+        string name, string text, char escapeChar, InstructionParseContext context) =>
+        name.ToUpperInvariant() switch
+        {
+            "RUN" => RunInstruction.ParseDiagnostic(text, escapeChar, context),
+            "CMD" => CmdInstruction.ParseDiagnostic(text, escapeChar),
+            "ENTRYPOINT" => EntrypointInstruction.ParseDiagnostic(text, escapeChar),
+            "HEALTHCHECK" => HealthCheckInstruction.ParseDiagnostic(text, escapeChar),
+            "COPY" => CopyInstruction.ParseDiagnostic(text, escapeChar, context),
+            "ADD" => AddInstruction.ParseDiagnostic(text, escapeChar, context),
+            "ONBUILD" => OnBuildInstruction.ParseDiagnostic(text, escapeChar, context),
+            _ => instructionParsers[name](text, escapeChar)
+        };
+
     protected static Parser<KeywordToken> InstructionIdentifier(char escapeChar) =>
         instructionParsers.Keys
             .Select(instructionName => KeywordToken.GetParser(instructionName, escapeChar))

--- a/src/Valleysoft.DockerfileModel/InstructionParseContext.cs
+++ b/src/Valleysoft.DockerfileModel/InstructionParseContext.cs
@@ -1,0 +1,141 @@
+using Valleysoft.DockerfileModel.Tokens;
+using static Valleysoft.DockerfileModel.ParseHelper;
+
+namespace Valleysoft.DockerfileModel;
+
+// Explicit per-parse context keeps the diagnostic path out of legacy parsers
+// without ambient state. Nested ONBUILD parsing shares the same original regions.
+internal sealed class InstructionParseContext
+{
+    private readonly ConstructReader.Region region;
+    private readonly int sourceStart;
+
+    public InstructionParseContext(ConstructReader.Region region, int sourceStart)
+    {
+        this.region = region;
+        this.sourceStart = sourceStart;
+    }
+
+    public bool HasHeredocs => region.Heredocs.Count > 0;
+
+    public InstructionParseContext Slice(int offset) => new(region, sourceStart + offset);
+
+    public Parser<IEnumerable<Token>> HeredocParser(char escapeChar, bool canContainVariables = false) =>
+        input =>
+        {
+            if (!HasHeredocs || input.Position > region.Heredocs[0].MarkerStart - sourceStart ||
+                region.End - sourceStart > input.Source.Length)
+            {
+                return Result.Failure<IEnumerable<Token>>(input, "Expected a complete heredoc.", new[] { "heredoc" });
+            }
+
+            List<Token> tokens = new();
+            int position = input.Position;
+            foreach (ConstructReader.HeredocRegion heredoc in region.Heredocs)
+            {
+                int markerStart = heredoc.MarkerStart - sourceStart;
+                tokens.AddRange(ParseGap(input.Source, position, markerStart - position,
+                    escapeChar, canContainVariables));
+
+                List<Token> marker = new() { new SymbolToken('<') };
+                int secondOperatorStart = heredoc.SecondOperatorStart - sourceStart;
+                marker.AddRange(ParseGap(input.Source, markerStart + 1, secondOperatorStart - markerStart - 1,
+                    escapeChar, false));
+                marker.Add(new SymbolToken('<'));
+                int operatorEnd = secondOperatorStart + 1;
+                if (heredoc.ChompStart is int chompStart)
+                {
+                    chompStart -= sourceStart;
+                    marker.AddRange(ParseGap(input.Source, operatorEnd, chompStart - operatorEnd, escapeChar, false));
+                    marker.Add(new SymbolToken('-'));
+                    operatorEnd = chompStart + 1;
+                }
+                int delimiterStart = heredoc.DelimiterStart - sourceStart;
+                marker.AddRange(ParseGap(input.Source, operatorEnd, delimiterStart - operatorEnd,
+                    escapeChar, false));
+                string rawDelimiter = input.Source.Substring(delimiterStart, heredoc.MarkerEnd - sourceStart - delimiterStart);
+                char? quote = rawDelimiter.Length >= 2 && (rawDelimiter[0] == '\'' || rawDelimiter[0] == '"') &&
+                    rawDelimiter[rawDelimiter.Length - 1] == rawDelimiter[0] ? rawDelimiter[0] : null;
+                if (quote is char quoteChar)
+                {
+                    marker.Add(new SymbolToken(quoteChar));
+                    rawDelimiter = rawDelimiter.Substring(1, rawDelimiter.Length - 2);
+                }
+                marker.Add(new HeredocDelimiterToken(RawDelimiterTokens(rawDelimiter, escapeChar)));
+                if (quote is char closingQuote)
+                {
+                    marker.Add(new SymbolToken(closingQuote));
+                }
+                HeredocMarkerToken markerToken = new(marker, diagnostic: true);
+                if (markerToken.DelimiterName != heredoc.Name)
+                {
+                    return Result.Failure<IEnumerable<Token>>(input,
+                        "The heredoc delimiter could not be represented without changing its value.", new[] { "heredoc delimiter" });
+                }
+                tokens.Add(markerToken);
+                position = heredoc.MarkerEnd - sourceStart;
+            }
+
+            tokens.AddRange(ParseGap(input.Source, position, region.HeaderEnd - sourceStart - position,
+                escapeChar, canContainVariables));
+            foreach (ConstructReader.HeredocRegion heredoc in region.Heredocs)
+            {
+                List<Token> body = new();
+                if (heredoc.ClosingLineStart > heredoc.BodyStart)
+                {
+                    body.Add(new StringToken(input.Source.Substring(heredoc.BodyStart - sourceStart,
+                        heredoc.ClosingLineStart - heredoc.BodyStart)));
+                }
+                if (heredoc.ClosingNameStart > heredoc.ClosingLineStart)
+                {
+                    body.Add(new StringToken(input.Source.Substring(heredoc.ClosingLineStart - sourceStart,
+                        heredoc.ClosingNameStart - heredoc.ClosingLineStart)));
+                }
+                body.Add(new HeredocDelimiterToken(new Token[] { new StringToken(heredoc.Name) }));
+                if (heredoc.End > heredoc.ClosingNameEnd)
+                {
+                    body.Add(new NewLineToken(input.Source.Substring(heredoc.ClosingNameEnd - sourceStart,
+                        heredoc.End - heredoc.ClosingNameEnd)));
+                }
+                tokens.Add(new HeredocBodyToken(body));
+            }
+
+            IInput remainder = input;
+            while (remainder.Position < region.End - sourceStart)
+            {
+                remainder = remainder.Advance();
+            }
+            return Result.Success<IEnumerable<Token>>(tokens, remainder);
+        };
+
+    private static IEnumerable<Token> ParseGap(string source, int offset, int length, char escapeChar, bool canContainVariables)
+    {
+        Parser<LiteralToken> literal = canContainVariables
+            ? LiteralWithVariables(escapeChar, whitespaceMode: WhitespaceMode.AllowedInQuotes)
+            : LiteralToken(escapeChar, Array.Empty<char>());
+        Parser<IEnumerable<Token>> parser =
+            from leading in ArgTrailingWhitespace(escapeChar)
+            from args in ArgTokens(literal.AsEnumerable(), escapeChar).Many()
+            from trailing in (from whitespace in Whitespace()
+                              where whitespace.Any()
+                              select whitespace).Many()
+            select ConcatTokens(leading, args.Flatten(), trailing.Flatten());
+        IResult<IEnumerable<Token>> result = parser.End().TryParse(source.Substring(offset, length));
+        if (!result.WasSuccessful)
+        {
+            int position = offset + result.Remainder.Position;
+            SourcePosition location = new SourceMap(source).GetSpan(position, position).Start;
+            throw new ParseException(result.Message, new Position(position, location.Line, location.Column));
+        }
+        return result.Value;
+    }
+
+    private static IEnumerable<Token> RawDelimiterTokens(string text, char escapeChar)
+    {
+        Parser<Token> continuation = LineContinuationToken.GetParser(escapeChar).Cast<LineContinuationToken, Token>();
+        Parser<Token> content =
+            from value in Sprache.Parse.AnyChar.Except(continuation).AtLeastOnce().Text()
+            select (Token)new StringToken(value);
+        return continuation.Or(content).Many().End().Parse(text);
+    }
+}

--- a/src/Valleysoft.DockerfileModel/InstructionParseContext.cs
+++ b/src/Valleysoft.DockerfileModel/InstructionParseContext.cs
@@ -76,8 +76,24 @@ internal sealed class InstructionParseContext
                 position = heredoc.MarkerEnd - sourceStart;
             }
 
-            tokens.AddRange(ParseGap(input.Source, position, region.HeaderEnd - sourceStart - position,
+            int argumentsEnd = (region.TrailingCommentStart ?? region.HeaderEnd) - sourceStart;
+            tokens.AddRange(ParseGap(input.Source, position, argumentsEnd - position,
                 escapeChar, canContainVariables));
+            if (region.TrailingCommentStart.HasValue)
+            {
+                Parser<IEnumerable<Token>> commentParser =
+                    from marker in Symbol('#')
+                    from leading in WhitespaceWithoutNewLine()
+                    from text in Sprache.Parse.AnyChar.Except(Sprache.Parse.LineEnd.End()).Many().Text()
+                    from lineEnd in OptionalNewLine().AsEnumerable()
+                    select ConcatTokens(new Token[]
+                    {
+                        new CommentToken(ConcatTokens(ConcatTokens(marker, leading),
+                            ConcatTokens(new StringToken(text.Trim()), GetTrailingWhitespaceToken(text))))
+                    }, lineEnd);
+                tokens.AddRange(commentParser.End().Parse(input.Source.Substring(argumentsEnd,
+                    region.HeaderEnd - sourceStart - argumentsEnd)));
+            }
             foreach (ConstructReader.HeredocRegion heredoc in region.Heredocs)
             {
                 List<Token> body = new();

--- a/src/Valleysoft.DockerfileModel/MalformedConstruct.cs
+++ b/src/Valleysoft.DockerfileModel/MalformedConstruct.cs
@@ -1,0 +1,13 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel;
+
+/// <summary>Unparsed original text retained after an error. This is not a validated instruction.</summary>
+public sealed class MalformedConstruct : DockerfileConstruct
+{
+    internal MalformedConstruct(string text) : base(new Token[] { new StringToken(text) })
+    {
+    }
+
+    public override ConstructType Type => ConstructType.Malformed;
+}

--- a/src/Valleysoft.DockerfileModel/OnBuildInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/OnBuildInstruction.cs
@@ -46,8 +46,12 @@ public class OnBuildInstruction : Instruction
         return GetTokens($"ONBUILD {instruction}", GetInnerParser(escapeChar));
     }
 
-    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar) =>
-        Instruction("ONBUILD", escapeChar, GetArgsParser(escapeChar));
+    internal static OnBuildInstruction ParseDiagnostic(string text, char escapeChar, InstructionParseContext context) =>
+        new(GetTokens(text, GetInnerParser(escapeChar, context)));
+
+    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar = Dockerfile.DefaultEscapeChar,
+        InstructionParseContext? context = null) =>
+        Instruction("ONBUILD", escapeChar, GetArgsParser(escapeChar, context));
 
     /// <summary>
     /// Parses the trigger instruction for ONBUILD by dispatching to the appropriate
@@ -59,9 +63,9 @@ public class OnBuildInstruction : Instruction
     /// at the ONBUILD level, rather than having them swallowed as raw literal text
     /// inside the inner instruction.
     /// </summary>
-    private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
+    private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar, InstructionParseContext? context) =>
         ArgTokens(
-            from instruction in TriggerInstructionParser(escapeChar)
+            from instruction in TriggerInstructionParser(escapeChar, context)
             select new Token[] { instruction },
             escapeChar);
 
@@ -71,7 +75,7 @@ public class OnBuildInstruction : Instruction
     /// Scanning for the longest valid prefix preserves the existing split between the
     /// inner instruction tokens and any trailing ONBUILD-level continuation comments.
     /// </summary>
-    private static Parser<Instruction> TriggerInstructionParser(char escapeChar) =>
+    private static Parser<Instruction> TriggerInstructionParser(char escapeChar, InstructionParseContext? context) =>
         input =>
         {
             IResult<string> instructionNameResult = InstructionNameParser(escapeChar)(input);
@@ -92,7 +96,7 @@ public class OnBuildInstruction : Instruction
             for (int consumedLength = remainingText.Length; consumedLength > 0; consumedLength--)
             {
                 string instructionText = remainingText.Substring(0, consumedLength);
-                if (!TryCreateTriggerInstruction(instructionText, escapeChar, out Instruction? instruction) ||
+                if (!TryCreateTriggerInstruction(instructionText, escapeChar, context?.Slice(input.Position), out Instruction? instruction) ||
                     !ArgTrailingWhitespace(escapeChar).TryParse(remainingText.Substring(consumedLength)).WasSuccessful)
                 {
                     continue;
@@ -107,11 +111,14 @@ public class OnBuildInstruction : Instruction
                 new[] { "valid ONBUILD trigger instruction" });
         };
 
-    private static bool TryCreateTriggerInstruction(string text, char escapeChar, out Instruction? instruction)
+    private static bool TryCreateTriggerInstruction(string text, char escapeChar,
+        InstructionParseContext? context, out Instruction? instruction)
     {
         try
         {
-            instruction = Instruction.CreateInstruction(text, escapeChar);
+            instruction = context is null
+                ? Instruction.CreateInstruction(text, escapeChar)
+                : Instruction.CreateDiagnosticInstruction(InstructionNameParser(escapeChar).Parse(text), text, escapeChar, context);
             return true;
         }
         catch (ParseException)

--- a/src/Valleysoft.DockerfileModel/ParseHelper.cs
+++ b/src/Valleysoft.DockerfileModel/ParseHelper.cs
@@ -562,7 +562,7 @@ internal static class ParseHelper
     /// <summary>
     /// Parses all whitespace except a new line.
     /// </summary>
-    private static Parser<WhitespaceToken?> WhitespaceWithoutNewLine() =>
+    internal static Parser<WhitespaceToken?> WhitespaceWithoutNewLine() =>
         from whitespace in Parse.WhiteSpace.Except(Parse.LineTerminator).XMany().Text()
         select whitespace.Length > 0 ? new WhitespaceToken(whitespace) : null;
 

--- a/src/Valleysoft.DockerfileModel/ParseHelper.cs
+++ b/src/Valleysoft.DockerfileModel/ParseHelper.cs
@@ -372,12 +372,17 @@ internal static class ParseHelper
     /// </summary>
     /// <param name="escapeChar">Escape character.</param>
     public static Parser<IEnumerable<Token>> ArgumentListAsLiteral(char escapeChar) =>
+        ArgumentListAsLiteral(escapeChar, requireContent: false);
+
+    internal static Parser<IEnumerable<Token>> ArgumentListAsLiteral(char escapeChar, bool requireContent) =>
         from literals in
             ArgTokens(
                 from literal in LiteralToken(escapeChar, Enumerable.Empty<char>()).Optional()
                 select new Token[] { literal.GetOrDefault() },
                 escapeChar).Many()
-        select CollapseLiteralTokens(literals.Flatten(), canContainVariables: false, escapeChar);
+        let tokens = literals.Flatten().ToArray()
+        where !requireContent || tokens.Length > 0
+        select CollapseLiteralTokens(tokens, canContainVariables: false, escapeChar);
 
     /// <summary>
     /// Parses a JSON array of strings.

--- a/src/Valleysoft.DockerfileModel/ParserDirective.cs
+++ b/src/Valleysoft.DockerfileModel/ParserDirective.cs
@@ -50,12 +50,25 @@ public class ParserDirective : DockerfileConstruct
     public static ParserDirective Parse(string text) =>
         new(GetTokens(text, GetParser()));
 
-    public static Parser<IEnumerable<Token>> GetParser() =>
+    public static Parser<IEnumerable<Token>> GetParser() => GetParser(DirectiveValueParser());
+
+    internal static Parser<ParserDirective> GetDiagnosticParser() =>
+        from tokens in GetParser(DirectiveValueParser(requireValue: true)).End()
+        select new ParserDirective(tokens);
+
+    internal static bool IsDirectiveCandidate(string text) =>
+        (from leading in Whitespace()
+         from commentChar in CommentToken.CommentCharParser()
+         from directive in TokenWithTrailingWhitespace(DirectiveNameParser())
+         from op in Symbol('=')
+         select op).TryParse(text).WasSuccessful;
+
+    private static Parser<IEnumerable<Token>> GetParser(Parser<LiteralToken> valueParser) =>
         from leading in Whitespace()
         from commentChar in CommentToken.CommentCharParser()
         from directive in TokenWithTrailingWhitespace(DirectiveNameParser())
         from op in TokenWithTrailingWhitespace(Symbol('='))
-        from value in TokenWithTrailingWhitespace(DirectiveValueParser())
+        from value in TokenWithTrailingWhitespace(valueParser)
         select ConcatTokens(
             leading,
             commentChar,
@@ -77,7 +90,7 @@ public class ParserDirective : DockerfileConstruct
         from name in Sprache.Parse.Identifier(Sprache.Parse.Letter, Sprache.Parse.LetterOrDigit)
         select new KeywordToken(name);
 
-    private static Parser<LiteralToken> DirectiveValueParser() =>
-        from val in NonWhitespace().Many().Text()
+    private static Parser<LiteralToken> DirectiveValueParser(bool requireValue = false) =>
+        from val in (requireValue ? NonWhitespace().AtLeastOnce() : NonWhitespace().Many()).Text()
         select new LiteralToken(new Token[] { new StringToken(val) }, canContainVariables: false, val[0]);
 }

--- a/src/Valleysoft.DockerfileModel/RunInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/RunInstruction.cs
@@ -165,9 +165,12 @@ public class RunInstruction : CommandInstruction
             $"RUN {GetFlagArgs(mounts, network, security, escapeChar)}{StringHelper.FormatAsJson(new string[] { command }.Concat(args))}", GetInnerParser(escapeChar));
     }
 
-    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar) =>
+    internal static RunInstruction ParseDiagnostic(string text, char escapeChar, InstructionParseContext context) =>
+        new(GetTokens(text, GetInnerParser(escapeChar, context)), escapeChar);
+
+    private static Parser<IEnumerable<Token>> GetInnerParser(char escapeChar, InstructionParseContext? context = null) =>
         Instruction("RUN", escapeChar,
-            GetArgsParser(escapeChar));
+            GetArgsParser(escapeChar, context));
 
     private static string GetFlagArgs(IEnumerable<Mount> mounts, string? network, string? security, char escapeChar)
     {
@@ -191,11 +194,14 @@ public class RunInstruction : CommandInstruction
         return builder.ToString();
     }
 
-    private new static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar) =>
+    private static Parser<IEnumerable<Token>> GetArgsParser(char escapeChar, InstructionParseContext? context) =>
         from options in Options(escapeChar)
         from whitespace in Whitespace()
-        from command in HeredocTokenParser(escapeChar)
-            .Or(ArgTokens(GetCommandParser(escapeChar).AsEnumerable(), escapeChar))
+        from command in context is { HasHeredocs: true }
+            ? context.HeredocParser(escapeChar)
+            : context is null
+                ? HeredocTokenParser(escapeChar).Or(ArgTokens(GetCommandParser(escapeChar, false).AsEnumerable(), escapeChar))
+                : ArgTokens(GetCommandParser(escapeChar, true).AsEnumerable(), escapeChar)
         select ConcatTokens(options, whitespace, command);
 
     private static Parser<IEnumerable<Token>> Options(char escapeChar) =>
@@ -206,8 +212,8 @@ public class RunInstruction : CommandInstruction
             escapeChar)
             .Many().Flatten();
 
-    private new static Parser<Command> GetCommandParser(char escapeChar) =>
+    private new static Parser<Command> GetCommandParser(char escapeChar, bool diagnostic) =>
         ExecFormCommand.GetParser(escapeChar)
             .Cast<ExecFormCommand, Command>()
-            .Or(ShellFormCommand.GetParser(escapeChar));
+            .Or(diagnostic ? ShellFormCommand.GetDiagnosticParser(escapeChar) : ShellFormCommand.GetParser(escapeChar));
 }

--- a/src/Valleysoft.DockerfileModel/ShellFormCommand.cs
+++ b/src/Valleysoft.DockerfileModel/ShellFormCommand.cs
@@ -22,6 +22,10 @@ public class ShellFormCommand : Command
         from tokens in GetInnerParser(escapeChar)
         select new ShellFormCommand(tokens);
 
+    internal static Parser<ShellFormCommand> GetDiagnosticParser(char escapeChar) =>
+        from tokens in ArgumentListAsLiteral(escapeChar, requireContent: true)
+        select new ShellFormCommand(tokens);
+
     public override CommandType CommandType => CommandType.ShellForm;
 
     public string Value

--- a/src/Valleysoft.DockerfileModel/SourceMap.cs
+++ b/src/Valleysoft.DockerfileModel/SourceMap.cs
@@ -1,0 +1,29 @@
+namespace Valleysoft.DockerfileModel;
+
+internal sealed class SourceMap
+{
+    private readonly List<int> lineStarts = new() { 0 };
+
+    public SourceMap(string text)
+    {
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '\n')
+            {
+                lineStarts.Add(i + 1);
+            }
+        }
+    }
+
+    public SourceSpan GetSpan(int start, int end) => new(GetPosition(start), GetPosition(end));
+
+    private SourcePosition GetPosition(int offset)
+    {
+        int lineIndex = lineStarts.BinarySearch(offset);
+        if (lineIndex < 0)
+        {
+            lineIndex = ~lineIndex - 1;
+        }
+        return new SourcePosition(offset, lineIndex + 1, offset - lineStarts[lineIndex] + 1);
+    }
+}

--- a/src/Valleysoft.DockerfileModel/SourcePosition.cs
+++ b/src/Valleysoft.DockerfileModel/SourcePosition.cs
@@ -1,0 +1,40 @@
+namespace Valleysoft.DockerfileModel;
+
+/// <summary>
+/// An original-source position: a zero-based UTF-16 offset and one-based line and column.
+/// Tabs and surrogate code units each occupy one column.
+/// </summary>
+public readonly struct SourcePosition : IEquatable<SourcePosition>
+{
+    public SourcePosition(int offset, int line, int column)
+    {
+        if (offset < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(offset));
+        }
+        if (line < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(line));
+        }
+        if (column < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(column));
+        }
+
+        Offset = offset;
+        Line = line;
+        Column = column;
+    }
+
+    public int Offset { get; }
+    public int Line { get; }
+    public int Column { get; }
+
+    public bool Equals(SourcePosition other) =>
+        Offset == other.Offset && Line == other.Line && Column == other.Column;
+
+    public override bool Equals(object? obj) => obj is SourcePosition other && Equals(other);
+    public override int GetHashCode() => unchecked((Offset * 397 ^ Line) * 397 ^ Column);
+    public static bool operator ==(SourcePosition left, SourcePosition right) => left.Equals(right);
+    public static bool operator !=(SourcePosition left, SourcePosition right) => !left.Equals(right);
+}

--- a/src/Valleysoft.DockerfileModel/SourceSpan.cs
+++ b/src/Valleysoft.DockerfileModel/SourceSpan.cs
@@ -1,0 +1,31 @@
+namespace Valleysoft.DockerfileModel;
+
+/// <summary>A half-open range in the original input, including Start and excluding End.</summary>
+public readonly struct SourceSpan : IEquatable<SourceSpan>
+{
+    public SourceSpan(SourcePosition start, SourcePosition end)
+    {
+        if (start.Line < 1 || start.Column < 1)
+        {
+            throw new ArgumentException("A valid source position is required.", nameof(start));
+        }
+        if (end.Line < 1 || end.Column < 1 || end.Offset < start.Offset ||
+            end.Line < start.Line || (end.Line == start.Line && end.Column < start.Column))
+        {
+            throw new ArgumentException("The end must be a valid position at or after the start.", nameof(end));
+        }
+
+        Start = start;
+        End = end;
+    }
+
+    public SourcePosition Start { get; }
+    public SourcePosition End { get; }
+    public int Length => End.Offset - Start.Offset;
+
+    public bool Equals(SourceSpan other) => Start == other.Start && End == other.End;
+    public override bool Equals(object? obj) => obj is SourceSpan other && Equals(other);
+    public override int GetHashCode() => unchecked(Start.GetHashCode() * 397 ^ End.GetHashCode());
+    public static bool operator ==(SourceSpan left, SourceSpan right) => left.Equals(right);
+    public static bool operator !=(SourceSpan left, SourceSpan right) => !left.Equals(right);
+}

--- a/src/Valleysoft.DockerfileModel/Tokens/HeredocMarkerToken.cs
+++ b/src/Valleysoft.DockerfileModel/Tokens/HeredocMarkerToken.cs
@@ -4,11 +4,20 @@ namespace Valleysoft.DockerfileModel.Tokens;
 /// Aggregate token representing a heredoc marker inline in the command stream: <<[-][QUOTE]DELIM[QUOTE].
 /// Child tokens are: SymbolToken('<'), SymbolToken('<'), optional SymbolToken('-'),
 /// optional SymbolToken(quoteChar), HeredocDelimiterToken(name), optional SymbolToken(quoteChar).
+/// Diagnostic parsing can retain continuation trivia between operator symbols.
 /// </summary>
 public class HeredocMarkerToken : AggregateToken
 {
-    internal HeredocMarkerToken(IEnumerable<Token> tokens) : base(tokens)
+    // Legacy parsers keep their existing raw-name and fixed-token interpretations.
+    private readonly bool diagnostic;
+
+    internal HeredocMarkerToken(IEnumerable<Token> tokens) : this(tokens, diagnostic: false)
     {
+    }
+
+    internal HeredocMarkerToken(IEnumerable<Token> tokens, bool diagnostic) : base(tokens)
+    {
+        this.diagnostic = diagnostic;
     }
 
     /// <summary>
@@ -18,6 +27,10 @@ public class HeredocMarkerToken : AggregateToken
     {
         get
         {
+            if (diagnostic)
+            {
+                return ReadDelimiter().Value;
+            }
             HeredocDelimiterToken? delim = Tokens.OfType<HeredocDelimiterToken>().FirstOrDefault();
             return delim?.Value ?? string.Empty;
         }
@@ -30,6 +43,10 @@ public class HeredocMarkerToken : AggregateToken
     {
         get
         {
+            if (diagnostic)
+            {
+                return Tokens.OfType<SymbolToken>().Skip(2).FirstOrDefault()?.Value == "-";
+            }
             // The chomp symbol '-' appears after the two '<' symbols and before any quote or delimiter.
             var tokenList = Tokens.ToList();
             // Tokens[0] = '<', Tokens[1] = '<', Tokens[2] = '-' or quote or delimiter
@@ -51,25 +68,36 @@ public class HeredocMarkerToken : AggregateToken
     {
         get
         {
-            var tokenList = Tokens.ToList();
-            // Find the HeredocDelimiterToken index; the quote symbol is immediately before it
-            for (int i = 0; i < tokenList.Count; i++)
-            {
-                if (tokenList[i] is HeredocDelimiterToken)
-                {
-                    if (i > 0 && tokenList[i - 1] is SymbolToken sym)
-                    {
-                        char c = sym.Value[0];
-                        if (c == '\'' || c == '"')
-                        {
-                            return c;
-                        }
-                    }
-                    break;
-                }
-            }
-            return null;
+            return diagnostic ? ReadDelimiter().QuoteChar : GetWrapperQuoteChar();
         }
+    }
+
+    private char? GetWrapperQuoteChar()
+    {
+        var tokenList = Tokens.ToList();
+        for (int i = 0; i < tokenList.Count; i++)
+        {
+            if (tokenList[i] is HeredocDelimiterToken)
+            {
+                if (i > 0 && tokenList[i - 1] is SymbolToken sym)
+                {
+                    char c = sym.Value[0];
+                    if (c == '\'' || c == '"')
+                    {
+                        return c;
+                    }
+                }
+                break;
+            }
+        }
+        return null;
+    }
+
+    private HeredocWord ReadDelimiter()
+    {
+        string value = Tokens.OfType<HeredocDelimiterToken>().FirstOrDefault()?.Value ?? "";
+        char? quote = GetWrapperQuoteChar();
+        return HeredocWord.Read($"{quote}{value}{quote}", 0);
     }
 
     /// <summary>

--- a/src/Valleysoft.DockerfileModel/TolerantDockerfileParser.cs
+++ b/src/Valleysoft.DockerfileModel/TolerantDockerfileParser.cs
@@ -1,0 +1,158 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel;
+
+internal static class TolerantDockerfileParser
+{
+    public static DockerfileParseResult Parse(
+        string text, DockerfileParseMode mode, UnknownInstructionBehavior unknownBehavior)
+    {
+        SourceMap sourceMap = new(text);
+        List<DockerfileConstruct> constructs = new();
+        List<DockerfileDiagnostic> diagnostics = new();
+        char escapeChar = Dockerfile.DefaultEscapeChar;
+        bool directivesComplete = false;
+        int start = 0;
+
+        while (start < text.Length)
+        {
+            ConstructReader.Region region = ConstructReader.Read(text, start, escapeChar);
+            string content = text.Substring(start, region.End - start);
+            SourceSpan span = sourceMap.GetSpan(start, region.End);
+            DockerfileConstruct? construct = null;
+            DockerfileDiagnostic? diagnostic = null;
+
+            if (region.UnterminatedMarker is int marker)
+            {
+                diagnostic = new DockerfileDiagnostic(
+                    DockerfileDiagnosticCodes.UnterminatedHeredoc, DiagnosticSeverity.Error,
+                    "The heredoc has no closing delimiter before the end of the input.",
+                    sourceMap.GetSpan(marker, region.End));
+                directivesComplete = true;
+            }
+            else if (!directivesComplete && ParserDirective.IsDirectiveCandidate(content))
+            {
+                IResult<ParserDirective> result = ParserDirective.GetDiagnosticParser().TryParse(content);
+                if (!result.WasSuccessful)
+                {
+                    diagnostic = Failure(DockerfileDiagnosticCodes.InvalidParserDirective,
+                        result.Message, result.Remainder.Position, start, content.Length, sourceMap);
+                    directivesComplete = true;
+                }
+                else if (result.Value.DirectiveName.Equals(ParserDirective.EscapeDirective, StringComparison.OrdinalIgnoreCase) &&
+                    result.Value.DirectiveValue is not "\\" and not "`")
+                {
+                    diagnostic = new DockerfileDiagnostic(
+                        DockerfileDiagnosticCodes.InvalidParserDirective, DiagnosticSeverity.Error,
+                        "An escape directive must specify a single backslash or backtick.", span);
+                    directivesComplete = true;
+                }
+                else
+                {
+                    construct = result.Value;
+                    if (result.Value.DirectiveName.Equals(ParserDirective.EscapeDirective, StringComparison.OrdinalIgnoreCase))
+                    {
+                        escapeChar = result.Value.DirectiveValue[0];
+                    }
+                }
+            }
+            else
+            {
+                directivesComplete = true;
+                try
+                {
+                    if (Whitespace.IsWhitespace(content))
+                    {
+                        construct = new Whitespace(content);
+                    }
+                    else if (content.TrimStart().StartsWith("#", StringComparison.Ordinal))
+                    {
+                        construct = Comment.Parse(content);
+                    }
+                    else
+                    {
+                        int nameStart = 0;
+                        while (nameStart < content.Length && char.IsWhiteSpace(content[nameStart]))
+                        {
+                            nameStart++;
+                        }
+
+                        IResult<KeywordToken> nameResult = KeywordToken.GetParser(escapeChar)
+                            .TryParse(content.Substring(nameStart));
+                        int nameEnd = nameStart + nameResult.Remainder.Position;
+                        if (!nameResult.WasSuccessful ||
+                            (nameEnd < content.Length && !char.IsWhiteSpace(content[nameEnd])))
+                        {
+                            diagnostic = Failure(DockerfileDiagnosticCodes.InvalidSyntax,
+                                "Expected an instruction name followed by whitespace or the end of input.",
+                                nameEnd, start, content.Length, sourceMap);
+                        }
+                        else if (Instruction.IsKnownInstruction(nameResult.Value.Value))
+                        {
+                            construct = Instruction.CreateDiagnosticInstruction(nameResult.Value.Value, content, escapeChar,
+                                new InstructionParseContext(region, start));
+                        }
+                        else
+                        {
+                            bool preserve = unknownBehavior == UnknownInstructionBehavior.Preserve;
+                            diagnostic = new DockerfileDiagnostic(
+                                DockerfileDiagnosticCodes.UnknownInstruction,
+                                preserve ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error,
+                                $"Unknown instruction '{nameResult.Value.Value}'." +
+                                    (preserve ? " Its arguments have been preserved without validation." : ""),
+                                sourceMap.GetSpan(start + nameStart, start + nameEnd));
+                            if (preserve)
+                            {
+                                construct = new UnknownInstruction(content.Substring(0, nameStart),
+                                    nameResult.Value, content.Substring(nameEnd), escapeChar);
+                            }
+                        }
+                    }
+                }
+                catch (ParseException exception)
+                {
+                    diagnostic = Failure(DockerfileDiagnosticCodes.InvalidSyntax,
+                        exception.Message, exception.Position?.Pos ?? 0, start, content.Length, sourceMap);
+                }
+
+                if (construct is not null && !string.Equals(construct.ToString(), content, StringComparison.Ordinal))
+                {
+                    diagnostic = new DockerfileDiagnostic(DockerfileDiagnosticCodes.InvalidSyntax,
+                        DiagnosticSeverity.Error, "The construct could not be parsed without losing source text.", span);
+                    construct = null;
+                }
+            }
+
+            if (diagnostic is not null)
+            {
+                diagnostics.Add(diagnostic);
+                if (diagnostic.Severity == DiagnosticSeverity.Error)
+                {
+                    if (mode == DockerfileParseMode.Strict)
+                    {
+                        return new DockerfileParseResult(null, diagnostics);
+                    }
+                    construct = new MalformedConstruct(content);
+                }
+            }
+
+            if (construct is null)
+            {
+                throw new InvalidOperationException("A construct parser must produce a model or an error diagnostic.");
+            }
+            construct.SourceSpan = span;
+            constructs.Add(construct);
+            start = region.End;
+        }
+
+        return new DockerfileParseResult(new Dockerfile(constructs), diagnostics);
+    }
+
+    private static DockerfileDiagnostic Failure(
+        string code, string message, int localOffset, int start, int length, SourceMap sourceMap)
+    {
+        int offset = start + Math.Max(0, Math.Min(localOffset, length));
+        return new DockerfileDiagnostic(code, DiagnosticSeverity.Error, message,
+            sourceMap.GetSpan(offset, offset < start + length ? offset + 1 : offset));
+    }
+}

--- a/src/Valleysoft.DockerfileModel/UnknownInstruction.cs
+++ b/src/Valleysoft.DockerfileModel/UnknownInstruction.cs
@@ -1,0 +1,33 @@
+using Valleysoft.DockerfileModel.Tokens;
+
+namespace Valleysoft.DockerfileModel;
+
+/// <summary>
+/// An unrecognized instruction retained without interpreting its arguments.
+/// Its arguments are opaque, including during variable resolution.
+/// </summary>
+public sealed class UnknownInstruction : GenericInstruction
+{
+    internal UnknownInstruction(string leading, KeywordToken name, string arguments, char escapeChar)
+        : base(CreateTokens(leading, name, arguments, escapeChar))
+    {
+    }
+
+    public override string? ResolveVariables(
+        char escapeChar, IDictionary<string, string?>? variables = null, ResolutionOptions? options = null) =>
+        ToString();
+
+    private static IEnumerable<Token> CreateTokens(
+        string leading, KeywordToken name, string arguments, char escapeChar)
+    {
+        if (leading.Length > 0)
+        {
+            yield return new StringToken(leading);
+        }
+        yield return name;
+        if (arguments.Length > 0)
+        {
+            yield return new LiteralToken(new Token[] { new StringToken(arguments) }, false, escapeChar);
+        }
+    }
+}


### PR DESCRIPTION
Dockerfile tooling needs to inspect incomplete or malformed input without losing source text or relying on exceptions. This adds an opt-in recovery API while retaining the existing `Dockerfile.Parse` behavior.

## Approach

- Add `Dockerfile.TryParse`, defaulting to strict parsing, with explicit recovery and independent unknown-instruction preservation. Structured diagnostics report errors and warnings; malformed regions and preserved unknown instructions round-trip verbatim.
- Attach immutable original-input spans to top-level constructs. Offsets use UTF-16 units, and spans remain provenance rather than tracking subsequent edits.
- Frame logical instructions and heredocs before typed parsing so continuations, quoting, and active escape directives preserve both source fidelity and instruction boundaries.

Unlike legacy parsing, `TryParse` diagnoses unterminated heredocs. Recovery conservatively retains the remainder of the input as one malformed region rather than interpreting body lines as instructions. Unknown preservation does not validate or expand opaque arguments.

Detailed usage and contracts live in `docs/parsing.md`, linked from the root README. Coverage includes compatibility, source partitions, heredoc boundaries, property-based checks, and deterministic malformed-input cases.

## Validation

- Full C# suite: 1,611 tests passed.
- Library builds for both `netstandard2.0` and `net10.0`.

Fixes: #347